### PR TITLE
feat: Truncate realized LP fee %'s to match UMIP

### DIFF
--- a/src/lpFeeCalculator/lpFeeCalculator.test.ts
+++ b/src/lpFeeCalculator/lpFeeCalculator.test.ts
@@ -30,12 +30,32 @@ describe("Realized liquidity provision calculation", function () {
       { utilA: toBNWei("0"), utilB: toBNWei("0.99"), apy: "220548340548340547", wpy: "3840050658887291" },
       { utilA: toBNWei("0"), utilB: toBNWei("1.00"), apy: "229000000000000000", wpy: "3973273191633388" },
     ];
+    const testedIntervalsTruncated = [
+      { utilA: toBNWei("0"), utilB: toBNWei("0.01"), apy: "615384615384600", wpy: "11000000000000" },
+      { utilA: toBNWei("0"), utilB: toBNWei("0.50"), apy: "30769230769230768", wpy: "582000000000000" },
+      { utilA: toBNWei("0.5"), utilB: toBNWei("0.51"), apy: "62153846153846200", wpy: "1160000000000000" },
+      { utilA: toBNWei("0.5"), utilB: toBNWei("0.56"), apy: "65230769230769233", wpy: "1215000000000000" },
+      { utilA: toBNWei("0.5"), utilB: toBNWei("0.5").add(100), apy: "60000000000000000", wpy: "1121000000000000" },
+      { utilA: toBNWei("0.6"), utilB: toBNWei("0.7"), apy: "114175824175824180", wpy: "2081000000000000" },
+      { utilA: toBNWei("0.7"), utilB: toBNWei("0.75"), apy: "294285714285714280", wpy: "4973000000000000" },
+      { utilA: toBNWei("0.7"), utilB: toBNWei("0.7").add(100), apy: "220000000000000000", wpy: "3831000000000000" },
+      { utilA: toBNWei("0.95"), utilB: toBNWei("1.00"), apy: "1008571428571428580", wpy: "13502000000000000" },
+      { utilA: toBNWei("0"), utilB: toBNWei("0.99"), apy: "220548340548340547", wpy: "3840000000000000" },
+      { utilA: toBNWei("0"), utilB: toBNWei("1.00"), apy: "229000000000000000", wpy: "3973000000000000" },
+    ];
 
     testedIntervals.forEach((interval) => {
       const apyFeePct = calculateApyFromUtilization(rateModel, interval.utilA, interval.utilB);
       assert.equal(apyFeePct.toString(), interval.apy);
 
       const realizedLpFeePct = calculateRealizedLpFeePct(rateModel, interval.utilA, interval.utilB).toString();
+      assert.equal(realizedLpFeePct.toString(), interval.wpy);
+    });
+    testedIntervalsTruncated.forEach((interval) => {
+      const apyFeePct = calculateApyFromUtilization(rateModel, interval.utilA, interval.utilB);
+      assert.equal(apyFeePct.toString(), interval.apy);
+
+      const realizedLpFeePct = calculateRealizedLpFeePct(rateModel, interval.utilA, interval.utilB, true).toString();
       assert.equal(realizedLpFeePct.toString(), interval.wpy);
     });
   });

--- a/src/lpFeeCalculator/lpFeeCalculator.ts
+++ b/src/lpFeeCalculator/lpFeeCalculator.ts
@@ -80,8 +80,17 @@ export function calculateApyFromUtilization(
 export function calculateRealizedLpFeePct(
   rateModel: RateModel,
   utilizationBeforeDeposit: BigNumberish,
-  utilizationAfterDeposit: BigNumberish
+  utilizationAfterDeposit: BigNumberish,
+  truncateDecimals = false
 ) {
   const apy = calculateApyFromUtilization(rateModel, toBN(utilizationBeforeDeposit), toBN(utilizationAfterDeposit));
-  return convertApyToWeeklyFee(apy);
+
+  // ACROSS-V2 UMIP requires that the realized fee percent is floor rounded as decimal to 6 decimals.
+  return truncateDecimals ? truncate18DecimalBN(convertApyToWeeklyFee(apy), 6) : convertApyToWeeklyFee(apy);
+}
+
+export function truncate18DecimalBN(input: BN, digits: number) {
+  const digitsToDrop = 18 - digits;
+  const multiplier = toBN(10).pow(digitsToDrop);
+  return input.div(multiplier).mul(multiplier);
 }


### PR DESCRIPTION
Note: The [across-v2](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-157.md#finding-slow-relays) UMIP doesn't reflect this truncation language yet but this PR can be merged in before hand since its backwards compatible. The `relayer-v2` code will then just need to pass in a flag to turn on truncation. 

The relayer and dataworker might want to only truncate %'s after a certain quote time so that it can validate older realized LP fee %'s