### PR TITLE
fix: prevent events from being triggered after fetching was stopped 

### DIFF
--- a/src/transfers-history/README.md
+++ b/src/transfers-history/README.md
@@ -11,7 +11,7 @@ const { TransfersHistoryClient } = transfersHistory;
 const client = new TransfersHistoryClient({
   chains: [
     { chainId: <chain_id>, 
-      providerUrl: <provider_url>, 
+      provider: <ethers_provider_instance>, 
       spokePoolContractAddr: <spoke_pool_address>, 
       lowerBoundBlockNumber: <block_no>, 
     }

--- a/src/transfers-history/client.e2e.ts
+++ b/src/transfers-history/client.e2e.ts
@@ -1,4 +1,5 @@
 import dotenv from "dotenv";
+import { providers } from "ethers";
 import { CHAIN_IDs } from "./adapters/web3/model";
 import { TransfersHistoryClient, TransfersHistoryEvent } from "./client";
 
@@ -12,19 +13,19 @@ describe("Client e2e tests", () => {
       chains: [
         {
           chainId: CHAIN_IDs.ARBITRUM_RINKEBY,
-          providerUrl: process.env[`WEB3_NODE_URL_${CHAIN_IDs.ARBITRUM_RINKEBY}`] || "",
+          provider: new providers.JsonRpcProvider(process.env[`WEB3_NODE_URL_${CHAIN_IDs.ARBITRUM_RINKEBY}`] || ""),
           spokePoolContractAddr: "0x3BED21dAe767e4Df894B31b14aD32369cE4bad8b",
           lowerBoundBlockNumber: 10523275,
         },
         {
           chainId: CHAIN_IDs.OPTIMISM_KOVAN,
-          providerUrl: process.env[`WEB3_NODE_URL_${CHAIN_IDs.OPTIMISM_KOVAN}`] || "",
+          provider: new providers.JsonRpcProvider(process.env[`WEB3_NODE_URL_${CHAIN_IDs.OPTIMISM_KOVAN}`] || ""),
           spokePoolContractAddr: "0x2b7b7bAE341089103dD22fa4e8D7E4FA63E11084",
           lowerBoundBlockNumber: 1618630,
         },
         {
           chainId: CHAIN_IDs.KOVAN,
-          providerUrl: process.env[`WEB3_NODE_URL_${CHAIN_IDs.KOVAN}`] || "",
+          provider: new providers.JsonRpcProvider(process.env[`WEB3_NODE_URL_${CHAIN_IDs.KOVAN}`] || ""),
           spokePoolContractAddr: "0x73549B5639B04090033c1E77a22eE9Aa44C2eBa0",
           lowerBoundBlockNumber: 30475937,
         },

--- a/src/transfers-history/client.ts
+++ b/src/transfers-history/client.ts
@@ -38,7 +38,7 @@ export class TransfersHistoryClient {
   private eventsServices: Record<string, Record<ChainId, SpokePoolEventsQueryService>> = {};
   private pollingIntervalSeconds: number = 15;
   private pollingTimers: Record<string, NodeJS.Timer> = {};
-  private fetchingState: Record<string, "started" | "stoped"> = {};
+  private fetchingState: Record<string, "started" | "stopped"> = {};
 
   constructor(
     config: TransfersHistoryClientParams,
@@ -91,7 +91,7 @@ export class TransfersHistoryClient {
   public stopFetchingTransfers(depositorAddr: string) {
     const timer = this.pollingTimers[depositorAddr];
     // mark that the fetching stopped for depositor address
-    this.fetchingState[depositorAddr] = "stoped";
+    this.fetchingState[depositorAddr] = "stopped";
     if (timer) {
       clearInterval(timer);
       delete this.pollingTimers[depositorAddr];

--- a/src/transfers-history/client.ts
+++ b/src/transfers-history/client.ts
@@ -23,7 +23,7 @@ export type TransfersHistoryClientEventListener = TransfersUpdatedEventListener;
 export type TransfersHistoryClientParams = {
   chains: {
     chainId: ChainId;
-    providerUrl: string;
+    provider: providers.Provider;
     spokePoolContractAddr: string;
     lowerBoundBlockNumber?: number;
   }[];
@@ -50,8 +50,7 @@ export class TransfersHistoryClient {
     }
 
     for (const chain of config.chains) {
-      clientConfig.web3ProvidersUrls[chain.chainId] = chain.providerUrl;
-      this.web3Providers[chain.chainId] = new providers.JsonRpcProvider(chain.providerUrl);
+      this.web3Providers[chain.chainId] = chain.provider;
       this.spokePoolInstances[chain.chainId] = SpokePool__factory.connect(
         chain.spokePoolContractAddr,
         this.web3Providers[chain.chainId]

--- a/src/transfers-history/client.ts
+++ b/src/transfers-history/client.ts
@@ -38,6 +38,7 @@ export class TransfersHistoryClient {
   private eventsServices: Record<string, Record<ChainId, SpokePoolEventsQueryService>> = {};
   private pollingIntervalSeconds: number = 15;
   private pollingTimers: Record<string, NodeJS.Timer> = {};
+  private fetchingState: Record<string, "started" | "stoped"> = {};
 
   constructor(
     config: TransfersHistoryClientParams,
@@ -71,7 +72,8 @@ export class TransfersHistoryClient {
   public async startFetchingTransfers(depositorAddr: string) {
     this.initSpokePoolEventsQueryServices(depositorAddr);
     this.getEventsForDepositor(depositorAddr);
-
+    // mark that we started fetching events for depositor address
+    this.fetchingState[depositorAddr] = "started";
     // add polling if user didn't opted out for polling
     if (this.pollingIntervalSeconds > 0) {
       let timer = this.pollingTimers[depositorAddr];
@@ -88,7 +90,8 @@ export class TransfersHistoryClient {
 
   public stopFetchingTransfers(depositorAddr: string) {
     const timer = this.pollingTimers[depositorAddr];
-
+    // mark that the fetching stopped for depositor address
+    this.fetchingState[depositorAddr] = "stoped";
     if (timer) {
       clearInterval(timer);
       delete this.pollingTimers[depositorAddr];
@@ -128,7 +131,12 @@ export class TransfersHistoryClient {
       filledTransfersCount: this.transfersRepository.countFilledTransfers(depositorAddr),
       pendingTransfersCount: this.transfersRepository.countPendingTransfers(depositorAddr),
     };
-    this.eventEmitter.emit(TransfersHistoryEvent.TransfersUpdated, eventData);
+
+    // emit event only if the fetching wasn't stopped for depositor address.
+    // this is to prevent events from being triggered after the fetching was stopped
+    if (this.fetchingState[depositorAddr] === "started") {
+      this.eventEmitter.emit(TransfersHistoryEvent.TransfersUpdated, eventData);
+    }
   }
 
   public getFilledTransfers(depositorAddr: string, limit?: number, offset?: number) {

--- a/src/transfers-history/config.ts
+++ b/src/transfers-history/config.ts
@@ -5,11 +5,9 @@ export type SpokePoolConfig = {
 };
 
 export type ClientConfig = {
-  web3ProvidersUrls: Record<ChainId, string>;
   spokePools: Record<ChainId, SpokePoolConfig>;
 };
 
 export const clientConfig: ClientConfig = {
-  web3ProvidersUrls: {},
   spokePools: {},
 };

--- a/src/transfers-history/index.ts
+++ b/src/transfers-history/index.ts
@@ -1,1 +1,2 @@
 export * from "./client";
+export * from "./model";


### PR DESCRIPTION
This PR stops events from being triggered if the fetching was stopped. This could happen when the last execution of the `setInterval()` callback was happening after the call of `stopFetchingTransfers()`

Also, the client instantiation requires the providers to be passed, instead of the provider URLs. This way we'll have less providers in our app