### PR TITLE
feat: get all txs history

### DIFF
--- a/src/transfers-history/client.e2e.ts
+++ b/src/transfers-history/client.e2e.ts
@@ -44,7 +44,8 @@ describe("Client e2e tests", () => {
         },
       ],
     });
-    // client.setLogLevel("debug");
+
+    client.setLogLevel("debug");
   });
 
   it("should fetch pending transfers from chain", async (done) => {

--- a/src/transfers-history/client.e2e.ts
+++ b/src/transfers-history/client.e2e.ts
@@ -6,71 +6,53 @@ import { TransfersHistoryClient, TransfersHistoryEvent } from "./client";
 dotenv.config({ path: ".env" });
 
 describe("Client e2e tests", () => {
-  it("should fetch pending transfers from chain", async (done) => {
-    jest.setTimeout(1000 * 60);
-    const client = new TransfersHistoryClient({
-      pollingIntervalSeconds: 0,
+  let client: TransfersHistoryClient;
+
+  beforeAll(() => {
+    client = new TransfersHistoryClient({
+      pollingIntervalSeconds: 5,
       chains: [
-        {
-          chainId: CHAIN_IDs.ARBITRUM_RINKEBY,
-          provider: new providers.JsonRpcProvider(process.env[`WEB3_NODE_URL_${CHAIN_IDs.ARBITRUM_RINKEBY}`] || ""),
-          spokePoolContractAddr: "0x3BED21dAe767e4Df894B31b14aD32369cE4bad8b",
-          lowerBoundBlockNumber: 10523275,
-        },
-        {
-          chainId: CHAIN_IDs.OPTIMISM_KOVAN,
-          provider: new providers.JsonRpcProvider(process.env[`WEB3_NODE_URL_${CHAIN_IDs.OPTIMISM_KOVAN}`] || ""),
-          spokePoolContractAddr: "0x1954D4A36ac4fD8BEde42E59368565A92290E705",
-          lowerBoundBlockNumber: 1618630,
-        },
-        {
-          chainId: CHAIN_IDs.KOVAN,
-          provider: new providers.JsonRpcProvider(process.env[`WEB3_NODE_URL_${CHAIN_IDs.KOVAN}`] || ""),
-          spokePoolContractAddr: "0x90bab3160d417B4cd791Db5f8C4E79704e67bd49",
-          lowerBoundBlockNumber: 30475937,
-        },
-        {
-          chainId: CHAIN_IDs.RINKEBY,
-          provider: new providers.JsonRpcProvider(process.env[`WEB3_NODE_URL_${CHAIN_IDs.RINKEBY}`] || ""),
-          spokePoolContractAddr: "0xB078bBb35f8E24c2431b9d2a88C0bC0c26CC1F92",
-          lowerBoundBlockNumber: 10485193,
-        },
         {
           chainId: CHAIN_IDs.MAINNET,
           provider: new providers.JsonRpcProvider(process.env[`WEB3_NODE_URL_${CHAIN_IDs.MAINNET}`] || ""),
-          spokePoolContractAddr: "0x931A43528779034ac9eb77df799d133557406176",
+          spokePoolContractAddr: "0x4D9079Bb4165aeb4084c526a32695dCfd2F77381",
           lowerBoundBlockNumber: 14704425,
         },
         {
           chainId: CHAIN_IDs.OPTIMISM,
           provider: new providers.JsonRpcProvider(process.env[`WEB3_NODE_URL_${CHAIN_IDs.OPTIMISM}`] || ""),
-          spokePoolContractAddr: "0x59485d57EEcc4058F7831f46eE83a7078276b4AE",
+          spokePoolContractAddr: "0xa420b2d1c0841415A695b81E5B867BCD07Dff8C9",
           lowerBoundBlockNumber: 6979967,
         },
         {
           chainId: CHAIN_IDs.ARBITRUM,
           provider: new providers.JsonRpcProvider(process.env[`WEB3_NODE_URL_${CHAIN_IDs.ARBITRUM}`] || ""),
-          spokePoolContractAddr: "0xe1C367e2b576Ac421a9f46C9cC624935730c36aa",
+          spokePoolContractAddr: "0xB88690461dDbaB6f04Dfad7df66B7725942FEb9C",
           lowerBoundBlockNumber: 11102271,
         },
         {
           chainId: CHAIN_IDs.BOBA,
           provider: new providers.JsonRpcProvider(process.env[`WEB3_NODE_URL_${CHAIN_IDs.BOBA}`] || ""),
-          spokePoolContractAddr: "0x7229405a2f0c550Ce35182EE1658302B65672443",
+          spokePoolContractAddr: "0xBbc6009fEfFc27ce705322832Cb2068F8C1e0A58",
           lowerBoundBlockNumber: 551955,
         },
         {
           chainId: CHAIN_IDs.POLYGON,
           provider: new providers.JsonRpcProvider(process.env[`WEB3_NODE_URL_${CHAIN_IDs.POLYGON}`] || ""),
-          spokePoolContractAddr: "0xD3ddAcAe5aFb00F9B9cD36EF0Ed7115d7f0b584c",
+          spokePoolContractAddr: "0x69B5c72837769eF1e7C164Abc6515DcFf217F920",
           lowerBoundBlockNumber: 27875891,
         },
       ],
     });
+    // client.setLogLevel("debug");
+  });
 
-    client.setLogLevel("debug");
-    await client.startFetchingTransfers("0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D");
-    client.on(TransfersHistoryEvent.TransfersUpdated, () => {
+  it("should fetch pending transfers from chain", async (done) => {
+    jest.setTimeout(1000 * 60);
+
+    client.startFetchingTransfers("0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D");
+    client.on(TransfersHistoryEvent.TransfersUpdated, (data) => {
+      console.log(data);
       const pendingTransfers = client.getPendingTransfers("0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D");
       const filledTransfers = client.getFilledTransfers("0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D");
       client.stopFetchingTransfers("0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D");
@@ -78,6 +60,25 @@ describe("Client e2e tests", () => {
       expect(filledTransfers.length).toBeGreaterThanOrEqual(0);
       expect(filledTransfers[0].fillTxs.length).toBeGreaterThanOrEqual(1);
       done();
+    });
+  });
+
+  it("should fetch all transfers", async (done) => {
+    let iteration = 0;
+    jest.setTimeout(1000 * 60);
+    client.startFetchingTransfers("all");
+    client.on(TransfersHistoryEvent.TransfersUpdated, () => {
+      iteration++;
+      const pendingTransfers = client.getPendingTransfers("all");
+      const filledTransfers = client.getFilledTransfers("all");
+      console.log({ pendingTransfers: pendingTransfers.length, filledTransfers: filledTransfers.length });
+      expect(pendingTransfers.length).toBeGreaterThanOrEqual(0);
+      expect(filledTransfers.length).toBeGreaterThanOrEqual(0);
+
+      if (iteration === 3) {
+        client.stopFetchingTransfers("all");
+        done();
+      }
     });
   });
 });


### PR DESCRIPTION
Signed-off-by: amateima <amatei@umaproject.org>

This PR improves the TX History client to be able to fetch all Across V2 deposits by calling `client.startFetchingTransfers("all")` instead of a particular ETH address