### PR TITLE
fix: fix processing of fill events

### DIFF
--- a/src/transfers-history/adapters/db/transfers-repository.ts
+++ b/src/transfers-history/adapters/db/transfers-repository.ts
@@ -38,13 +38,17 @@ export class TransfersRepository {
     this.transfers[chainId][depositorAddr][depositId] = transfer;
   }
 
-  public updateFilledAmount(chainId: ChainId, depositAddr: string, depositId: number, filled: BigNumber) {
-    const oldTransfer = this.transfers[chainId][depositAddr][depositId];
-    this.transfers[chainId][depositAddr][depositId] = {
-      ...oldTransfer,
-      filled,
-      status: oldTransfer.amount.eq(filled) ? "filled" : "pending",
-    };
+  public updateFilledAmount(chainId: ChainId, depositorAddr: string, depositId: number, filled: BigNumber) {
+    const transfer = this.transfers[chainId][depositorAddr][depositId];
+    if (transfer) {
+      this.transfers[chainId][depositorAddr][depositId] = {
+        ...transfer,
+        filled,
+        status: transfer.amount.eq(filled) ? "filled" : "pending",
+      };
+    } else {
+      console.error(`couldn't fill deposit on chain ${chainId}, depositId ${depositId}, depositor ${depositorAddr}`);
+    }
   }
 
   public getTransfersByChainAndDepositor(chainId: ChainId, depositorAddr: string) {

--- a/src/transfers-history/adapters/web3/SpokePoolEventsQuerier.ts
+++ b/src/transfers-history/adapters/web3/SpokePoolEventsQuerier.ts
@@ -44,6 +44,7 @@ export class SpokePoolEventsQuerier implements ISpokePoolContractEventsQuerier {
         undefined,
         undefined,
         undefined,
+        undefined,
         depositorAddr,
         undefined,
         undefined

--- a/src/transfers-history/client.e2e.ts
+++ b/src/transfers-history/client.e2e.ts
@@ -29,14 +29,22 @@ describe("Client e2e tests", () => {
           spokePoolContractAddr: "0x73549B5639B04090033c1E77a22eE9Aa44C2eBa0",
           lowerBoundBlockNumber: 30475937,
         },
+        {
+          chainId: CHAIN_IDs.RINKEBY,
+          provider: new providers.JsonRpcProvider(process.env[`WEB3_NODE_URL_${CHAIN_IDs.RINKEBY}`] || ""),
+          spokePoolContractAddr: "0xB078bBb35f8E24c2431b9d2a88C0bC0c26CC1F92",
+          lowerBoundBlockNumber: 10485193,
+        },
       ],
     });
     client.setLogLevel("debug");
-    await client.startFetchingTransfers("0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D");
+    await client.startFetchingTransfers("0x718648C8c531F91b528A7757dD2bE813c3940608");
     client.on(TransfersHistoryEvent.TransfersUpdated, () => {
-      const pendingTransfers = client.getPendingTransfers("0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D", 30, 0);
-      client.stopFetchingTransfers("0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D");
+      const pendingTransfers = client.getPendingTransfers("0x718648C8c531F91b528A7757dD2bE813c3940608", 10, 0);
+      const filledTransfers = client.getFilledTransfers("0x718648C8c531F91b528A7757dD2bE813c3940608", 10, 0);
+      client.stopFetchingTransfers("0x718648C8c531F91b528A7757dD2bE813c3940608");
       expect(pendingTransfers.length).toBeGreaterThan(0);
+      expect(filledTransfers.length).toBeGreaterThan(0);
       done();
     });
   });

--- a/src/transfers-history/services/SpokePoolEventsQueryService.ts
+++ b/src/transfers-history/services/SpokePoolEventsQueryService.ts
@@ -1,13 +1,10 @@
 import { TypedEvent } from "@across-protocol/contracts-v2/dist/typechain/common";
 import { FundsDepositedEvent, FilledRelayEvent } from "@across-protocol/contracts-v2/dist/typechain/SpokePool";
-import { BigNumber, providers } from "ethers";
-
-import { TransfersRepository } from "../adapters/db/transfers-repository";
+import { providers } from "ethers";
 import { Logger } from "../adapters/logger";
 import { ISpokePoolContractEventsQuerier } from "../adapters/web3";
 import { ChainId } from "../adapters/web3/model";
 import { clientConfig } from "../config";
-import { Transfer } from "../model";
 
 export class SpokePoolEventsQueryService {
   private latestBlockNumber: number | undefined;
@@ -17,12 +14,14 @@ export class SpokePoolEventsQueryService {
     private provider: providers.Provider,
     private eventsQuerier: ISpokePoolContractEventsQuerier,
     private logger: Logger,
-    private transfersRepository: TransfersRepository,
     private depositorAddr?: string
   ) {}
 
   public async getEvents() {
     let from;
+    let depositEvents: FundsDepositedEvent[] = [];
+    let filledRelayEvents: FilledRelayEvent[] = [];
+    let blockTimestampMap: { [blockNumber: number]: number } = {};
 
     if (this.latestBlockNumber) {
       from = this.latestBlockNumber + 1;
@@ -32,52 +31,33 @@ export class SpokePoolEventsQueryService {
     const to = (await this.provider.getBlock("latest")).number;
 
     if (from > to) {
-      this.logger.debug(
-        "[SpokePoolEventsQueryService::getEvents]",
-        `🔴 chain ${this.chainId}: from ${from} > to ${to}`
-      );
-      return;
+      this.logger.debug("[SpokePoolEventsQueryService]", `🔴 chain ${this.chainId}: from ${from} > to ${to}`);
+
+      return {
+        depositEvents: [],
+        filledRelayEvents: [],
+        blockTimestampMap: {},
+      };
     }
 
-    this.logger.debug(
-      "[SpokePoolEventsQueryService::getEvents]",
-      `🟢 chain ${this.chainId}: fetch events from ${from} to ${to}`
-    );
-    const [depositEvents, filledRelayEvents] = await Promise.all([
+    [depositEvents, filledRelayEvents] = await Promise.all([
       this.eventsQuerier.getFundsDepositEvents(from, to, this.depositorAddr),
       this.eventsQuerier.getFilledRelayEvents(from, to, this.depositorAddr),
     ]);
+
+    console.log(filledRelayEvents.filter(f => f.args.depositId === 9));
     this.logger.debug(
       "[SpokePoolEventsQueryService::getEvents]",
-      `🟢 chain ${this.chainId}: fetched ${depositEvents.length} FundsDeposited events and ${filledRelayEvents.length} FilledRelayEvents`
+      `🟢 chain ${this.chainId}: fetched ${depositEvents.length} FundsDeposited events and ${filledRelayEvents.length} FilledRelayEvents from block ${from} to block ${to}`
     );
-    const blockTimestampMap = await this.getBlocksTimestamp([...depositEvents, ...filledRelayEvents]);
-    depositEvents.map(event => this.insertFundsDepositedEvent(event, blockTimestampMap[event.blockNumber]));
-    filledRelayEvents.map(event => this.insertFilledRelayEvent(event));
+    blockTimestampMap = await this.getBlocksTimestamp(depositEvents);
     this.latestBlockNumber = to;
-  }
 
-  private insertFundsDepositedEvent(event: FundsDepositedEvent, timestamp: number) {
-    const { args, transactionHash } = event;
-    const { amount, originToken, destinationChainId, depositId, depositor } = args;
-    const transfer: Transfer = {
-      amount: BigNumber.from(amount),
-      assetAddr: originToken,
-      depositId: depositId,
-      depositTime: timestamp,
-      depositTxHash: transactionHash,
-      destinationChainId: destinationChainId.toNumber(),
-      filled: BigNumber.from("0"),
-      sourceChainId: this.chainId,
-      status: "pending",
+    return {
+      depositEvents,
+      filledRelayEvents,
+      blockTimestampMap,
     };
-    this.transfersRepository.insertTransfer(this.chainId, depositor, depositId, transfer);
-  }
-
-  private insertFilledRelayEvent(event: FilledRelayEvent) {
-    const { args } = event;
-    const { totalFilledAmount, depositor, depositId } = args;
-    this.transfersRepository.updateFilledAmount(this.chainId, depositor, depositId, totalFilledAmount);
   }
 
   /**

--- a/src/transfers-history/services/SpokePoolEventsQueryService.ts
+++ b/src/transfers-history/services/SpokePoolEventsQueryService.ts
@@ -45,7 +45,6 @@ export class SpokePoolEventsQueryService {
       this.eventsQuerier.getFilledRelayEvents(from, to, this.depositorAddr),
     ]);
 
-    console.log(filledRelayEvents.filter(f => f.args.depositId === 9));
     this.logger.debug(
       "[SpokePoolEventsQueryService::getEvents]",
       `🟢 chain ${this.chainId}: fetched ${depositEvents.length} FundsDeposited events and ${filledRelayEvents.length} FilledRelayEvents from block ${from} to block ${to}`


### PR DESCRIPTION
Signed-off-by: amateima <amatei@umaproject.org>

This PR fixes a small issue I found. In some cases the RelayFilled events were inserted into the database before the initial deposit event, leading to data inconsistencies. Now, the filling events are inserted into the store only after all FundsDeposited events from all chains were fetched.