### PR TITLE
fix: optional chaining to fix undefined error

### DIFF
--- a/src/contracts/acrossConfigStore.e2e.ts
+++ b/src/contracts/acrossConfigStore.e2e.ts
@@ -9,7 +9,7 @@ dotenv.config();
 const configStoreAddress = ethers.utils.getAddress("0xDd74f7603e3fDA6435aEc91F8960a6b8b40415f3");
 const wethAddress = ethers.utils.getAddress("0xd0A1E359811322d97991E03f863a0C30C2cF029C");
 
-describe("PoolEventState", function () {
+describe("AcrossConfigStore", function () {
   let provider: Provider;
   let client: Client;
   beforeAll(async () => {

--- a/src/pool/poolClient.ts
+++ b/src/pool/poolClient.ts
@@ -319,7 +319,7 @@ function joinUserState(
   const positionValue = BigNumber.from(poolState.exchangeRateCurrent)
     .mul(userState.balanceOf)
     .div(fixedPointAdjustment);
-  const totalDeposited = BigNumber.from(tokenEventState.tokenBalances[userState.address] || "0");
+  const totalDeposited = BigNumber.from(tokenEventState?.tokenBalances[userState.address] || "0");
   const feesEarned = positionValue.sub(totalDeposited.add(transferValue));
   return {
     address: userState.address,


### PR DESCRIPTION
Signed-off-by: David <david@umaproject.org>

fixes this 
```
react_devtools_backend.js:4026 error loading user TypeError: Cannot read properties of undefined (reading 'tokenBalances')
    at gf (poolClient.ts:322:41)
    at f.<anonymous> (poolClient.ts:644:7)
    at c (runtime.js:63:40)
    at Generator._invoke (runtime.js:294:22)
    at Generator.next (runtime.js:119:21)
    at k (23.a8c21cbc.chunk.js:2:682903)
    at i (23.a8c21cbc.chunk.js:2:683106)
    at 23.a8c21cbc.chunk.js:2:683165
    at new Promise (<anonymous>)
    at f.<anonymous> (23.a8c21cbc.chunk.js:2:683046)
```


For some reason this can sometimes be undefined and typescript is not picking that up