### PR TITLE
improve(Coingecko): Use PRO API as fallback, not first choice

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,5 +83,8 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.com/",
     "access": "public"
+  },
+  "jest": {
+    "testEnvironment": "node"
   }
 }

--- a/src/coingecko/Coingecko.e2e.ts
+++ b/src/coingecko/Coingecko.e2e.ts
@@ -70,9 +70,9 @@ describe("coingecko", function () {
   test("Fallback to Pro", async function () {
     // Default test timeout of 5000ms is too short usually for this test. Manually expand it.
     jest.setTimeout(30000);
-    // Send tons of basic requests so that we hit pro. Basic has a 50/min rate limit.
-    for (let i = 0; i < 51; i++) {
-      console.log(i);
+    // Send tons of basic requests so that we hit pro. Basic has a ~50/min rate limit but this varies. In practice
+    // its a bit lower more like ~20-30/min.
+    for (let i = 0; i < 20; i++) {
       assert.ok(await cg.getCurrentPriceByContract("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", "eth"));
     }
   });

--- a/src/coingecko/Coingecko.ts
+++ b/src/coingecko/Coingecko.ts
@@ -122,7 +122,7 @@ export class Coingecko {
       const basicUrl = `${host}/${path}`;
 
       try {
-        const result = await axios(basicUrl, { timeout: 1000 });
+        const result = await axios(basicUrl, { timeout: 500 });
         return result.data;
       } catch (err) {
         this.logger.debug({

--- a/src/coingecko/Coingecko.ts
+++ b/src/coingecko/Coingecko.ts
@@ -27,8 +27,8 @@ export class Coingecko {
 
   // Retry configuration.
   private retryDelay = 1;
-  private numRetries = 3;
-  private basicApiTimeout = 130; // ms
+  private numRetries = 0; // Most failures are due to 429 rate-limiting, so there is no point in retrying.
+  private basicApiTimeout = 250; // ms
 
   public static get(logger: Logger, apiKey?: string) {
     if (!this.instance)
@@ -136,7 +136,9 @@ export class Coingecko {
         return await this._callPro(path);
       }
     };
-    return retry(sendRequest, this.numRetries, this.retryDelay);
+
+    // Note: If a pro API key is configured, there is no need to retry as the Pro API will act as the basic's fall back.
+    return retry(sendRequest, this.apiKey === undefined ? this.numRetries : 0, this.retryDelay);
   }
 
   private async _callBasic(path: string, timeout?: number) {
@@ -147,7 +149,7 @@ export class Coingecko {
       const result = await axios(url, { timeout });
       return result.data;
     } catch (err) {
-      const msg = get(err, "response.data.error", get(err, "response.statusText", "Unknown Coingecko Error"));
+      const msg = get(err, "response.data.error", get(err, "response.statusText", (err as AxiosError).message));
       throw new Error(msg);
     }
   }
@@ -160,7 +162,7 @@ export class Coingecko {
       const result = await axios(url, { params: { x_cg_pro_api_key: this.apiKey } });
       return result.data;
     } catch (err) {
-      const msg = get(err, "response.data.error", get(err, "response.statusText", "Unknown Coingecko-Pro Error"));
+      const msg = get(err, "response.data.error", get(err, "response.statusText", (err as AxiosError).message));
       throw new Error(msg);
     }
   }

--- a/src/coingecko/Coingecko.ts
+++ b/src/coingecko/Coingecko.ts
@@ -122,7 +122,7 @@ export class Coingecko {
       const basicUrl = `${host}/${path}`;
 
       try {
-        const result = await axios(basicUrl, { timeout: 500 });
+        const result = await axios(basicUrl);
         return result.data;
       } catch (err) {
         this.logger.debug({

--- a/src/coingecko/Coingecko.ts
+++ b/src/coingecko/Coingecko.ts
@@ -122,7 +122,7 @@ export class Coingecko {
       const basicUrl = `${host}/${path}`;
 
       try {
-        const result = await axios(basicUrl);
+        const result = await axios(basicUrl, { timeout: 1000 });
         return result.data;
       } catch (err) {
         this.logger.debug({

--- a/src/coingecko/Coingecko.ts
+++ b/src/coingecko/Coingecko.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 import assert from "assert";
 import get from "lodash.get";
 import { retry } from "../utils";
@@ -28,6 +28,7 @@ export class Coingecko {
   // Retry configuration.
   private retryDelay = 1;
   private numRetries = 3;
+  private basicApiTimeout = 130; // ms
 
   public static get(logger: Logger, apiKey?: string) {
     if (!this.instance)
@@ -122,12 +123,13 @@ export class Coingecko {
       const basicUrl = `${host}/${path}`;
 
       try {
-        const result = await axios(basicUrl, { timeout: 200 });
+        const result = await axios(basicUrl, { timeout: this.basicApiTimeout });
         return result.data;
       } catch (err) {
         this.logger.debug({
           at: "sdk-v2/coingecko",
           message: `Basic CG url request failed, falling back to CG PRO host ${proHost}`,
+          errMessage: (err as AxiosError).message,
         });
         const proUrl = `${proHost}/${path}`;
         try {

--- a/src/coingecko/Coingecko.ts
+++ b/src/coingecko/Coingecko.ts
@@ -122,7 +122,7 @@ export class Coingecko {
       const basicUrl = `${host}/${path}`;
 
       try {
-        const result = await axios(basicUrl);
+        const result = await axios(basicUrl, { timeout: 200 });
         return result.data;
       } catch (err) {
         this.logger.debug({

--- a/src/coingecko/Coingecko.ts
+++ b/src/coingecko/Coingecko.ts
@@ -147,7 +147,7 @@ export class Coingecko {
           const result = await axios(proUrl, { params: { x_cg_pro_api_key: this.apiKey } });
           return result.data;
         } catch (errPro) {
-          const msg = get(err, "response.data.error", get(err, "response.statusText", "Unknown Coingecko Error"));
+          const msg = get(errPro, "response.data.error", get(errPro, "response.statusText", "Unknown Coingecko Error"));
           throw new Error(msg);
         }
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -242,7 +242,10 @@ export async function estimateTotalGasRequiredByUnsignedTransaction(
   gasMarkup: number,
   gasPrice?: BigNumberish
 ): Promise<BigNumberish> {
-  assert(gasMarkup > -1 && gasMarkup <= 4, "Gas Markup must be within the range of (-1.0, +4.0] so that total gas multiplier is between (0, +5.0]");
+  assert(
+    gasMarkup > -1 && gasMarkup <= 4,
+    "Gas Markup must be within the range of (-1.0, +4.0] so that total gas multiplier is between (0, +5.0]"
+  );
   const gasTotalMultiplier = 1.0 + gasMarkup;
   const voidSigner = new VoidSigner(senderAddress, provider);
   // Verify if this provider has been L2Provider wrapped


### PR DESCRIPTION
We want to reduce coingecko Pro API requests to under 500,000/month, currently we're on track for 1.2million a month.

Some stats:
- A direct request to CG basic API takes 200ms if successful or 100ms if you get rate limited and receive a 429
- Same with CG pro API: Takes 200ms if successful
- CG API needs to warm up, first call always takes slightly longer (say 250-300ms instead of 150-200)

Coingecko API requests can only be sent on cache misses, which should be rare (5% of requests) [following this PR](https://github.com/across-protocol/frontend-v2/commit/995853ea370c29b495a799848ca444412d9e53a4). For cache misses, the response time is already going to be slow because of how the Lambda function works, so saving 100ms on these requests isn't a material improvement.

Therefore, the extra 100ms saved by always hitting the Pro API vs trying the basic API first and then on a fallback, hitting the Pro API, is not worth it IMO versus reducing # of CG pro requests. Moreover, most of the basic API requests succeed, although the rate limit of ~20-30/minute does result in say 10% (empirical observation) of requests to fail, so the fallback will make sure no CG requests fail (<1%).

This PR will result in a 50% latency (+100ms) increase for any basic API requests that fail and fallback to pro, but I think that’s ok as these instances should be rare because. The average response time for a cache miss will still be >1000ms (give or take for the lambda spin up time), with some edge cases taking an extra 300ms to fallback to the pro API, and the average case taking an extra 200ms to hit the basic API.

But, the main benefit of this PR will be that CG pro requests will reduce to well under 500,000/month.