### PR TITLE
improve: Update default spokepool addresses

### DIFF
--- a/src/relayFeeCalculator/chain-queries/arbitrum.ts
+++ b/src/relayFeeCalculator/chain-queries/arbitrum.ts
@@ -11,7 +11,7 @@ export class ArbitrumQueries implements QueryInterface {
   constructor(
     readonly provider: providers.Provider,
     readonly symbolMapping = SymbolMapping,
-    spokePoolAddress = "0xe1C367e2b576Ac421a9f46C9cC624935730c36aa",
+    spokePoolAddress = "0xB88690461dDbaB6f04Dfad7df66B7725942FEb9C",
     private readonly usdcAddress = "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
     private readonly simulatedRelayerAddress = "0x893d0d70ad97717052e3aa8903d9615804167759"
   ) {

--- a/src/relayFeeCalculator/chain-queries/boba.ts
+++ b/src/relayFeeCalculator/chain-queries/boba.ts
@@ -13,7 +13,7 @@ export class BobaQueries implements QueryInterface {
   constructor(
     provider: providers.Provider,
     readonly symbolMapping = SymbolMapping,
-    spokePoolAddress = "0x59485d57EEcc4058F7831f46eE83a7078276b4AE",
+    spokePoolAddress = "0xBbc6009fEfFc27ce705322832Cb2068F8C1e0A58",
     private readonly usdcAddress = "0x66a2A913e447d6b4BF33EFbec43aAeF87890FBbc",
     private readonly simulatedRelayerAddress = "0x893d0d70ad97717052e3aa8903d9615804167759"
   ) {

--- a/src/relayFeeCalculator/chain-queries/optimism.ts
+++ b/src/relayFeeCalculator/chain-queries/optimism.ts
@@ -14,7 +14,7 @@ export class OptimismQueries implements QueryInterface {
   constructor(
     provider: providers.Provider,
     readonly symbolMapping = SymbolMapping,
-    spokePoolAddress = "0x59485d57EEcc4058F7831f46eE83a7078276b4AE",
+    spokePoolAddress = "0xa420b2d1c0841415A695b81E5B867BCD07Dff8C9",
     private readonly usdcAddress = "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
     private readonly simulatedRelayerAddress = "0x893d0d70ad97717052e3aa8903d9615804167759"
   ) {


### PR DESCRIPTION
This PR updates the default spokePoolAddress parameters on the Optimism, Boba, and Arbitrum QueryInterface classes. The new addresses align with the [official documentation](https://docs.across.to/v2/developers/contract-addresses).



