### PR TITLE
feat: create multiplier to buffer gas costs

### DIFF
--- a/src/relayFeeCalculator/chain-queries/arbitrum.ts
+++ b/src/relayFeeCalculator/chain-queries/arbitrum.ts
@@ -7,10 +7,10 @@ import {
 import { providers } from "ethers";
 import { SymbolMapping } from "./ethereum";
 import { Coingecko } from "../../coingecko/Coingecko";
-import { ArbitrumSpokePool__factory, ArbitrumSpokePool } from "@across-protocol/contracts-v2";
+import { ArbitrumSpokePool__factory, SpokePool } from "@across-protocol/contracts-v2";
 
 export class ArbitrumQueries implements QueryInterface {
-  private spokePool: ArbitrumSpokePool;
+  private spokePool: SpokePool;
 
   constructor(
     readonly provider: providers.Provider,

--- a/src/relayFeeCalculator/chain-queries/arbitrum.ts
+++ b/src/relayFeeCalculator/chain-queries/arbitrum.ts
@@ -17,14 +17,20 @@ export class ArbitrumQueries implements QueryInterface {
     readonly symbolMapping = SymbolMapping,
     spokePoolAddress = "0xB88690461dDbaB6f04Dfad7df66B7725942FEb9C",
     private readonly usdcAddress = "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
-    private readonly simulatedRelayerAddress = "0x893d0d70ad97717052e3aa8903d9615804167759"
+    private readonly simulatedRelayerAddress = "0x893d0d70ad97717052e3aa8903d9615804167759",
+    readonly gasMultiplier: number = 0
   ) {
     this.spokePool = ArbitrumSpokePool__factory.connect(spokePoolAddress, provider);
   }
 
   async getGasCosts(_tokenSymbol: string): Promise<BigNumberish> {
     const tx = await createUnsignedFillRelayTransaction(this.spokePool, this.usdcAddress, this.simulatedRelayerAddress);
-    return estimateTotalGasRequiredByUnsignedTransaction(tx, this.simulatedRelayerAddress, this.provider);
+    return estimateTotalGasRequiredByUnsignedTransaction(
+      tx,
+      this.simulatedRelayerAddress,
+      this.provider,
+      this.gasMultiplier
+    );
   }
 
   async getTokenPrice(tokenSymbol: string): Promise<string | number> {

--- a/src/relayFeeCalculator/chain-queries/boba.ts
+++ b/src/relayFeeCalculator/chain-queries/boba.ts
@@ -15,7 +15,7 @@ export class BobaQueries implements QueryInterface {
   private spokePool: OptimismSpokePool;
 
   constructor(
-    private provider: providers.Provider,
+    readonly provider: providers.Provider,
     readonly symbolMapping = SymbolMapping,
     spokePoolAddress = "0xBbc6009fEfFc27ce705322832Cb2068F8C1e0A58",
     private readonly usdcAddress = "0x66a2A913e447d6b4BF33EFbec43aAeF87890FBbc",

--- a/src/relayFeeCalculator/chain-queries/boba.ts
+++ b/src/relayFeeCalculator/chain-queries/boba.ts
@@ -19,7 +19,8 @@ export class BobaQueries implements QueryInterface {
     readonly symbolMapping = SymbolMapping,
     spokePoolAddress = "0xBbc6009fEfFc27ce705322832Cb2068F8C1e0A58",
     private readonly usdcAddress = "0x66a2A913e447d6b4BF33EFbec43aAeF87890FBbc",
-    private readonly simulatedRelayerAddress = "0x893d0d70ad97717052e3aa8903d9615804167759"
+    private readonly simulatedRelayerAddress = "0x893d0d70ad97717052e3aa8903d9615804167759",
+    readonly gasMultiplier: number = 0
   ) {
     // TODO: replace with address getter.
     this.spokePool = OptimismSpokePool__factory.connect(spokePoolAddress, provider);
@@ -31,6 +32,7 @@ export class BobaQueries implements QueryInterface {
       tx,
       this.simulatedRelayerAddress,
       this.provider,
+      this.gasMultiplier,
       parseUnits("1", 9)
     );
   }

--- a/src/relayFeeCalculator/chain-queries/boba.ts
+++ b/src/relayFeeCalculator/chain-queries/boba.ts
@@ -7,12 +7,12 @@ import {
 import { utils, providers } from "ethers";
 import { SymbolMapping } from "./ethereum";
 import { Coingecko } from "../../coingecko/Coingecko";
-import { OptimismSpokePool__factory, OptimismSpokePool } from "@across-protocol/contracts-v2";
+import { OptimismSpokePool__factory, SpokePool } from "@across-protocol/contracts-v2";
 
 const { parseUnits } = utils;
 
 export class BobaQueries implements QueryInterface {
-  private spokePool: OptimismSpokePool;
+  private spokePool: SpokePool;
 
   constructor(
     readonly provider: providers.Provider,

--- a/src/relayFeeCalculator/chain-queries/boba.ts
+++ b/src/relayFeeCalculator/chain-queries/boba.ts
@@ -1,5 +1,9 @@
 import { QueryInterface } from "../relayFeeCalculator";
-import { BigNumberish } from "../../utils";
+import {
+  BigNumberish,
+  createUnsignedFillRelayTransaction,
+  estimateTotalGasRequiredByUnsignedTransaction,
+} from "../../utils";
 import { utils, providers } from "ethers";
 import { SymbolMapping } from "./ethereum";
 import { Coingecko } from "../../coingecko/Coingecko";
@@ -11,7 +15,7 @@ export class BobaQueries implements QueryInterface {
   private spokePool: OptimismSpokePool;
 
   constructor(
-    provider: providers.Provider,
+    private provider: providers.Provider,
     readonly symbolMapping = SymbolMapping,
     spokePoolAddress = "0xBbc6009fEfFc27ce705322832Cb2068F8C1e0A58",
     private readonly usdcAddress = "0x66a2A913e447d6b4BF33EFbec43aAeF87890FBbc",
@@ -22,24 +26,13 @@ export class BobaQueries implements QueryInterface {
   }
 
   async getGasCosts(_tokenSymbol: string): Promise<BigNumberish> {
-    // Create a dummy transaction to estimate. Note: the simulated caller would need to be holding weth and have approved the contract.
-    const gasEstimate = await this.spokePool.estimateGas.fillRelay(
-      "0xBb23Cd0210F878Ea4CcA50e9dC307fb0Ed65Cf6B",
-      "0xBb23Cd0210F878Ea4CcA50e9dC307fb0Ed65Cf6B",
-      this.usdcAddress,
-      "10",
-      "10",
-      "1",
-      "1",
-      "1",
-      "1",
-      "1",
-      { from: this.simulatedRelayerAddress }
+    const tx = await createUnsignedFillRelayTransaction(this.spokePool, this.usdcAddress, this.simulatedRelayerAddress);
+    return estimateTotalGasRequiredByUnsignedTransaction(
+      tx,
+      this.simulatedRelayerAddress,
+      this.provider,
+      parseUnits("1", 9)
     );
-
-    // Boba's gas price is hardcoded to 1 gwei.
-    const bobaGasPrice = parseUnits("1", 9);
-    return gasEstimate.mul(bobaGasPrice).toString();
   }
 
   async getTokenPrice(tokenSymbol: string): Promise<number> {

--- a/src/relayFeeCalculator/chain-queries/ethereum.ts
+++ b/src/relayFeeCalculator/chain-queries/ethereum.ts
@@ -72,8 +72,6 @@ export const SymbolMapping: { [symbol: string]: { address: string; decimals: num
   },
 };
 
-export const defaultAverageGas = 116006;
-
 export class EthereumQueries implements QueryInterface {
   private spokePool: EthereumSpokePool;
 

--- a/src/relayFeeCalculator/chain-queries/ethereum.ts
+++ b/src/relayFeeCalculator/chain-queries/ethereum.ts
@@ -6,7 +6,7 @@ import {
 } from "../../utils";
 import { Coingecko } from "../../coingecko/Coingecko";
 import { providers } from "ethers";
-import { EthereumSpokePool, EthereumSpokePool__factory } from "@across-protocol/contracts-v2";
+import { EthereumSpokePool__factory, SpokePool } from "@across-protocol/contracts-v2";
 
 // Note: these are the mainnet addresses for these symbols meant to be used for pricing.
 export const SymbolMapping: { [symbol: string]: { address: string; decimals: number } } = {
@@ -73,7 +73,7 @@ export const SymbolMapping: { [symbol: string]: { address: string; decimals: num
 };
 
 export class EthereumQueries implements QueryInterface {
-  private spokePool: EthereumSpokePool;
+  private spokePool: SpokePool;
 
   constructor(
     readonly provider: providers.Provider,

--- a/src/relayFeeCalculator/chain-queries/ethereum.ts
+++ b/src/relayFeeCalculator/chain-queries/ethereum.ts
@@ -80,13 +80,19 @@ export class EthereumQueries implements QueryInterface {
     readonly symbolMapping = SymbolMapping,
     readonly spokePoolAddress = "0x4D9079Bb4165aeb4084c526a32695dCfd2F77381",
     readonly usdcAddress = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-    readonly simulatedRelayerAddress = "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D"
+    readonly simulatedRelayerAddress = "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D",
+    readonly gasMultiplier: number = 0
   ) {
     this.spokePool = EthereumSpokePool__factory.connect(this.spokePoolAddress, this.provider);
   }
   async getGasCosts(_tokenSymbol: string): Promise<BigNumberish> {
     const tx = await createUnsignedFillRelayTransaction(this.spokePool, this.usdcAddress, this.simulatedRelayerAddress);
-    return estimateTotalGasRequiredByUnsignedTransaction(tx, this.simulatedRelayerAddress, this.provider);
+    return estimateTotalGasRequiredByUnsignedTransaction(
+      tx,
+      this.simulatedRelayerAddress,
+      this.provider,
+      this.gasMultiplier
+    );
   }
 
   async getTokenPrice(tokenSymbol: string): Promise<number> {

--- a/src/relayFeeCalculator/chain-queries/ethereum.ts
+++ b/src/relayFeeCalculator/chain-queries/ethereum.ts
@@ -78,7 +78,7 @@ export class EthereumQueries implements QueryInterface {
   private spokePool: EthereumSpokePool;
 
   constructor(
-    public readonly provider: providers.Provider,
+    readonly provider: providers.Provider,
     readonly symbolMapping = SymbolMapping,
     readonly spokePoolAddress = "0x4D9079Bb4165aeb4084c526a32695dCfd2F77381",
     readonly usdcAddress = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",

--- a/src/relayFeeCalculator/chain-queries/optimism.ts
+++ b/src/relayFeeCalculator/chain-queries/optimism.ts
@@ -7,12 +7,12 @@ import {
 import { providers } from "ethers";
 import { SymbolMapping } from "./ethereum";
 import { Coingecko } from "../../coingecko/Coingecko";
-import { OptimismSpokePool__factory, OptimismSpokePool } from "@across-protocol/contracts-v2";
+import { OptimismSpokePool__factory, SpokePool } from "@across-protocol/contracts-v2";
 
 import { L2Provider, asL2Provider } from "@eth-optimism/sdk";
 
 export class OptimismQueries implements QueryInterface {
-  private spokePool: OptimismSpokePool;
+  private spokePool: SpokePool;
   readonly provider: L2Provider<providers.Provider>;
 
   constructor(

--- a/src/relayFeeCalculator/chain-queries/optimism.ts
+++ b/src/relayFeeCalculator/chain-queries/optimism.ts
@@ -20,7 +20,8 @@ export class OptimismQueries implements QueryInterface {
     readonly symbolMapping = SymbolMapping,
     spokePoolAddress = "0xa420b2d1c0841415A695b81E5B867BCD07Dff8C9",
     private readonly usdcAddress = "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
-    private readonly simulatedRelayerAddress = "0x893d0d70ad97717052e3aa8903d9615804167759"
+    private readonly simulatedRelayerAddress = "0x893d0d70ad97717052e3aa8903d9615804167759",
+    readonly gasMultiplier: number = 0
   ) {
     this.provider = asL2Provider(provider);
     this.spokePool = OptimismSpokePool__factory.connect(spokePoolAddress, provider);
@@ -28,7 +29,12 @@ export class OptimismQueries implements QueryInterface {
 
   async getGasCosts(_tokenSymbol: string): Promise<BigNumberish> {
     const tx = await createUnsignedFillRelayTransaction(this.spokePool, this.usdcAddress, this.simulatedRelayerAddress);
-    return estimateTotalGasRequiredByUnsignedTransaction(tx, this.simulatedRelayerAddress, this.provider);
+    return estimateTotalGasRequiredByUnsignedTransaction(
+      tx,
+      this.simulatedRelayerAddress,
+      this.provider,
+      this.gasMultiplier
+    );
   }
 
   async getTokenPrice(tokenSymbol: string): Promise<number> {

--- a/src/relayFeeCalculator/chain-queries/optimism.ts
+++ b/src/relayFeeCalculator/chain-queries/optimism.ts
@@ -13,7 +13,7 @@ import { L2Provider, asL2Provider } from "@eth-optimism/sdk";
 
 export class OptimismQueries implements QueryInterface {
   private spokePool: OptimismSpokePool;
-  private provider: L2Provider<providers.Provider>;
+  readonly provider: L2Provider<providers.Provider>;
 
   constructor(
     provider: providers.Provider,

--- a/src/relayFeeCalculator/chain-queries/polygon.ts
+++ b/src/relayFeeCalculator/chain-queries/polygon.ts
@@ -17,14 +17,20 @@ export class PolygonQueries implements QueryInterface {
     readonly symbolMapping = SymbolMapping,
     readonly spokePoolAddress = "0x69B5c72837769eF1e7C164Abc6515DcFf217F920",
     readonly usdcAddress = "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
-    readonly simulatedRelayerAddress = "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D"
+    readonly simulatedRelayerAddress = "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D",
+    readonly gasMultiplier: number = 0
   ) {
     this.spokePool = PolygonSpokePool__factory.connect(spokePoolAddress, provider);
   }
 
   async getGasCosts(_tokenSymbol: string): Promise<BigNumberish> {
     const tx = await createUnsignedFillRelayTransaction(this.spokePool, this.usdcAddress, this.simulatedRelayerAddress);
-    return estimateTotalGasRequiredByUnsignedTransaction(tx, this.simulatedRelayerAddress, this.provider);
+    return estimateTotalGasRequiredByUnsignedTransaction(
+      tx,
+      this.simulatedRelayerAddress,
+      this.provider,
+      this.gasMultiplier
+    );
   }
 
   async getTokenPrice(tokenSymbol: string): Promise<string | number> {

--- a/src/relayFeeCalculator/chain-queries/polygon.ts
+++ b/src/relayFeeCalculator/chain-queries/polygon.ts
@@ -7,10 +7,10 @@ import {
 import { providers } from "ethers";
 import { SymbolMapping } from "./ethereum";
 import { Coingecko } from "../../coingecko/Coingecko";
-import { PolygonSpokePool, PolygonSpokePool__factory } from "@across-protocol/contracts-v2";
+import { PolygonSpokePool__factory, SpokePool } from "@across-protocol/contracts-v2";
 
 export class PolygonQueries implements QueryInterface {
-  private spokePool: PolygonSpokePool;
+  private spokePool: SpokePool;
 
   constructor(
     readonly provider: providers.Provider,

--- a/src/relayFeeCalculator/chain-queries/queries.e2e.ts
+++ b/src/relayFeeCalculator/chain-queries/queries.e2e.ts
@@ -2,6 +2,8 @@
 // NODE_URL_42161
 // NODE_URL_288
 // NODE_URL_10
+// NODE_URL_1
+// NODE_URL_137
 
 import dotenv from "dotenv";
 
@@ -35,7 +37,8 @@ describe("Queries", function () {
     ]);
   });
   test("Ethereum", async function () {
-    const ethereumQueries = new EthereumQueries();
+    const provider = new providers.JsonRpcProvider(process.env.NODE_URL_1);
+    const ethereumQueries = new EthereumQueries(provider);
     await Promise.all([
       ethereumQueries.getGasCosts("USDC"),
       ethereumQueries.getTokenDecimals("USDC"),
@@ -52,7 +55,8 @@ describe("Queries", function () {
     ]);
   });
   test("Polygon", async function () {
-    const polygonQueries = new PolygonQueries();
+    const provider = new providers.JsonRpcProvider(process.env.NODE_URL_137);
+    const polygonQueries = new PolygonQueries(provider);
     await Promise.all([
       polygonQueries.getGasCosts("USDC"),
       polygonQueries.getTokenDecimals("USDC"),

--- a/src/relayFeeCalculator/relayFeeCalculator.test.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.test.ts
@@ -39,6 +39,22 @@ describe("RelayFeeCalculator", () => {
   beforeAll(() => {
     queries = new ExampleQueries();
   });
+  it("gasPercentageFee", async () => {
+    client = new RelayFeeCalculator({ queries });
+    // A list of inputs and ground truth [input, ground truth]
+    const gasFeePercents = [
+      [1000, "30557200000000000000000"],
+      [5000, "6111440000000000000000"],
+      // A test with a prime number
+      [104729, "291774007199534035462"],
+    ];
+    for (const [input, truth] of gasFeePercents) {
+      const result = (await client.gasFeePercent(input, "usdc")).toString();
+      expect(result).toEqual(truth);
+    }
+    // Test that zero amount fails
+    await expect(client.gasFeePercent(0, "USDC")).rejects.toThrowError();
+  });
   it("relayerFeeDetails", async () => {
     client = new RelayFeeCalculator({ queries });
     const result = await client.relayerFeeDetails(100000000, "usdc");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,8 @@
-import { BaseContract, BigNumber, ethers, PopulatedTransaction, providers, VoidSigner } from "ethers";
+import { BigNumber, ethers, PopulatedTransaction, providers, VoidSigner } from "ethers";
 import * as uma from "@uma/sdk";
 import Decimal from "decimal.js";
 import { isL2Provider, L2Provider } from "@eth-optimism/sdk";
+import { SpokePool } from "@across-protocol/contracts-v2";
 
 export type BigNumberish = string | number | BigNumber;
 export type BN = BigNumber;
@@ -262,13 +263,13 @@ export async function estimateTotalGasRequiredByUnsignedTransaction(
  * @returns A populated (but unsigned) transaction that can be signed/sent or used for estimating gas costs
  */
 export async function createUnsignedFillRelayTransaction(
-  spokePool: BaseContract,
+  spokePool: SpokePool,
   destinationTokenAddress: string,
   simulatedRelayerAddress: string
 ): Promise<PopulatedTransaction> {
-  // Generate a baseline set of function parameters for the fillRelay contract function
+  // Populate and return an unsigned tx as per the given spoke pool
   // NOTE: 0xBb23Cd0210F878Ea4CcA50e9dC307fb0Ed65Cf6B is a dummy address
-  const contractFunctionParams = [
+  return await spokePool.populateTransaction.fillRelay(
     "0xBb23Cd0210F878Ea4CcA50e9dC307fb0Ed65Cf6B",
     "0xBb23Cd0210F878Ea4CcA50e9dC307fb0Ed65Cf6B",
     destinationTokenAddress,
@@ -279,8 +280,6 @@ export async function createUnsignedFillRelayTransaction(
     "1",
     "1",
     "1",
-    { from: simulatedRelayerAddress },
-  ];
-  // Populate and return an unsigned tx as per the given spoke pool
-  return await spokePool.populateTransaction.fillRelay(...contractFunctionParams);
+    { from: simulatedRelayerAddress }
+  );
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -227,18 +227,18 @@ export async function retry<T>(call: () => Promise<T>, times: number, delayS: nu
 /**
  * Estimates the total gas cost required to submit an unsigned (populated) transaction on-chain
  * @param unsignedTx The unsigned transaction that this function will estimate
- * @param relayerAddress The address that the transaction will be submitted from ()
+ * @param senderAddress The address that the transaction will be submitted from
  * @param provider A valid ethers provider - will be used to reason the gas price
  * @param gasPrice A manually provided gas price - if set, this function will not resolve the current gas price
  * @returns The total gas cost to submit this transaction - i.e. gasPrice * estimatedGasUnits
  */
 export async function estimateTotalGasRequiredByUnsignedTransaction(
   unsignedTx: PopulatedTransaction,
-  relayerAddress: string,
+  senderAddress: string,
   provider: providers.Provider | L2Provider<providers.Provider>,
   gasPrice?: BigNumberish
 ): Promise<BigNumberish> {
-  const voidSigner = new VoidSigner(relayerAddress, provider);
+  const voidSigner = new VoidSigner(senderAddress, provider);
   // Verify if this provider has been L2Provider wrapped
   if (isL2Provider(provider)) {
     const populatedTransaction = await voidSigner.populateTransaction(unsignedTx);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { BigNumber, ethers, PopulatedTransaction, providers, VoidSigner } from "ethers";
+import { BaseContract, BigNumber, ethers, PopulatedTransaction, providers, VoidSigner } from "ethers";
 import * as uma from "@uma/sdk";
 import Decimal from "decimal.js";
 import { isL2Provider, L2Provider } from "@eth-optimism/sdk";
@@ -252,4 +252,34 @@ export async function estimateTotalGasRequiredByUnsignedTransaction(
     // price & the estimated number of gas units needed
     return BigNumber.from(resolvedGasPrice).mul(estimatedGasUnits).toString();
   }
+}
+
+/**
+ * Create an unsigned transaction of a fillRelay contract call
+ * @param spokePool The specific spokepool that will populate this tx
+ * @param destinationTokenAddress A valid ERC20 token (system-wide default is UDSC)
+ * @param simulatedRelayerAddress The relayer address that relays this transaction
+ * @returns A populated (but unsigned) transaction that can be signed/sent or used for estimating gas costs
+ */
+export async function createUnsignedFillRelayTransaction(
+  spokePool: BaseContract,
+  destinationTokenAddress: string,
+  simulatedRelayerAddress: string
+): Promise<PopulatedTransaction> {
+  // Generate a baseline set of function parameters for the fillRelay contract function
+  const contractFunctionParams = [
+    "0xBb23Cd0210F878Ea4CcA50e9dC307fb0Ed65Cf6B",
+    "0xBb23Cd0210F878Ea4CcA50e9dC307fb0Ed65Cf6B",
+    destinationTokenAddress,
+    "10",
+    "10",
+    "1",
+    "1",
+    "1",
+    "1",
+    "1",
+    { from: simulatedRelayerAddress },
+  ];
+  // Populate and return an unsigned tx as per the given spoke pool
+  return await spokePool.populateTransaction.fillRelay(...contractFunctionParams);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -267,6 +267,7 @@ export async function createUnsignedFillRelayTransaction(
   simulatedRelayerAddress: string
 ): Promise<PopulatedTransaction> {
   // Generate a baseline set of function parameters for the fillRelay contract function
+  // NOTE: 0xBb23Cd0210F878Ea4CcA50e9dC307fb0Ed65Cf6B is a dummy address
   const contractFunctionParams = [
     "0xBb23Cd0210F878Ea4CcA50e9dC307fb0Ed65Cf6B",
     "0xBb23Cd0210F878Ea4CcA50e9dC307fb0Ed65Cf6B",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import { BigNumber, ethers, PopulatedTransaction, providers, VoidSigner } from "ethers";
 import * as uma from "@uma/sdk";
 import Decimal from "decimal.js";
-import { isL2Provider, L2Provider } from "@eth-optimism/sdk";
+import { isL2Provider as isOptimismL2Provider, L2Provider } from "@eth-optimism/sdk";
 import { SpokePool } from "@across-protocol/contracts-v2";
 
 export type BigNumberish = string | number | BigNumber;
@@ -241,7 +241,9 @@ export async function estimateTotalGasRequiredByUnsignedTransaction(
 ): Promise<BigNumberish> {
   const voidSigner = new VoidSigner(senderAddress, provider);
   // Verify if this provider has been L2Provider wrapped
-  if (isL2Provider(provider)) {
+  // NOTE: In this case, this will be true if the provider is
+  //       using the Optimism blockchain
+  if (isOptimismL2Provider(provider)) {
     const populatedTransaction = await voidSigner.populateTransaction(unsignedTx);
     return (await provider.estimateTotalGasCost(populatedTransaction)).toString();
   } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14820,9 +14820,9 @@ terminal-link@^2.0.0:
     supports-hyperlinks "^2.0.0"
 
 terser@^4.6.2:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
-  integrity sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.1.tgz#a00e5634562de2239fd404c649051bf6fc21144f"
+  integrity sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"


### PR DESCRIPTION
This PR is aimed at creating the notion of a `gasMultiplier` to pad against gas spikes. Each QueryInterface class (Boba, Arbitrum, Optimism, Ethereum, Polygon) has the option to include a `gasMultplier`. 

The buffered result is `gasCost = totalGasEstimated * (1.0 + gasMultiplier)` where `gasMultiplier = 0.0` in the default case.