### PR TITLE
feat: Allow relayer fee user to pass in token price to use

### DIFF
--- a/src/coingecko/Coingecko.e2e.ts
+++ b/src/coingecko/Coingecko.e2e.ts
@@ -1,14 +1,15 @@
 import assert from "assert";
 import Coingecko from "./Coingecko";
+import dotenv from "dotenv";
+dotenv.config({ path: ".env" });
 
 // this requires e2e testing, should only test manually for now
 describe("coingecko", function () {
   let cg: Coingecko;
   test("init", function () {
-    cg = Coingecko.get();
+    if (process.env.COINGECKO_PRO_API_KEY !== undefined) cg = Coingecko.get(process.env.COINGECKO_PRO_API_KEY);
+    else cg = Coingecko.get();
     assert.ok(cg);
-    const cgPro = Coingecko.getPro();
-    assert.ok(cgPro);
   });
   test("getContractDetails", async function () {
     const address = "0x04fa0d235c4abf4bcf4787af4cf447de572ef828";

--- a/src/coingecko/Coingecko.e2e.ts
+++ b/src/coingecko/Coingecko.e2e.ts
@@ -7,6 +7,8 @@ describe("coingecko", function () {
   test("init", function () {
     cg = Coingecko.get();
     assert.ok(cg);
+    const cgPro = Coingecko.getPro();
+    assert.ok(cgPro);
   });
   test("getContractDetails", async function () {
     const address = "0x04fa0d235c4abf4bcf4787af4cf447de572ef828";

--- a/src/coingecko/Coingecko.ts
+++ b/src/coingecko/Coingecko.ts
@@ -33,7 +33,12 @@ export class Coingecko {
     return this.instance;
   }
 
-  private constructor(private readonly host = "https://api.coingecko.com/api/v3") {}
+  public static getPro(apiKey?: string) {
+    if (!this.instance) this.instance = new Coingecko("https://pro-api.coingecko.com/api/v3", apiKey);
+    return this.instance;
+  }
+
+  private constructor(private readonly host = "https://api.coingecko.com/api/v3", private readonly apiKey?: string) {}
 
   // Fetch historic prices for a `contract` denominated in `currency` between timestamp `from` and `to`. Note timestamps
   // are assumed to be js timestamps and are converted to unixtimestamps by dividing by 1000.
@@ -106,7 +111,7 @@ export class Coingecko {
       try {
         const { host } = this;
         const url = `${host}/${path}`;
-        const result = await axios(url);
+        const result = await axios(url, { params: { x_cg_pro_api_key: this.apiKey } });
         return result.data;
       } catch (err) {
         const msg = get(err, "response.data.error", get(err, "response.statusText", "Unknown Coingecko Error"));

--- a/src/coingecko/Coingecko.ts
+++ b/src/coingecko/Coingecko.ts
@@ -28,17 +28,16 @@ export class Coingecko {
   private retryDelay = 1;
   private numRetries = 3;
 
-  public static get(host?: string) {
-    if (!this.instance) this.instance = new Coingecko(host);
+  public static get(apiKey?: string) {
+    if (!this.instance)
+      this.instance =
+        apiKey === undefined
+          ? new Coingecko("https://api.coingecko.com/api/v3")
+          : new Coingecko("https://pro-api.coingecko.com/api/v3", apiKey);
     return this.instance;
   }
 
-  public static getPro(apiKey?: string) {
-    if (!this.instance) this.instance = new Coingecko("https://pro-api.coingecko.com/api/v3", apiKey);
-    return this.instance;
-  }
-
-  private constructor(private readonly host = "https://api.coingecko.com/api/v3", private readonly apiKey?: string) {}
+  private constructor(private readonly host: string, private readonly apiKey?: string) {}
 
   // Fetch historic prices for a `contract` denominated in `currency` between timestamp `from` and `to`. Note timestamps
   // are assumed to be js timestamps and are converted to unixtimestamps by dividing by 1000.
@@ -112,6 +111,7 @@ export class Coingecko {
         const { host } = this;
         const url = `${host}/${path}`;
         const result = await axios(url, { params: { x_cg_pro_api_key: this.apiKey } });
+        console.log(`INFO(coingecko): Sent GET request to url ${result.request.responseURL}`);
         return result.data;
       } catch (err) {
         const msg = get(err, "response.data.error", get(err, "response.statusText", "Unknown Coingecko Error"));

--- a/src/relayFeeCalculator/chain-queries/arbitrum.ts
+++ b/src/relayFeeCalculator/chain-queries/arbitrum.ts
@@ -17,7 +17,8 @@ export class ArbitrumQueries implements QueryInterface {
     readonly symbolMapping = SymbolMapping,
     spokePoolAddress = "0xB88690461dDbaB6f04Dfad7df66B7725942FEb9C",
     private readonly usdcAddress = "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
-    private readonly simulatedRelayerAddress = "0x893d0d70ad97717052e3aa8903d9615804167759"
+    private readonly simulatedRelayerAddress = "0x893d0d70ad97717052e3aa8903d9615804167759",
+    private readonly coingeckoProApiKey?: string
   ) {
     this.spokePool = SpokePool__factory.connect(spokePoolAddress, provider);
   }
@@ -27,9 +28,10 @@ export class ArbitrumQueries implements QueryInterface {
     return estimateTotalGasRequiredByUnsignedTransaction(tx, this.simulatedRelayerAddress, this.provider);
   }
 
-  async getTokenPrice(tokenSymbol: string, coingeckoProApiKey?: string): Promise<number> {
+  async getTokenPrice(tokenSymbol: string): Promise<number> {
     if (!this.symbolMapping[tokenSymbol]) throw new Error(`${tokenSymbol} does not exist in mapping`);
-    const coingeckoInstance = coingeckoProApiKey !== undefined ? Coingecko.getPro(coingeckoProApiKey) : Coingecko.get();
+    const coingeckoInstance =
+      this.coingeckoProApiKey !== undefined ? Coingecko.getPro(this.coingeckoProApiKey) : Coingecko.get();
     const [, price] = await coingeckoInstance.getCurrentPriceByContract(this.symbolMapping[tokenSymbol].address, "eth");
     return price;
   }

--- a/src/relayFeeCalculator/chain-queries/arbitrum.ts
+++ b/src/relayFeeCalculator/chain-queries/arbitrum.ts
@@ -24,9 +24,10 @@ export class ArbitrumQueries implements QueryInterface {
     return gasPrice.mul(gasEstimate).toString();
   }
 
-  async getTokenPrice(tokenSymbol: string): Promise<number> {
+  async getTokenPrice(tokenSymbol: string, coingeckoProApiKey?: string): Promise<number> {
     if (!this.symbolMapping[tokenSymbol]) throw new Error(`${tokenSymbol} does not exist in mapping`);
-    const [, price] = await Coingecko.get().getCurrentPriceByContract(this.symbolMapping[tokenSymbol].address, "eth");
+    const coingeckoInstance = coingeckoProApiKey !== undefined ? Coingecko.getPro(coingeckoProApiKey) : Coingecko.get();
+    const [, price] = await coingeckoInstance.getCurrentPriceByContract(this.symbolMapping[tokenSymbol].address, "eth");
     return price;
   }
 

--- a/src/relayFeeCalculator/chain-queries/arbitrum.ts
+++ b/src/relayFeeCalculator/chain-queries/arbitrum.ts
@@ -30,8 +30,7 @@ export class ArbitrumQueries implements QueryInterface {
 
   async getTokenPrice(tokenSymbol: string): Promise<number> {
     if (!this.symbolMapping[tokenSymbol]) throw new Error(`${tokenSymbol} does not exist in mapping`);
-    const coingeckoInstance =
-      this.coingeckoProApiKey !== undefined ? Coingecko.getPro(this.coingeckoProApiKey) : Coingecko.get();
+    const coingeckoInstance = Coingecko.get(this.coingeckoProApiKey);
     const [, price] = await coingeckoInstance.getCurrentPriceByContract(this.symbolMapping[tokenSymbol].address, "eth");
     return price;
   }

--- a/src/relayFeeCalculator/chain-queries/boba.ts
+++ b/src/relayFeeCalculator/chain-queries/boba.ts
@@ -42,9 +42,10 @@ export class BobaQueries implements QueryInterface {
     return gasEstimate.mul(bobaGasPrice).toString();
   }
 
-  async getTokenPrice(tokenSymbol: string): Promise<number> {
+  async getTokenPrice(tokenSymbol: string, coingeckoProApiKey?: string): Promise<number> {
     if (!this.symbolMapping[tokenSymbol]) throw new Error(`${tokenSymbol} does not exist in mapping`);
-    const [, price] = await Coingecko.get().getCurrentPriceByContract(this.symbolMapping[tokenSymbol].address, "eth");
+    const coingeckoInstance = coingeckoProApiKey !== undefined ? Coingecko.getPro(coingeckoProApiKey) : Coingecko.get();
+    const [, price] = await coingeckoInstance.getCurrentPriceByContract(this.symbolMapping[tokenSymbol].address, "eth");
     return price;
   }
 

--- a/src/relayFeeCalculator/chain-queries/boba.ts
+++ b/src/relayFeeCalculator/chain-queries/boba.ts
@@ -38,8 +38,7 @@ export class BobaQueries implements QueryInterface {
 
   async getTokenPrice(tokenSymbol: string): Promise<number> {
     if (!this.symbolMapping[tokenSymbol]) throw new Error(`${tokenSymbol} does not exist in mapping`);
-    const coingeckoInstance =
-      this.coingeckoProApiKey !== undefined ? Coingecko.getPro(this.coingeckoProApiKey) : Coingecko.get();
+    const coingeckoInstance = Coingecko.get(this.coingeckoProApiKey);
     const [, price] = await coingeckoInstance.getCurrentPriceByContract(this.symbolMapping[tokenSymbol].address, "eth");
     return price;
   }

--- a/src/relayFeeCalculator/chain-queries/boba.ts
+++ b/src/relayFeeCalculator/chain-queries/boba.ts
@@ -19,7 +19,8 @@ export class BobaQueries implements QueryInterface {
     readonly symbolMapping = SymbolMapping,
     spokePoolAddress = "0xBbc6009fEfFc27ce705322832Cb2068F8C1e0A58",
     private readonly usdcAddress = "0x66a2A913e447d6b4BF33EFbec43aAeF87890FBbc",
-    private readonly simulatedRelayerAddress = "0x893d0d70ad97717052e3aa8903d9615804167759"
+    private readonly simulatedRelayerAddress = "0x893d0d70ad97717052e3aa8903d9615804167759",
+    private readonly coingeckoProApiKey?: string
   ) {
     // TODO: replace with address getter.
     this.spokePool = SpokePool__factory.connect(spokePoolAddress, provider);
@@ -35,9 +36,10 @@ export class BobaQueries implements QueryInterface {
     );
   }
 
-  async getTokenPrice(tokenSymbol: string, coingeckoProApiKey?: string): Promise<number> {
+  async getTokenPrice(tokenSymbol: string): Promise<number> {
     if (!this.symbolMapping[tokenSymbol]) throw new Error(`${tokenSymbol} does not exist in mapping`);
-    const coingeckoInstance = coingeckoProApiKey !== undefined ? Coingecko.getPro(coingeckoProApiKey) : Coingecko.get();
+    const coingeckoInstance =
+      this.coingeckoProApiKey !== undefined ? Coingecko.getPro(this.coingeckoProApiKey) : Coingecko.get();
     const [, price] = await coingeckoInstance.getCurrentPriceByContract(this.symbolMapping[tokenSymbol].address, "eth");
     return price;
   }

--- a/src/relayFeeCalculator/chain-queries/ethereum.ts
+++ b/src/relayFeeCalculator/chain-queries/ethereum.ts
@@ -81,9 +81,10 @@ export class EthereumQueries implements QueryInterface {
       .toString();
   }
 
-  async getTokenPrice(tokenSymbol: string): Promise<number> {
+  async getTokenPrice(tokenSymbol: string, coingeckoProApiKey?: string): Promise<number> {
     if (!this.symbolMapping[tokenSymbol]) throw new Error(`${tokenSymbol} does not exist in mapping`);
-    const [, price] = await Coingecko.get().getCurrentPriceByContract(this.symbolMapping[tokenSymbol].address, "eth");
+    const coingeckoInstance = coingeckoProApiKey !== undefined ? Coingecko.getPro(coingeckoProApiKey) : Coingecko.get();
+    const [, price] = await coingeckoInstance.getCurrentPriceByContract(this.symbolMapping[tokenSymbol].address, "eth");
     return price;
   }
 

--- a/src/relayFeeCalculator/chain-queries/ethereum.ts
+++ b/src/relayFeeCalculator/chain-queries/ethereum.ts
@@ -80,7 +80,8 @@ export class EthereumQueries implements QueryInterface {
     readonly symbolMapping = SymbolMapping,
     readonly spokePoolAddress = "0x4D9079Bb4165aeb4084c526a32695dCfd2F77381",
     readonly usdcAddress = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-    readonly simulatedRelayerAddress = "0x893d0D70AD97717052E3AA8903D9615804167759"
+    readonly simulatedRelayerAddress = "0x893d0D70AD97717052E3AA8903D9615804167759",
+    private readonly coingeckoProApiKey?: string
   ) {
     this.spokePool = SpokePool__factory.connect(this.spokePoolAddress, this.provider);
   }
@@ -89,9 +90,10 @@ export class EthereumQueries implements QueryInterface {
     return estimateTotalGasRequiredByUnsignedTransaction(tx, this.simulatedRelayerAddress, this.provider);
   }
 
-  async getTokenPrice(tokenSymbol: string, coingeckoProApiKey?: string): Promise<number> {
+  async getTokenPrice(tokenSymbol: string): Promise<number> {
     if (!this.symbolMapping[tokenSymbol]) throw new Error(`${tokenSymbol} does not exist in mapping`);
-    const coingeckoInstance = coingeckoProApiKey !== undefined ? Coingecko.getPro(coingeckoProApiKey) : Coingecko.get();
+    const coingeckoInstance =
+      this.coingeckoProApiKey !== undefined ? Coingecko.getPro(this.coingeckoProApiKey) : Coingecko.get();
     const [, price] = await coingeckoInstance.getCurrentPriceByContract(this.symbolMapping[tokenSymbol].address, "eth");
     return price;
   }

--- a/src/relayFeeCalculator/chain-queries/ethereum.ts
+++ b/src/relayFeeCalculator/chain-queries/ethereum.ts
@@ -92,8 +92,7 @@ export class EthereumQueries implements QueryInterface {
 
   async getTokenPrice(tokenSymbol: string): Promise<number> {
     if (!this.symbolMapping[tokenSymbol]) throw new Error(`${tokenSymbol} does not exist in mapping`);
-    const coingeckoInstance =
-      this.coingeckoProApiKey !== undefined ? Coingecko.getPro(this.coingeckoProApiKey) : Coingecko.get();
+    const coingeckoInstance = Coingecko.get(this.coingeckoProApiKey);
     const [, price] = await coingeckoInstance.getCurrentPriceByContract(this.symbolMapping[tokenSymbol].address, "eth");
     return price;
   }

--- a/src/relayFeeCalculator/chain-queries/optimism.ts
+++ b/src/relayFeeCalculator/chain-queries/optimism.ts
@@ -20,7 +20,8 @@ export class OptimismQueries implements QueryInterface {
     readonly symbolMapping = SymbolMapping,
     spokePoolAddress = "0xa420b2d1c0841415A695b81E5B867BCD07Dff8C9",
     private readonly usdcAddress = "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
-    private readonly simulatedRelayerAddress = "0x893d0d70ad97717052e3aa8903d9615804167759"
+    private readonly simulatedRelayerAddress = "0x893d0d70ad97717052e3aa8903d9615804167759",
+    private readonly coingeckoProApiKey?: string
   ) {
     this.provider = asL2Provider(provider);
     this.spokePool = SpokePool__factory.connect(spokePoolAddress, provider);
@@ -31,9 +32,10 @@ export class OptimismQueries implements QueryInterface {
     return estimateTotalGasRequiredByUnsignedTransaction(tx, this.simulatedRelayerAddress, this.provider);
   }
 
-  async getTokenPrice(tokenSymbol: string, coingeckoProApiKey?: string): Promise<number> {
+  async getTokenPrice(tokenSymbol: string): Promise<number> {
     if (!this.symbolMapping[tokenSymbol]) throw new Error(`${tokenSymbol} does not exist in mapping`);
-    const coingeckoInstance = coingeckoProApiKey !== undefined ? Coingecko.getPro(coingeckoProApiKey) : Coingecko.get();
+    const coingeckoInstance =
+      this.coingeckoProApiKey !== undefined ? Coingecko.getPro(this.coingeckoProApiKey) : Coingecko.get();
     const [, price] = await coingeckoInstance.getCurrentPriceByContract(this.symbolMapping[tokenSymbol].address, "eth");
     return price;
   }

--- a/src/relayFeeCalculator/chain-queries/optimism.ts
+++ b/src/relayFeeCalculator/chain-queries/optimism.ts
@@ -34,8 +34,7 @@ export class OptimismQueries implements QueryInterface {
 
   async getTokenPrice(tokenSymbol: string): Promise<number> {
     if (!this.symbolMapping[tokenSymbol]) throw new Error(`${tokenSymbol} does not exist in mapping`);
-    const coingeckoInstance =
-      this.coingeckoProApiKey !== undefined ? Coingecko.getPro(this.coingeckoProApiKey) : Coingecko.get();
+    const coingeckoInstance = Coingecko.get(this.coingeckoProApiKey);
     const [, price] = await coingeckoInstance.getCurrentPriceByContract(this.symbolMapping[tokenSymbol].address, "eth");
     return price;
   }

--- a/src/relayFeeCalculator/chain-queries/optimism.ts
+++ b/src/relayFeeCalculator/chain-queries/optimism.ts
@@ -42,9 +42,10 @@ export class OptimismQueries implements QueryInterface {
     return (await this.provider.estimateTotalGasCost(populatedTransaction)).toString();
   }
 
-  async getTokenPrice(tokenSymbol: string): Promise<number> {
+  async getTokenPrice(tokenSymbol: string, coingeckoProApiKey?: string): Promise<number> {
     if (!this.symbolMapping[tokenSymbol]) throw new Error(`${tokenSymbol} does not exist in mapping`);
-    const [, price] = await Coingecko.get().getCurrentPriceByContract(this.symbolMapping[tokenSymbol].address, "eth");
+    const coingeckoInstance = coingeckoProApiKey !== undefined ? Coingecko.getPro(coingeckoProApiKey) : Coingecko.get();
+    const [, price] = await coingeckoInstance.getCurrentPriceByContract(this.symbolMapping[tokenSymbol].address, "eth");
     return price;
   }
 

--- a/src/relayFeeCalculator/chain-queries/polygon.ts
+++ b/src/relayFeeCalculator/chain-queries/polygon.ts
@@ -17,14 +17,18 @@ export class PolygonQueries implements QueryInterface {
       .toString();
   }
 
-  async getTokenPrice(tokenSymbol: string): Promise<number> {
+  async getTokenPrice(tokenSymbol: string, coingeckoProApiKey?: string): Promise<number> {
     if (!this.symbolMapping[tokenSymbol]) throw new Error(`${tokenSymbol} does not exist in mapping`);
-    const [, tokenPrice] = await Coingecko.get().getCurrentPriceByContract(
+    const coingeckoInstance = coingeckoProApiKey !== undefined ? Coingecko.getPro(coingeckoProApiKey) : Coingecko.get();
+    const [, tokenPrice] = await coingeckoInstance.getCurrentPriceByContract(
       this.symbolMapping[tokenSymbol].address,
       "usd"
     );
 
-    const [, maticPrice] = await Coingecko.get().getCurrentPriceByContract(this.symbolMapping["MATIC"].address, "usd");
+    const [, maticPrice] = await coingeckoInstance.getCurrentPriceByContract(
+      this.symbolMapping["MATIC"].address,
+      "usd"
+    );
     return Number((tokenPrice / maticPrice).toFixed(this.symbolMapping["MATIC"].decimals));
   }
 

--- a/src/relayFeeCalculator/chain-queries/polygon.ts
+++ b/src/relayFeeCalculator/chain-queries/polygon.ts
@@ -30,8 +30,7 @@ export class PolygonQueries implements QueryInterface {
 
   async getTokenPrice(tokenSymbol: string): Promise<number> {
     if (!this.symbolMapping[tokenSymbol]) throw new Error(`${tokenSymbol} does not exist in mapping`);
-    const coingeckoInstance =
-      this.coingeckoProApiKey !== undefined ? Coingecko.getPro(this.coingeckoProApiKey) : Coingecko.get();
+    const coingeckoInstance = Coingecko.get(this.coingeckoProApiKey);
     const [, tokenPrice] = await coingeckoInstance.getCurrentPriceByContract(
       this.symbolMapping[tokenSymbol].address,
       "usd"

--- a/src/relayFeeCalculator/chain-queries/polygon.ts
+++ b/src/relayFeeCalculator/chain-queries/polygon.ts
@@ -17,7 +17,8 @@ export class PolygonQueries implements QueryInterface {
     readonly symbolMapping = SymbolMapping,
     readonly spokePoolAddress = "0x69B5c72837769eF1e7C164Abc6515DcFf217F920",
     readonly usdcAddress = "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
-    readonly simulatedRelayerAddress = "0x893d0D70AD97717052E3AA8903D9615804167759"
+    readonly simulatedRelayerAddress = "0x893d0D70AD97717052E3AA8903D9615804167759",
+    private readonly coingeckoProApiKey?: string
   ) {
     this.spokePool = SpokePool__factory.connect(spokePoolAddress, provider);
   }
@@ -27,9 +28,10 @@ export class PolygonQueries implements QueryInterface {
     return estimateTotalGasRequiredByUnsignedTransaction(tx, this.simulatedRelayerAddress, this.provider);
   }
 
-  async getTokenPrice(tokenSymbol: string, coingeckoProApiKey?: string): Promise<number> {
+  async getTokenPrice(tokenSymbol: string): Promise<number> {
     if (!this.symbolMapping[tokenSymbol]) throw new Error(`${tokenSymbol} does not exist in mapping`);
-    const coingeckoInstance = coingeckoProApiKey !== undefined ? Coingecko.getPro(coingeckoProApiKey) : Coingecko.get();
+    const coingeckoInstance =
+      this.coingeckoProApiKey !== undefined ? Coingecko.getPro(this.coingeckoProApiKey) : Coingecko.get();
     const [, tokenPrice] = await coingeckoInstance.getCurrentPriceByContract(
       this.symbolMapping[tokenSymbol].address,
       "usd"

--- a/src/relayFeeCalculator/chain-queries/queries.e2e.ts
+++ b/src/relayFeeCalculator/chain-queries/queries.e2e.ts
@@ -11,7 +11,7 @@ import { ArbitrumQueries } from "./arbitrum";
 
 import { providers } from "ethers";
 import { BobaQueries } from "./boba";
-import { EthereumQueries } from "./ethereum";
+import { EthereumQueries, SymbolMapping } from "./ethereum";
 import { OptimismQueries } from "./optimism";
 import { PolygonQueries } from "./polygon";
 
@@ -25,8 +25,16 @@ describe("Queries", function () {
       arbitrumQueries.getGasCosts("USDC"),
       arbitrumQueries.getTokenDecimals("USDC"),
       arbitrumQueries.getTokenPrice("USDC"),
-      arbitrumQueries.getTokenPrice("USDC", process.env.COINGECKO_PRO_API_KEY),
     ]);
+    const queriesWithCoingeckoProApi = new ArbitrumQueries(
+      provider,
+      SymbolMapping,
+      "0xB88690461dDbaB6f04Dfad7df66B7725942FEb9C",
+      "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "0x893d0d70ad97717052e3aa8903d9615804167759",
+      process.env.COINGECKO_PRO_API_KEY
+    );
+    await queriesWithCoingeckoProApi.getTokenPrice("USDC");
   });
   test("Boba", async function () {
     const provider = new providers.JsonRpcProvider(process.env.NODE_URL_288);
@@ -35,8 +43,16 @@ describe("Queries", function () {
       bobaQueries.getGasCosts("USDC"),
       bobaQueries.getTokenDecimals("USDC"),
       bobaQueries.getTokenPrice("USDC"),
-      bobaQueries.getTokenPrice("USDC", process.env.COINGECKO_PRO_API_KEY),
     ]);
+    const queriesWithCoingeckoProApi = new ArbitrumQueries(
+      provider,
+      SymbolMapping,
+      "0xBbc6009fEfFc27ce705322832Cb2068F8C1e0A58",
+      "0x66a2A913e447d6b4BF33EFbec43aAeF87890FBbc",
+      "0x893d0d70ad97717052e3aa8903d9615804167759",
+      process.env.COINGECKO_PRO_API_KEY
+    );
+    await queriesWithCoingeckoProApi.getTokenPrice("USDC");
   });
   test("Ethereum", async function () {
     const provider = new providers.JsonRpcProvider(process.env.NODE_URL_1);
@@ -45,8 +61,16 @@ describe("Queries", function () {
       ethereumQueries.getGasCosts("USDC"),
       ethereumQueries.getTokenDecimals("USDC"),
       ethereumQueries.getTokenPrice("USDC"),
-      ethereumQueries.getTokenPrice("USDC", process.env.COINGECKO_PRO_API_KEY),
     ]);
+    const queriesWithCoingeckoProApi = new ArbitrumQueries(
+      provider,
+      SymbolMapping,
+      "0x4D9079Bb4165aeb4084c526a32695dCfd2F77381",
+      "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "0x893d0d70ad97717052e3aa8903d9615804167759",
+      process.env.COINGECKO_PRO_API_KEY
+    );
+    await queriesWithCoingeckoProApi.getTokenPrice("USDC");
   });
   test("Optimism", async function () {
     const provider = new providers.JsonRpcProvider(process.env.NODE_URL_10);
@@ -55,8 +79,16 @@ describe("Queries", function () {
       optimismQueries.getGasCosts("USDC"),
       optimismQueries.getTokenDecimals("USDC"),
       optimismQueries.getTokenPrice("USDC"),
-      optimismQueries.getTokenPrice("USDC", process.env.COINGECKO_PRO_API_KEY),
     ]);
+    const queriesWithCoingeckoProApi = new ArbitrumQueries(
+      provider,
+      SymbolMapping,
+      "0xa420b2d1c0841415A695b81E5B867BCD07Dff8C9",
+      "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+      "0x893d0d70ad97717052e3aa8903d9615804167759",
+      process.env.COINGECKO_PRO_API_KEY
+    );
+    await queriesWithCoingeckoProApi.getTokenPrice("USDC");
   });
   test("Polygon", async function () {
     const provider = new providers.JsonRpcProvider(process.env.NODE_URL_137);
@@ -65,7 +97,15 @@ describe("Queries", function () {
       polygonQueries.getGasCosts("USDC"),
       polygonQueries.getTokenDecimals("USDC"),
       polygonQueries.getTokenPrice("USDC"),
-      polygonQueries.getTokenPrice("USDC", process.env.COINGECKO_PRO_API_KEY),
     ]);
+    const queriesWithCoingeckoProApi = new ArbitrumQueries(
+      provider,
+      SymbolMapping,
+      "0x69B5c72837769eF1e7C164Abc6515DcFf217F920",
+      "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+      "0x893d0d70ad97717052e3aa8903d9615804167759",
+      process.env.COINGECKO_PRO_API_KEY
+    );
+    await queriesWithCoingeckoProApi.getTokenPrice("USDC");
   });
 });

--- a/src/relayFeeCalculator/chain-queries/queries.e2e.ts
+++ b/src/relayFeeCalculator/chain-queries/queries.e2e.ts
@@ -25,6 +25,7 @@ describe("Queries", function () {
       arbitrumQueries.getGasCosts("USDC"),
       arbitrumQueries.getTokenDecimals("USDC"),
       arbitrumQueries.getTokenPrice("USDC"),
+      arbitrumQueries.getTokenPrice("USDC", process.env.COINGECKO_PRO_API_KEY),
     ]);
   });
   test("Boba", async function () {
@@ -34,6 +35,7 @@ describe("Queries", function () {
       bobaQueries.getGasCosts("USDC"),
       bobaQueries.getTokenDecimals("USDC"),
       bobaQueries.getTokenPrice("USDC"),
+      bobaQueries.getTokenPrice("USDC", process.env.COINGECKO_PRO_API_KEY),
     ]);
   });
   test("Ethereum", async function () {
@@ -43,6 +45,7 @@ describe("Queries", function () {
       ethereumQueries.getGasCosts("USDC"),
       ethereumQueries.getTokenDecimals("USDC"),
       ethereumQueries.getTokenPrice("USDC"),
+      ethereumQueries.getTokenPrice("USDC", process.env.COINGECKO_PRO_API_KEY),
     ]);
   });
   test("Optimism", async function () {
@@ -52,6 +55,7 @@ describe("Queries", function () {
       optimismQueries.getGasCosts("USDC"),
       optimismQueries.getTokenDecimals("USDC"),
       optimismQueries.getTokenPrice("USDC"),
+      optimismQueries.getTokenPrice("USDC", process.env.COINGECKO_PRO_API_KEY),
     ]);
   });
   test("Polygon", async function () {
@@ -61,6 +65,7 @@ describe("Queries", function () {
       polygonQueries.getGasCosts("USDC"),
       polygonQueries.getTokenDecimals("USDC"),
       polygonQueries.getTokenPrice("USDC"),
+      polygonQueries.getTokenPrice("USDC", process.env.COINGECKO_PRO_API_KEY),
     ]);
   });
 });

--- a/src/relayFeeCalculator/relayFeeCalculator.test.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.test.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import dotenv from "dotenv";
 import { RelayFeeCalculator, QueryInterface } from "./relayFeeCalculator";
-import { gasCost, BigNumberish, toBNWei } from "../utils";
+import { gasCost, BigNumberish, toBNWei, toBN } from "../utils";
 
 dotenv.config({ path: ".env" });
 
@@ -43,6 +43,16 @@ describe("RelayFeeCalculator", () => {
     client = new RelayFeeCalculator({ queries });
     const result = await client.relayerFeeDetails(100000000, "usdc");
     assert.ok(result);
+
+    // overriding token price also succeeds
+    const resultWithPrice = await client.relayerFeeDetails(100000000, "usdc", 1.01);
+    assert.ok(resultWithPrice);
+
+    // gasFeePercent is lower if token price is higher.
+    assert.equal(
+      true,
+      toBN(resultWithPrice.gasFeePercent).lt((await client.relayerFeeDetails(100000000, "usdc", 1.0)).gasFeePercent)
+    );
   });
   it("capitalFeePercent", async () => {
     // Invalid capital cost configs throws on construction:

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -71,6 +71,10 @@ export class RelayFeeCalculator {
     assert(capitalCosts.decimals > 0 && capitalCosts.decimals <= 18, "invalid decimals");
   }
 
+  async getTokenPrice(tokenSymbol: string): Promise<number> {
+    return this.queries.getTokenPrice(tokenSymbol);
+  }
+
   async gasFeePercent(amountToRelay: BigNumberish, tokenSymbol: string, _tokenPrice?: number): Promise<BigNumber> {
     const getGasCosts = this.queries.getGasCosts(tokenSymbol).catch((error) => {
       console.error(`ERROR(gasFeePercent): Error while fetching gas costs ${error}`);

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -80,9 +80,9 @@ export class RelayFeeCalculator {
       console.error(`ERROR(gasFeePercent): Error while fetching token price ${error}`);
       throw error;
     });
-    const results = await Promise.all(_tokenPrice ? [getGasCosts, getTokenPrice] : [getGasCosts]);
+    const results = await Promise.all(_tokenPrice !== undefined ? [getGasCosts, getTokenPrice] : [getGasCosts]);
     const gasCosts = results[0];
-    const tokenPrice = _tokenPrice ? _tokenPrice : results[1];
+    const tokenPrice = (_tokenPrice !== undefined ? _tokenPrice : results[1]) as number;
     const decimals = this.queries.getTokenDecimals(tokenSymbol);
     const gasFeesInToken = nativeToToken(gasCosts, tokenPrice, decimals, this.nativeTokenDecimals);
     return percent(gasFeesInToken, amountToRelay);

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -71,8 +71,8 @@ export class RelayFeeCalculator {
     assert(capitalCosts.decimals > 0 && capitalCosts.decimals <= 18, "invalid decimals");
   }
 
-  async getTokenPrice(tokenSymbol: string, coingeckoProApiKey?: string): Promise<number> {
-    return this.queries.getTokenPrice(tokenSymbol, coingeckoProApiKey);
+  async getTokenPrice(tokenSymbol: string): Promise<number> {
+    return this.queries.getTokenPrice(tokenSymbol);
   }
 
   async gasFeePercent(amountToRelay: BigNumberish, tokenSymbol: string, _tokenPrice?: number): Promise<BigNumber> {

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -7,7 +7,7 @@ const { percent, fixedPointAdjustment } = uma.across.utils;
 // This needs to be implemented for every chain and passed into RelayFeeCalculator
 export interface QueryInterface {
   getGasCosts: (tokenSymbol: string) => Promise<BigNumberish>;
-  getTokenPrice: (tokenSymbol: string, coingeckoProApiKey?: string) => Promise<number>;
+  getTokenPrice: (tokenSymbol: string) => Promise<number>;
   getTokenDecimals: (tokenSymbol: string) => number;
 }
 

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -84,9 +84,7 @@ export class RelayFeeCalculator {
       console.error(`ERROR(gasFeePercent): Error while fetching token price ${error}`);
       throw error;
     });
-    const results = await Promise.all(_tokenPrice !== undefined ? [getGasCosts, getTokenPrice] : [getGasCosts]);
-    const gasCosts = results[0];
-    const tokenPrice = (_tokenPrice !== undefined ? _tokenPrice : results[1]) as number;
+    const [gasCosts, tokenPrice] = await Promise.all([getGasCosts, _tokenPrice !== undefined ? _tokenPrice : getTokenPrice]);
     const decimals = this.queries.getTokenDecimals(tokenSymbol);
     const gasFeesInToken = nativeToToken(gasCosts, tokenPrice, decimals, this.nativeTokenDecimals);
     return percent(gasFeesInToken, amountToRelay);

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -7,7 +7,7 @@ const { percent, fixedPointAdjustment } = uma.across.utils;
 // This needs to be implemented for every chain and passed into RelayFeeCalculator
 export interface QueryInterface {
   getGasCosts: (tokenSymbol: string) => Promise<BigNumberish>;
-  getTokenPrice: (tokenSymbol: string) => Promise<number>;
+  getTokenPrice: (tokenSymbol: string, coingeckoProApiKey?: string) => Promise<number>;
   getTokenDecimals: (tokenSymbol: string) => number;
 }
 
@@ -71,8 +71,8 @@ export class RelayFeeCalculator {
     assert(capitalCosts.decimals > 0 && capitalCosts.decimals <= 18, "invalid decimals");
   }
 
-  async getTokenPrice(tokenSymbol: string): Promise<number> {
-    return this.queries.getTokenPrice(tokenSymbol);
+  async getTokenPrice(tokenSymbol: string, coingeckoProApiKey?: string): Promise<number> {
+    return this.queries.getTokenPrice(tokenSymbol, coingeckoProApiKey);
   }
 
   async gasFeePercent(amountToRelay: BigNumberish, tokenSymbol: string, _tokenPrice?: number): Promise<BigNumber> {


### PR DESCRIPTION
This will allow Vercel API for example to precompute Coingecko price and pass into SDK so that SDK doesn't have to make API call