### PR TITLE
fix: Correct CoinGecko log message

### DIFF
--- a/src/coingecko/Coingecko.ts
+++ b/src/coingecko/Coingecko.ts
@@ -116,8 +116,9 @@ export class Coingecko {
       try {
         const { host } = this;
         const url = `${host}/${path}`;
+        // Log message deliberately suppresses ?x_cg_pro_api_key=<key> for Pro endpoints.
+        this.logger.debug({ at: "sdk-v2/coingecko", message: `Sending GET request to url ${url}` });
         const result = await axios(url, { params: { x_cg_pro_api_key: this.apiKey } });
-        this.logger.debug({ at: "sdk-v2/coingecko", message: `Sent GET request to url ${result.request.responseURL}` });
         return result.data;
       } catch (err) {
         const msg = get(err, "response.data.error", get(err, "response.statusText", "Unknown Coingecko Error"));


### PR DESCRIPTION
Spotted during test. The original log message doesn't work because the
member result.request.responseURL doesn't seem to exist at that path
(there is a responseURL member at another path). However, that member
shows the fully-formed path - including the API key for pro endpoints -
which would allow for the key to leak via logging.

Therefore, suppress the extra arguments and only print the URL that was
was requested via the url input parameter to axios. It might be nice to
show something like "?x_cg_pro_api_key=\<apiKey\>".

Also, relocate the log message, since it never gets printed in the event
that the GET request fails.

Ref: ACX-125