### PR TITLE
improve: update sdk queries to accurately estimate gas costs

### DIFF
--- a/src/relayFeeCalculator/chain-queries/boba.ts
+++ b/src/relayFeeCalculator/chain-queries/boba.ts
@@ -1,5 +1,9 @@
 import { QueryInterface } from "../relayFeeCalculator";
-import { BigNumberish } from "../../utils";
+import {
+  BigNumberish,
+  createUnsignedFillRelayTransaction,
+  estimateTotalGasRequiredByUnsignedTransaction,
+} from "../../utils";
 import { utils, providers } from "ethers";
 import { SymbolMapping } from "./ethereum";
 import { Coingecko } from "../../coingecko/Coingecko";
@@ -11,7 +15,7 @@ export class BobaQueries implements QueryInterface {
   private spokePool: OptimismSpokePool;
 
   constructor(
-    provider: providers.Provider,
+    private provider: providers.Provider,
     readonly symbolMapping = SymbolMapping,
     spokePoolAddress = "0xBbc6009fEfFc27ce705322832Cb2068F8C1e0A58",
     private readonly usdcAddress = "0x66a2A913e447d6b4BF33EFbec43aAeF87890FBbc",
@@ -22,24 +26,13 @@ export class BobaQueries implements QueryInterface {
   }
 
   async getGasCosts(_tokenSymbol: string): Promise<BigNumberish> {
-    // Create a dummy transaction to estimate. Note: the simulated caller would need to be holding weth and have approved the contract.
-    const gasEstimate = await this.spokePool.estimateGas.fillRelay(
-      "0xBb23Cd0210F878Ea4CcA50e9dC307fb0Ed65Cf6B",
-      "0xBb23Cd0210F878Ea4CcA50e9dC307fb0Ed65Cf6B",
-      this.usdcAddress,
-      "10",
-      "10",
-      "1",
-      "1",
-      "1",
-      "1",
-      "1",
-      { from: this.simulatedRelayerAddress }
+    const tx = await createUnsignedFillRelayTransaction(this.spokePool, this.usdcAddress, this.simulatedRelayerAddress);
+    return estimateTotalGasRequiredByUnsignedTransaction(
+      tx,
+      this.simulatedRelayerAddress,
+      this.provider,
+      parseUnits("1", 9)
     );
-
-    // Boba's gas price is hardcoded to 1 gwei.
-    const bobaGasPrice = parseUnits("1", 9);
-    return gasEstimate.mul(bobaGasPrice).toString();
   }
 
   async getTokenPrice(tokenSymbol: string): Promise<number> {

--- a/src/relayFeeCalculator/chain-queries/queries.e2e.ts
+++ b/src/relayFeeCalculator/chain-queries/queries.e2e.ts
@@ -2,6 +2,8 @@
 // NODE_URL_42161
 // NODE_URL_288
 // NODE_URL_10
+// NODE_URL_1
+// NODE_URL_137
 
 import dotenv from "dotenv";
 
@@ -35,7 +37,8 @@ describe("Queries", function () {
     ]);
   });
   test("Ethereum", async function () {
-    const ethereumQueries = new EthereumQueries();
+    const provider = new providers.JsonRpcProvider(process.env.NODE_URL_1);
+    const ethereumQueries = new EthereumQueries(provider);
     await Promise.all([
       ethereumQueries.getGasCosts("USDC"),
       ethereumQueries.getTokenDecimals("USDC"),
@@ -52,7 +55,8 @@ describe("Queries", function () {
     ]);
   });
   test("Polygon", async function () {
-    const polygonQueries = new PolygonQueries();
+    const provider = new providers.JsonRpcProvider(process.env.NODE_URL_137);
+    const polygonQueries = new PolygonQueries(provider);
     await Promise.all([
       polygonQueries.getGasCosts("USDC"),
       polygonQueries.getTokenDecimals("USDC"),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { BigNumber, ethers, PopulatedTransaction, providers, VoidSigner } from "ethers";
+import { BaseContract, BigNumber, ethers, PopulatedTransaction, providers, VoidSigner } from "ethers";
 import * as uma from "@uma/sdk";
 import Decimal from "decimal.js";
 import { isL2Provider, L2Provider } from "@eth-optimism/sdk";
@@ -252,4 +252,34 @@ export async function estimateTotalGasRequiredByUnsignedTransaction(
     // price & the estimated number of gas units needed
     return BigNumber.from(resolvedGasPrice).mul(estimatedGasUnits).toString();
   }
+}
+
+/**
+ * Create an unsigned transaction of a fillRelay contract call
+ * @param spokePool The specific spokepool that will populate this tx
+ * @param destinationTokenAddress A valid ERC20 token (system-wide default is UDSC)
+ * @param simulatedRelayerAddress The relayer address that relays this transaction
+ * @returns A populated (but unsigned) transaction that can be signed/sent or used for estimating gas costs
+ */
+export async function createUnsignedFillRelayTransaction(
+  spokePool: BaseContract,
+  destinationTokenAddress: string,
+  simulatedRelayerAddress: string
+): Promise<PopulatedTransaction> {
+  // Generate a baseline set of function parameters for the fillRelay contract function
+  const contractFunctionParams = [
+    "0xBb23Cd0210F878Ea4CcA50e9dC307fb0Ed65Cf6B",
+    "0xBb23Cd0210F878Ea4CcA50e9dC307fb0Ed65Cf6B",
+    destinationTokenAddress,
+    "10",
+    "10",
+    "1",
+    "1",
+    "1",
+    "1",
+    "1",
+    { from: simulatedRelayerAddress },
+  ];
+  // Populate and return an unsigned tx as per the given spoke pool
+  return await spokePool.populateTransaction.fillRelay(...contractFunctionParams);
 }


### PR DESCRIPTION
This PR aims to reflect the gas cost estimation changes proposed by [PR 212](https://github.com/across-protocol/relayer-v2/pull/212) at the SDK level. 

During the development of this PR, I found a pattern in the call structure across all chain queries to estimate gas costs. I encapsulated it in two utility functions. 

Finally, the SDK [e2e test ](https://github.com/across-protocol/sdk-v2/runs/7641513096?check_suite_focus=true) was found to have an error on production, so this PR includes a patch.