### PR TITLE
chore: Bump version to 0.1.21 as 0.1.20 was accidentally created without changing package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
Version in package.json always needs to be changed first before creating any new release/tag