### PR TITLE
feat(tx-history): add fill txs to transfers

### DIFF
--- a/src/transfers-history/adapters/db/transfers-repository.ts
+++ b/src/transfers-history/adapters/db/transfers-repository.ts
@@ -42,13 +42,20 @@ export class TransfersRepository {
     this.transfers[chainId][depositorAddr][depositId] = transfer;
   }
 
-  public updateFilledAmount(chainId: ChainId, depositorAddr: string, depositId: number, filled: BigNumber) {
+  public updateFilledAmount(
+    chainId: ChainId,
+    depositorAddr: string,
+    depositId: number,
+    filled: BigNumber,
+    fillTxHash: string
+  ) {
     const transfer = this.transfers?.[chainId]?.[depositorAddr]?.[depositId];
     if (transfer) {
       this.transfers[chainId][depositorAddr][depositId] = {
         ...transfer,
         filled,
         status: transfer.amount.eq(filled) ? "filled" : "pending",
+        fillTxs: [...transfer.fillTxs, fillTxHash],
       };
     } else {
       console.error(`couldn't fill deposit on chain ${chainId}, depositId ${depositId}, depositor ${depositorAddr}`);

--- a/src/transfers-history/client.e2e.ts
+++ b/src/transfers-history/client.e2e.ts
@@ -76,6 +76,7 @@ describe("Client e2e tests", () => {
       client.stopFetchingTransfers("0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D");
       expect(pendingTransfers.length).toBeGreaterThanOrEqual(0);
       expect(filledTransfers.length).toBeGreaterThanOrEqual(0);
+      expect(filledTransfers[0].fillTxs.length).toBeGreaterThanOrEqual(1);
       done();
     });
   });

--- a/src/transfers-history/client.ts
+++ b/src/transfers-history/client.ts
@@ -168,14 +168,21 @@ export class TransfersHistoryClient {
       filled: BigNumber.from("0"),
       sourceChainId: originChainId.toNumber(),
       status: "pending",
+      fillTxs: [],
     };
     this.transfersRepository.insertTransfer(originChainId.toNumber(), depositor, depositId, transfer);
   }
 
   private insertFilledRelayEvent(event: FilledRelayEvent) {
-    const { args } = event;
+    const { args, transactionHash } = event;
     const { totalFilledAmount, depositor, depositId, originChainId } = args;
-    this.transfersRepository.updateFilledAmount(originChainId.toNumber(), depositor, depositId, totalFilledAmount);
+    this.transfersRepository.updateFilledAmount(
+      originChainId.toNumber(),
+      depositor,
+      depositId,
+      totalFilledAmount,
+      transactionHash
+    );
   }
 
   public getFilledTransfers(depositorAddr: string, limit?: number, offset?: number) {

--- a/src/transfers-history/model/transfer.ts
+++ b/src/transfers-history/model/transfer.ts
@@ -13,4 +13,5 @@ export type Transfer = {
   assetAddr: string;
   amount: BigNumber;
   depositTxHash: string;
+  fillTxs: string[];
 };


### PR DESCRIPTION
Signed-off-by: amateima <amatei@umaproject.org>

Quick change in order to get the hashes of the fill transactions for displaying them in Across frontend