### PR TITLE
fix(transfers-history): improve response times

### DIFF
--- a/src/transfers-history/README.md
+++ b/src/transfers-history/README.md
@@ -10,7 +10,11 @@ const { TransfersHistoryClient } = transfersHistory;
 
 const client = new TransfersHistoryClient({
   chains: [
-    { chainId: <chain_id>, providerUrl: <provider_url>, spokePoolContractAddr: <spoke_pool_address> }
+    { chainId: <chain_id>, 
+      providerUrl: <provider_url>, 
+      spokePoolContractAddr: <spoke_pool_address>, 
+      lowerBoundBlockNumber: <block_no>, 
+    }
   ],
   // optional 
   pollingIntervalSeconds: <polling_interval_in_seconds>

--- a/src/transfers-history/adapters/db/transfers-repository.ts
+++ b/src/transfers-history/adapters/db/transfers-repository.ts
@@ -59,7 +59,7 @@ export class TransfersRepository {
     if (!this.usersTransfers[depositorAddr]) {
       this.usersTransfers[depositorAddr] = { pending: [], filled: [] };
     }
-    this.usersTransfers[depositorAddr].filled = transfers;
+    this.usersTransfers[depositorAddr].pending = transfers;
   }
 
   public setDepositorFilledTransfers(depositorAddr: string, transfers: Transfer[]) {
@@ -67,7 +67,7 @@ export class TransfersRepository {
       this.usersTransfers[depositorAddr] = { filled: [], pending: [] };
     }
 
-    this.usersTransfers[depositorAddr].pending = transfers;
+    this.usersTransfers[depositorAddr].filled = transfers;
   }
 
   public aggregateTransfers(depositorAddr: string) {
@@ -105,7 +105,7 @@ export class TransfersRepository {
   }
 
   public getPendingTransfers(depositorAddr: string, limit?: number, offset?: number) {
-    const transfers = this.usersTransfers[depositorAddr]?.filled || [];
+    const transfers = this.usersTransfers[depositorAddr]?.pending || [];
 
     if (transfers.length === 0) {
       return transfers;

--- a/src/transfers-history/client.e2e.ts
+++ b/src/transfers-history/client.e2e.ts
@@ -1,37 +1,42 @@
 import dotenv from "dotenv";
 import { CHAIN_IDs } from "./adapters/web3/model";
-import { TransfersHistoryClient } from "./client";
+import { TransfersHistoryClient, TransfersHistoryEvent } from "./client";
 
 dotenv.config({ path: ".env" });
 
-const wait = (seconds: number) => {
-  return new Promise(resolve => {
-    setTimeout(resolve, seconds * 1000);
-  });
-};
-
-describe.only("Client e2e tests", () => {
-  it("should fetch pending transfers from chain", async () => {
-    jest.setTimeout(60 * 1000);
+describe("Client e2e tests", () => {
+  it("should fetch pending transfers from chain", async done => {
+    jest.setTimeout(120 * 1000);
     const client = new TransfersHistoryClient({
+      pollingIntervalSeconds: 0,
       chains: [
         {
           chainId: CHAIN_IDs.ARBITRUM_RINKEBY,
           providerUrl: process.env[`WEB3_NODE_URL_${CHAIN_IDs.ARBITRUM_RINKEBY}`] || "",
-          spokePoolContractAddr: "0x68306388c266dce735245A0A6DAe6Dd3b727A640",
+          spokePoolContractAddr: "0x3BED21dAe767e4Df894B31b14aD32369cE4bad8b",
+          lowerBoundBlockNumber: 10523275,
         },
         {
           chainId: CHAIN_IDs.OPTIMISM_KOVAN,
           providerUrl: process.env[`WEB3_NODE_URL_${CHAIN_IDs.OPTIMISM_KOVAN}`] || "",
-          spokePoolContractAddr: "0x99EC530a761E68a377593888D9504002Bd191717",
+          spokePoolContractAddr: "0x2b7b7bAE341089103dD22fa4e8D7E4FA63E11084",
+          lowerBoundBlockNumber: 1618630,
+        },
+        {
+          chainId: CHAIN_IDs.KOVAN,
+          providerUrl: process.env[`WEB3_NODE_URL_${CHAIN_IDs.KOVAN}`] || "",
+          spokePoolContractAddr: "0x73549B5639B04090033c1E77a22eE9Aa44C2eBa0",
+          lowerBoundBlockNumber: 30475937,
         },
       ],
     });
     client.setLogLevel("debug");
-    await client.startFetchingTransfers("0x9B6134Fe036F1C22D9Fe76c15AC81B7bC31212eB");
-    await wait(15);
-    const transfers = client.getPendingTransfers("0x9B6134Fe036F1C22D9Fe76c15AC81B7bC31212eB");
-    client.stopFetchingTransfers("0x9B6134Fe036F1C22D9Fe76c15AC81B7bC31212eB");
-    expect(transfers.length).toBeGreaterThan(0);
+    await client.startFetchingTransfers("0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D");
+    client.on(TransfersHistoryEvent.TransfersUpdated, () => {
+      const pendingTransfers = client.getPendingTransfers("0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D", 30, 0);
+      client.stopFetchingTransfers("0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D");
+      expect(pendingTransfers.length).toBeGreaterThan(0);
+      done();
+    });
   });
 });

--- a/src/transfers-history/client.ts
+++ b/src/transfers-history/client.ts
@@ -25,6 +25,7 @@ export type TransfersHistoryClientParams = {
     chainId: ChainId;
     providerUrl: string;
     spokePoolContractAddr: string;
+    lowerBoundBlockNumber?: number;
   }[];
   pollingIntervalSeconds?: number;
 };
@@ -59,6 +60,7 @@ export class TransfersHistoryClient {
         undefined,
         this.logger
       );
+      clientConfig.spokePools[chain.chainId] = { lowerBoundBlockNumber: chain.lowerBoundBlockNumber || 0 };
     }
   }
 

--- a/src/transfers-history/config.ts
+++ b/src/transfers-history/config.ts
@@ -1,7 +1,7 @@
-import { ChainId, CHAIN_IDs } from "./adapters/web3/model";
+import { ChainId } from "./adapters/web3/model";
 
 export type SpokePoolConfig = {
-  lowerBoundBlockNumber: number;
+  lowerBoundBlockNumber?: number;
 };
 
 export type ClientConfig = {
@@ -11,11 +11,5 @@ export type ClientConfig = {
 
 export const clientConfig: ClientConfig = {
   web3ProvidersUrls: {},
-  spokePools: {
-    [CHAIN_IDs.ARBITRUM_RINKEBY]: { lowerBoundBlockNumber: 9828565 },
-    [CHAIN_IDs.OPTIMISM_KOVAN]: { lowerBoundBlockNumber: 0 },
-    [CHAIN_IDs.RINKEBY]: { lowerBoundBlockNumber: 0 },
-    [CHAIN_IDs.KOVAN]: { lowerBoundBlockNumber: 0 },
-    [CHAIN_IDs.MAINNET]: { lowerBoundBlockNumber: 0 },
-  },
+  spokePools: {},
 };

--- a/src/transfers-history/services/SpokePoolEventsQueryService.ts
+++ b/src/transfers-history/services/SpokePoolEventsQueryService.ts
@@ -41,10 +41,12 @@ export class SpokePoolEventsQueryService {
 
     this.logger.debug(
       "[SpokePoolEventsQueryService::getEvents]",
-      `🟢 chain ${this.chainId}: fetched events from ${from} to ${to}`
+      `🟢 chain ${this.chainId}: fetch events from ${from} to ${to}`
     );
-    const depositEvents = await this.eventsQuerier.getFundsDepositEvents(from, to, this.depositorAddr);
-    const filledRelayEvents = await this.eventsQuerier.getFilledRelayEvents(from, to, this.depositorAddr);
+    const [depositEvents, filledRelayEvents] = await Promise.all([
+      this.eventsQuerier.getFundsDepositEvents(from, to, this.depositorAddr),
+      this.eventsQuerier.getFilledRelayEvents(from, to, this.depositorAddr),
+    ]);
     this.logger.debug(
       "[SpokePoolEventsQueryService::getEvents]",
       `🟢 chain ${this.chainId}: fetched ${depositEvents.length} FundsDeposited events and ${filledRelayEvents.length} FilledRelayEvents`

--- a/src/transfers-history/services/SpokePoolEventsQueryService.ts
+++ b/src/transfers-history/services/SpokePoolEventsQueryService.ts
@@ -22,9 +22,13 @@ export class SpokePoolEventsQueryService {
   ) {}
 
   public async getEvents() {
-    const from = this.latestBlockNumber
-      ? this.latestBlockNumber + 1
-      : clientConfig.spokePools[this.chainId].lowerBoundBlockNumber;
+    let from;
+
+    if (this.latestBlockNumber) {
+      from = this.latestBlockNumber + 1;
+    } else {
+      from = clientConfig.spokePools[this.chainId].lowerBoundBlockNumber ?? -1;
+    }
     const to = (await this.provider.getBlock("latest")).number;
 
     if (from > to) {


### PR DESCRIPTION
This PR fixes a couple of issues identified during testing the FE integration

1. getPendingTransfers() was returning the filled transfers
2. I parallelised the calls for getting FundsDeposited and RelayFilled events
3. I parallelised the queryFilter() calls in case these calls need to be performed in batches (web3 provider limitation)
4. `lowerBoundBlockNumber` optional parameter is now part of the client config object and SHOULD be provided in order to limit the number of the queried blocks