### PR TITLE
improve: Allow clients to pass in an optional custom logger

### DIFF
--- a/src/coingecko/Coingecko.ts
+++ b/src/coingecko/Coingecko.ts
@@ -117,7 +117,7 @@ export class Coingecko {
         const { host } = this;
         const url = `${host}/${path}`;
         const result = await axios(url, { params: { x_cg_pro_api_key: this.apiKey } });
-        this.logger.info({ at: "sdk-v2/coingecko", message: `Sent GET request to url ${result.request.responseURL}` });
+        this.logger.debug({ at: "sdk-v2/coingecko", message: `Sent GET request to url ${result.request.responseURL}` });
         return result.data;
       } catch (err) {
         const msg = get(err, "response.data.error", get(err, "response.statusText", "Unknown Coingecko Error"));

--- a/src/coingecko/Coingecko.ts
+++ b/src/coingecko/Coingecko.ts
@@ -117,7 +117,7 @@ export class Coingecko {
         const { host } = this;
         const url = `${host}/${path}`;
         const result = await axios(url, { params: { x_cg_pro_api_key: this.apiKey } });
-        this.logger.info("sdk-v2/coingecko", `Sent GET request to url ${result.request.responseURL}`, {});
+        this.logger.info({ at: "sdk-v2/coingecko", message: `Sent GET request to url ${result.request.responseURL}` });
         return result.data;
       } catch (err) {
         const msg = get(err, "response.data.error", get(err, "response.statusText", "Unknown Coingecko Error"));

--- a/src/relayFeeCalculator/chain-queries/arbitrum.ts
+++ b/src/relayFeeCalculator/chain-queries/arbitrum.ts
@@ -1,4 +1,4 @@
-import { QueryInterface } from "../relayFeeCalculator";
+import { DEFAULT_LOGGER, Logger, QueryInterface } from "../relayFeeCalculator";
 import {
   BigNumberish,
   createUnsignedFillRelayTransaction,
@@ -18,19 +18,20 @@ export class ArbitrumQueries implements QueryInterface {
     spokePoolAddress = "0xB88690461dDbaB6f04Dfad7df66B7725942FEb9C",
     private readonly usdcAddress = "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
     private readonly simulatedRelayerAddress = "0x893d0d70ad97717052e3aa8903d9615804167759",
-    private readonly coingeckoProApiKey?: string
+    private readonly coingeckoProApiKey?: string,
+    private readonly logger: Logger = DEFAULT_LOGGER
   ) {
     this.spokePool = SpokePool__factory.connect(spokePoolAddress, provider);
   }
 
-  async getGasCosts(_tokenSymbol: string): Promise<BigNumberish> {
+  async getGasCosts(): Promise<BigNumberish> {
     const tx = await createUnsignedFillRelayTransaction(this.spokePool, this.usdcAddress, this.simulatedRelayerAddress);
     return estimateTotalGasRequiredByUnsignedTransaction(tx, this.simulatedRelayerAddress, this.provider);
   }
 
   async getTokenPrice(tokenSymbol: string): Promise<number> {
     if (!this.symbolMapping[tokenSymbol]) throw new Error(`${tokenSymbol} does not exist in mapping`);
-    const coingeckoInstance = Coingecko.get(this.coingeckoProApiKey);
+    const coingeckoInstance = Coingecko.get(this.logger, this.coingeckoProApiKey);
     const [, price] = await coingeckoInstance.getCurrentPriceByContract(this.symbolMapping[tokenSymbol].address, "eth");
     return price;
   }

--- a/src/relayFeeCalculator/chain-queries/boba.ts
+++ b/src/relayFeeCalculator/chain-queries/boba.ts
@@ -1,4 +1,4 @@
-import { QueryInterface } from "../relayFeeCalculator";
+import { DEFAULT_LOGGER, Logger, QueryInterface } from "../relayFeeCalculator";
 import {
   BigNumberish,
   createUnsignedFillRelayTransaction,
@@ -20,13 +20,14 @@ export class BobaQueries implements QueryInterface {
     spokePoolAddress = "0xBbc6009fEfFc27ce705322832Cb2068F8C1e0A58",
     private readonly usdcAddress = "0x66a2A913e447d6b4BF33EFbec43aAeF87890FBbc",
     private readonly simulatedRelayerAddress = "0x893d0d70ad97717052e3aa8903d9615804167759",
-    private readonly coingeckoProApiKey?: string
+    private readonly coingeckoProApiKey?: string,
+    private readonly logger: Logger = DEFAULT_LOGGER
   ) {
     // TODO: replace with address getter.
     this.spokePool = SpokePool__factory.connect(spokePoolAddress, provider);
   }
 
-  async getGasCosts(_tokenSymbol: string): Promise<BigNumberish> {
+  async getGasCosts(): Promise<BigNumberish> {
     const tx = await createUnsignedFillRelayTransaction(this.spokePool, this.usdcAddress, this.simulatedRelayerAddress);
     return estimateTotalGasRequiredByUnsignedTransaction(
       tx,
@@ -38,7 +39,7 @@ export class BobaQueries implements QueryInterface {
 
   async getTokenPrice(tokenSymbol: string): Promise<number> {
     if (!this.symbolMapping[tokenSymbol]) throw new Error(`${tokenSymbol} does not exist in mapping`);
-    const coingeckoInstance = Coingecko.get(this.coingeckoProApiKey);
+    const coingeckoInstance = Coingecko.get(this.logger, this.coingeckoProApiKey);
     const [, price] = await coingeckoInstance.getCurrentPriceByContract(this.symbolMapping[tokenSymbol].address, "eth");
     return price;
   }

--- a/src/relayFeeCalculator/chain-queries/ethereum.ts
+++ b/src/relayFeeCalculator/chain-queries/ethereum.ts
@@ -1,4 +1,4 @@
-import { QueryInterface } from "../relayFeeCalculator";
+import { DEFAULT_LOGGER, Logger, QueryInterface } from "../relayFeeCalculator";
 import {
   BigNumberish,
   createUnsignedFillRelayTransaction,
@@ -81,18 +81,19 @@ export class EthereumQueries implements QueryInterface {
     readonly spokePoolAddress = "0x4D9079Bb4165aeb4084c526a32695dCfd2F77381",
     readonly usdcAddress = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
     readonly simulatedRelayerAddress = "0x893d0D70AD97717052E3AA8903D9615804167759",
-    private readonly coingeckoProApiKey?: string
+    private readonly coingeckoProApiKey?: string,
+    private readonly logger: Logger = DEFAULT_LOGGER
   ) {
     this.spokePool = SpokePool__factory.connect(this.spokePoolAddress, this.provider);
   }
-  async getGasCosts(_tokenSymbol: string): Promise<BigNumberish> {
+  async getGasCosts(): Promise<BigNumberish> {
     const tx = await createUnsignedFillRelayTransaction(this.spokePool, this.usdcAddress, this.simulatedRelayerAddress);
     return estimateTotalGasRequiredByUnsignedTransaction(tx, this.simulatedRelayerAddress, this.provider);
   }
 
   async getTokenPrice(tokenSymbol: string): Promise<number> {
     if (!this.symbolMapping[tokenSymbol]) throw new Error(`${tokenSymbol} does not exist in mapping`);
-    const coingeckoInstance = Coingecko.get(this.coingeckoProApiKey);
+    const coingeckoInstance = Coingecko.get(this.logger, this.coingeckoProApiKey);
     const [, price] = await coingeckoInstance.getCurrentPriceByContract(this.symbolMapping[tokenSymbol].address, "eth");
     return price;
   }

--- a/src/relayFeeCalculator/chain-queries/polygon.ts
+++ b/src/relayFeeCalculator/chain-queries/polygon.ts
@@ -1,4 +1,4 @@
-import { QueryInterface } from "../relayFeeCalculator";
+import { DEFAULT_LOGGER, Logger, QueryInterface } from "../relayFeeCalculator";
 import {
   BigNumberish,
   createUnsignedFillRelayTransaction,
@@ -18,19 +18,20 @@ export class PolygonQueries implements QueryInterface {
     readonly spokePoolAddress = "0x69B5c72837769eF1e7C164Abc6515DcFf217F920",
     readonly usdcAddress = "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
     readonly simulatedRelayerAddress = "0x893d0D70AD97717052E3AA8903D9615804167759",
-    private readonly coingeckoProApiKey?: string
+    private readonly coingeckoProApiKey?: string,
+    private readonly logger: Logger = DEFAULT_LOGGER
   ) {
     this.spokePool = SpokePool__factory.connect(spokePoolAddress, provider);
   }
 
-  async getGasCosts(_tokenSymbol: string): Promise<BigNumberish> {
+  async getGasCosts(): Promise<BigNumberish> {
     const tx = await createUnsignedFillRelayTransaction(this.spokePool, this.usdcAddress, this.simulatedRelayerAddress);
     return estimateTotalGasRequiredByUnsignedTransaction(tx, this.simulatedRelayerAddress, this.provider);
   }
 
   async getTokenPrice(tokenSymbol: string): Promise<number> {
     if (!this.symbolMapping[tokenSymbol]) throw new Error(`${tokenSymbol} does not exist in mapping`);
-    const coingeckoInstance = Coingecko.get(this.coingeckoProApiKey);
+    const coingeckoInstance = Coingecko.get(this.logger, this.coingeckoProApiKey);
     const [, tokenPrice] = await coingeckoInstance.getCurrentPriceByContract(
       this.symbolMapping[tokenSymbol].address,
       "usd"

--- a/src/relayFeeCalculator/chain-queries/queries.e2e.ts
+++ b/src/relayFeeCalculator/chain-queries/queries.e2e.ts
@@ -22,7 +22,7 @@ describe("Queries", function () {
     const provider = new providers.JsonRpcProvider(process.env.NODE_URL_42161);
     const arbitrumQueries = new ArbitrumQueries(provider);
     await Promise.all([
-      arbitrumQueries.getGasCosts("USDC"),
+      arbitrumQueries.getGasCosts(),
       arbitrumQueries.getTokenDecimals("USDC"),
       arbitrumQueries.getTokenPrice("USDC"),
     ]);
@@ -40,7 +40,7 @@ describe("Queries", function () {
     const provider = new providers.JsonRpcProvider(process.env.NODE_URL_288);
     const bobaQueries = new BobaQueries(provider);
     await Promise.all([
-      bobaQueries.getGasCosts("USDC"),
+      bobaQueries.getGasCosts(),
       bobaQueries.getTokenDecimals("USDC"),
       bobaQueries.getTokenPrice("USDC"),
     ]);
@@ -58,7 +58,7 @@ describe("Queries", function () {
     const provider = new providers.JsonRpcProvider(process.env.NODE_URL_1);
     const ethereumQueries = new EthereumQueries(provider);
     await Promise.all([
-      ethereumQueries.getGasCosts("USDC"),
+      ethereumQueries.getGasCosts(),
       ethereumQueries.getTokenDecimals("USDC"),
       ethereumQueries.getTokenPrice("USDC"),
     ]);
@@ -76,7 +76,7 @@ describe("Queries", function () {
     const provider = new providers.JsonRpcProvider(process.env.NODE_URL_10);
     const optimismQueries = new OptimismQueries(provider);
     await Promise.all([
-      optimismQueries.getGasCosts("USDC"),
+      optimismQueries.getGasCosts(),
       optimismQueries.getTokenDecimals("USDC"),
       optimismQueries.getTokenPrice("USDC"),
     ]);
@@ -94,7 +94,7 @@ describe("Queries", function () {
     const provider = new providers.JsonRpcProvider(process.env.NODE_URL_137);
     const polygonQueries = new PolygonQueries(provider);
     await Promise.all([
-      polygonQueries.getGasCosts("USDC"),
+      polygonQueries.getGasCosts(),
       polygonQueries.getTokenDecimals("USDC"),
       polygonQueries.getTokenPrice("USDC"),
     ]);

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -33,12 +33,14 @@ export interface LoggingFunction {
 }
 
 export interface Logger {
+  debug: LoggingFunction;
   info: LoggingFunction;
   warn: LoggingFunction;
   error: LoggingFunction;
 }
 
 export const DEFAULT_LOGGER: Logger = {
+  debug: (...args) => console.debug(args),
   info: (...args) => console.info(args),
   warn: (...args) => console.warn(args),
   error: (...args) => console.error(args),
@@ -156,7 +158,7 @@ export class RelayFeeCalculator {
   async relayerFeeDetails(amountToRelay: BigNumberish, tokenSymbol: string, tokenPrice?: number) {
     let isAmountTooLow = false;
     const gasFeePercent = await this.gasFeePercent(amountToRelay, tokenSymbol, tokenPrice);
-    this.logger.info({
+    this.logger.debug({
       at: "sdk-v2/relayerFeeDetails",
       message: "Computed gasFeePercent",
       gasFeePercent,
@@ -164,7 +166,7 @@ export class RelayFeeCalculator {
     });
     const gasFeeTotal = gasFeePercent.mul(amountToRelay).div(fixedPointAdjustment);
     const capitalFeePercent = await this.capitalFeePercent(amountToRelay, tokenSymbol);
-    this.logger.info({ at: "sdk-v2/relayerFeeDetails", message: "Computed capitalFeePercent", capitalFeePercent });
+    this.logger.debug({ at: "sdk-v2/relayerFeeDetails", message: "Computed capitalFeePercent", capitalFeePercent });
     const capitalFeeTotal = capitalFeePercent.mul(amountToRelay).div(fixedPointAdjustment);
     const relayFeePercent = gasFeePercent.add(capitalFeePercent);
     const relayFeeTotal = gasFeeTotal.add(capitalFeeTotal);

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -6,7 +6,7 @@ const { percent, fixedPointAdjustment } = uma.across.utils;
 
 // This needs to be implemented for every chain and passed into RelayFeeCalculator
 export interface QueryInterface {
-  getGasCosts: (tokenSymbol: string) => Promise<BigNumberish>;
+  getGasCosts: () => Promise<BigNumberish>;
   getTokenPrice: (tokenSymbol: string) => Promise<number>;
   getTokenDecimals: (tokenSymbol: string) => number;
 }
@@ -28,6 +28,22 @@ export interface RelayFeeCalculatorConfig {
   queries: QueryInterface;
 }
 
+export interface LoggingFunction {
+  (at: string, message: string, extraData: { [key: string]: any }): void;
+}
+
+export interface Logger {
+  info: LoggingFunction;
+  warn: LoggingFunction;
+  error: LoggingFunction;
+}
+
+export const DEFAULT_LOGGER: Logger = {
+  info: (...args) => console.info(args),
+  warn: (...args) => console.warn(args),
+  error: (...args) => console.error(args),
+};
+
 export class RelayFeeCalculator {
   private queries: Required<RelayFeeCalculatorConfig>["queries"];
   private gasDiscountPercent: Required<RelayFeeCalculatorConfig>["gasDiscountPercent"];
@@ -36,7 +52,12 @@ export class RelayFeeCalculator {
   private nativeTokenDecimals: Required<RelayFeeCalculatorConfig>["nativeTokenDecimals"];
   private capitalCostsPercent: Required<RelayFeeCalculatorConfig>["capitalCostsPercent"];
   private capitalCostsConfig: Required<RelayFeeCalculatorConfig>["capitalCostsConfig"];
-  constructor(config: RelayFeeCalculatorConfig) {
+
+  // For logging if set. This function should accept 2 args - severity (INFO, WARN, ERROR) and the logs data, which will
+  // be an object.
+  private logger: Logger;
+
+  constructor(config: RelayFeeCalculatorConfig, logger: Logger = DEFAULT_LOGGER) {
     this.queries = config.queries;
     this.gasDiscountPercent = config.gasDiscountPercent || 0;
     this.capitalDiscountPercent = config.capitalDiscountPercent || 0;
@@ -63,6 +84,8 @@ export class RelayFeeCalculator {
     for (const token of Object.keys(this.capitalCostsConfig)) {
       RelayFeeCalculator.validateCapitalCostsConfig(this.capitalCostsConfig[token]);
     }
+
+    this.logger = logger;
   }
 
   static validateCapitalCostsConfig(capitalCosts: CapitalCostConfig) {
@@ -76,15 +99,18 @@ export class RelayFeeCalculator {
   }
 
   async gasFeePercent(amountToRelay: BigNumberish, tokenSymbol: string, _tokenPrice?: number): Promise<BigNumber> {
-    const getGasCosts = this.queries.getGasCosts(tokenSymbol).catch((error) => {
-      console.error(`ERROR(gasFeePercent): Error while fetching gas costs ${error}`);
+    const getGasCosts = this.queries.getGasCosts().catch((error) => {
+      this.logger.error("sdk-v2/gasFeePercent", "Error while fetching gas costs", { error });
       throw error;
     });
     const getTokenPrice = this.queries.getTokenPrice(tokenSymbol).catch((error) => {
-      console.error(`ERROR(gasFeePercent): Error while fetching token price ${error}`);
+      this.logger.error("sdk-v2/gasFeePercent", "Error while fetching token price", { error });
       throw error;
     });
-    const [gasCosts, tokenPrice] = await Promise.all([getGasCosts, _tokenPrice !== undefined ? _tokenPrice : getTokenPrice]);
+    const [gasCosts, tokenPrice] = await Promise.all([
+      getGasCosts,
+      _tokenPrice !== undefined ? _tokenPrice : getTokenPrice,
+    ]);
     const decimals = this.queries.getTokenDecimals(tokenSymbol);
     const gasFeesInToken = nativeToToken(gasCosts, tokenPrice, decimals, this.nativeTokenDecimals);
     return percent(gasFeesInToken, amountToRelay);
@@ -130,14 +156,15 @@ export class RelayFeeCalculator {
   async relayerFeeDetails(amountToRelay: BigNumberish, tokenSymbol: string, tokenPrice?: number) {
     let isAmountTooLow = false;
     const gasFeePercent = await this.gasFeePercent(amountToRelay, tokenSymbol, tokenPrice);
-    console.log(
-      `INFO(relayerFeeDetails): Computed gasFeePercent ${gasFeePercent}, overrode optional tokenPrice param: ${
-        tokenPrice !== undefined
-      }`
-    );
+    this.logger.info("sdk-v2/relayerFeeDetails", "Computed gasFeePercent", {
+      gasFeePercent,
+      overriddenTokenPrice: tokenPrice,
+    });
     const gasFeeTotal = gasFeePercent.mul(amountToRelay).div(fixedPointAdjustment);
     const capitalFeePercent = await this.capitalFeePercent(amountToRelay, tokenSymbol);
-    console.log(`INFO(relayerFeeDetails): Computed capitalFeePercent ${capitalFeePercent}`);
+    this.logger.info("sdk-v2/relayerFeeDetails", "Computed capitalFeePercent", {
+      capitalFeePercent,
+    });
     const capitalFeeTotal = capitalFeePercent.mul(amountToRelay).div(fixedPointAdjustment);
     const relayFeePercent = gasFeePercent.add(capitalFeePercent);
     const relayFeeTotal = gasFeeTotal.add(capitalFeeTotal);

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -29,7 +29,7 @@ export interface RelayFeeCalculatorConfig {
 }
 
 export interface LoggingFunction {
-  (at: string, message: string, extraData: { [key: string]: any }): void;
+  (data: { at: string; message: string; [key: string]: any }): void;
 }
 
 export interface Logger {
@@ -100,11 +100,11 @@ export class RelayFeeCalculator {
 
   async gasFeePercent(amountToRelay: BigNumberish, tokenSymbol: string, _tokenPrice?: number): Promise<BigNumber> {
     const getGasCosts = this.queries.getGasCosts().catch((error) => {
-      this.logger.error("sdk-v2/gasFeePercent", "Error while fetching gas costs", { error });
+      this.logger.error({ at: "sdk-v2/gasFeePercent", message: "Error while fetching gas costs", error });
       throw error;
     });
     const getTokenPrice = this.queries.getTokenPrice(tokenSymbol).catch((error) => {
-      this.logger.error("sdk-v2/gasFeePercent", "Error while fetching token price", { error });
+      this.logger.error({ at: "sdk-v2/gasFeePercent", message: "Error while fetching token price", error });
       throw error;
     });
     const [gasCosts, tokenPrice] = await Promise.all([
@@ -156,15 +156,15 @@ export class RelayFeeCalculator {
   async relayerFeeDetails(amountToRelay: BigNumberish, tokenSymbol: string, tokenPrice?: number) {
     let isAmountTooLow = false;
     const gasFeePercent = await this.gasFeePercent(amountToRelay, tokenSymbol, tokenPrice);
-    this.logger.info("sdk-v2/relayerFeeDetails", "Computed gasFeePercent", {
+    this.logger.info({
+      at: "sdk-v2/relayerFeeDetails",
+      message: "Computed gasFeePercent",
       gasFeePercent,
       overriddenTokenPrice: tokenPrice,
     });
     const gasFeeTotal = gasFeePercent.mul(amountToRelay).div(fixedPointAdjustment);
     const capitalFeePercent = await this.capitalFeePercent(amountToRelay, tokenSymbol);
-    this.logger.info("sdk-v2/relayerFeeDetails", "Computed capitalFeePercent", {
-      capitalFeePercent,
-    });
+    this.logger.info({ at: "sdk-v2/relayerFeeDetails", message: "Computed capitalFeePercent", capitalFeePercent });
     const capitalFeeTotal = capitalFeePercent.mul(amountToRelay).div(fixedPointAdjustment);
     const relayFeePercent = gasFeePercent.add(capitalFeePercent);
     const relayFeeTotal = gasFeeTotal.add(capitalFeeTotal);


### PR DESCRIPTION
Clients can pass in any loggers they want as long as they conform to the interface. This can work well with loggers such as winston and GCP logger. 