### PR TITLE
feat: handling of `RequestedSpeedUpDepositEvent` events

### DIFF
--- a/src/transfers-history/adapters/web3/SpokePoolEventsQuerier.ts
+++ b/src/transfers-history/adapters/web3/SpokePoolEventsQuerier.ts
@@ -12,6 +12,7 @@ const DEFAULT_BLOCK_RANGE = 100_000;
 export interface ISpokePoolContractEventsQuerier {
   getFundsDepositEvents: (from: number, to: number, depositorAddr?: string) => Promise<TypedEvent<any>[]>;
   getFilledRelayEvents: (from: number, to: number, depositorAddr?: string) => Promise<TypedEvent<any>[]>;
+  getSpeedUpDepositEvents: (from: number, to: number, depositorAddr?: string) => Promise<TypedEvent<any>[]>;
 }
 
 /**
@@ -28,6 +29,10 @@ export class SpokePoolEventsQuerier implements ISpokePoolContractEventsQuerier {
 
   public async getFilledRelayEvents(from: number, to: number, depositorAddr?: string): Promise<TypedEvent<any>[]> {
     return this.getEvents(from, to, this.getFilledRelayEventsFilter(depositorAddr));
+  }
+
+  public async getSpeedUpDepositEvents(from: number, to: number, depositorAddr?: string): Promise<TypedEvent<any>[]> {
+    return this.getEvents(from, to, this.getSpeedUpDepositEventsFilter(depositorAddr));
   }
 
   private getFilledRelayEventsFilter(depositorAddr?: string) {
@@ -68,6 +73,18 @@ export class SpokePoolEventsQuerier implements ISpokePoolContractEventsQuerier {
       );
     }
     return this.spokePool.filters.FundsDeposited();
+  }
+
+  private getSpeedUpDepositEventsFilter(depositorAddr?: string) {
+    if (depositorAddr) {
+      return this.spokePool.filters.RequestedSpeedUpDeposit(
+        undefined,
+        undefined,
+        depositorAddr.toLowerCase(),
+        undefined
+      );
+    }
+    return this.spokePool.filters.RequestedSpeedUpDeposit();
   }
 
   private async getEvents(

--- a/src/transfers-history/client.e2e.ts
+++ b/src/transfers-history/client.e2e.ts
@@ -56,10 +56,13 @@ describe("Client e2e tests", () => {
       console.log(data);
       const pendingTransfers = client.getPendingTransfers("0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D");
       const filledTransfers = client.getFilledTransfers("0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D");
+      const transfersWithSpeedUps = filledTransfers.filter(({ speedUps }) => speedUps.length) || [];
       client.stopFetchingTransfers("0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D");
       expect(pendingTransfers.length).toBeGreaterThanOrEqual(0);
       expect(filledTransfers.length).toBeGreaterThanOrEqual(0);
       expect(filledTransfers[0].fillTxs.length).toBeGreaterThanOrEqual(1);
+      expect(transfersWithSpeedUps.length).toBeGreaterThan(0);
+
       done();
     });
   });

--- a/src/transfers-history/model/transfer.ts
+++ b/src/transfers-history/model/transfer.ts
@@ -14,4 +14,7 @@ export type Transfer = {
   amount: BigNumber;
   depositTxHash: string;
   fillTxs: string[];
+  initialRelayerFeePct: BigNumber;
+  currentRelayerFeePct: BigNumber;
+  speedUps: { txHash: string; relayerFeePct: BigNumber; timestamp: number }[];
 };


### PR DESCRIPTION
This PR extends the `Transfer` entity by adding speed-up / relay fee-related fields to the model and the respective handlers. The goal of this addition is to display fees in the transactions table of the UI and allow handling of speed-ups in the UI.