### PR TITLE
feat(Coingecko): Cache prices & bundle requests

### DIFF
--- a/src/coingecko/Coingecko.e2e.ts
+++ b/src/coingecko/Coingecko.e2e.ts
@@ -1,17 +1,41 @@
 import assert from "assert";
-import Coingecko from "./Coingecko";
 import dotenv from "dotenv";
 import winston from "winston";
+import * as coingecko from "./Coingecko";
 dotenv.config({ path: ".env" });
+
+const Coingecko = coingecko.Coingecko;
+const msToS = coingecko.msToS;
+type CoinGeckoPrice = coingecko.CoinGeckoPrice;
 
 const dummyLogger = winston.createLogger({
   level: "debug",
   transports: [new winston.transports.Console()],
 });
 
+class TestGecko extends Coingecko {
+
+  private static testInstance: TestGecko | undefined;
+
+  public static get(logger: winston.Logger) {
+    if (!this.testInstance)
+      this.testInstance = new TestGecko(logger);
+    return this.testInstance;
+  }
+
+  // Hack to return protected getPriceCache.
+  _getPriceCache(currency: string, platform_id: string): { [addr: string]: CoinGeckoPrice } {
+    return this.getPriceCache(currency, platform_id);
+  }
+
+  constructor(logger: winston.Logger) {
+    super("127.0.0.1", "127.0.0.1", logger);
+  };
+}
+
 // this requires e2e testing, should only test manually for now
 describe("coingecko", function () {
-  let cg: Coingecko;
+  let cg: coingecko.Coingecko;
   test("init", function () {
     cg = Coingecko.get(dummyLogger, process.env.COINGECKO_PRO_API_KEY);
     assert.ok(cg);
@@ -72,8 +96,47 @@ describe("coingecko", function () {
     jest.setTimeout(30000);
     // Send tons of basic requests so that we hit pro. Basic has a ~50/min rate limit but this varies. In practice
     // its a bit lower more like ~20-30/min.
+
+    cg.maxPriceAge = 0; // Disable cache to force price lookups
     for (let i = 0; i < 20; i++) {
       assert.ok(await cg.getCurrentPriceByContract("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", "eth"));
+    }
+  });
+  test("Validate price cache", async function () {
+    // Don't lookup against CoinGecko.
+    let tg: TestGecko = TestGecko.get(dummyLogger);
+    assert.ok(tg);
+
+    const baseCurrency = "eth";
+    const network = "ethereum";
+
+    const priceCache: { [addr: string]: CoinGeckoPrice } = tg._getPriceCache(baseCurrency, network);
+    tg.maxPriceAge = 600; // Bound timestamps by 10 minutes
+    for (let i = 0; i < 10; ++i) {
+      const addr = `0x${i.toString(16).padStart(42, "0")}`; // Non-existent, ensure CG lookup would fail.
+      priceCache[addr] = {
+        address: addr,
+        price: Math.random() * (1 + i),
+        timestamp: msToS(Date.now()) - tg.maxPriceAge + (1 + i),
+      };
+    }
+
+    // Verify cache hit for valid timestamps.
+    for (const expected of Object.values(priceCache)) {
+      const addr: string = expected.address;
+      const result: [timestamp: string, price: number] = await tg.getCurrentPriceByContract(addr, baseCurrency);
+      const timestamp: string = result[0];
+      const price: number = result[1];
+
+      assert.ok(timestamp === expected.timestamp.toString(), `${expected.timestamp} !== ${timestamp}`);
+      assert.ok(price === expected.price, `${expected.price} !== ${price}`);
+    }
+
+    // Invalidate all cached results and verify failed price lookup.
+    tg.maxPriceAge = 1; // seconds
+    for (const expected of Object.values(priceCache)) {
+      const addr: string = expected.address;
+      await expect(tg.getCurrentPriceByContract(addr, baseCurrency)).rejects.toThrow();
     }
   });
 });

--- a/src/coingecko/Coingecko.e2e.ts
+++ b/src/coingecko/Coingecko.e2e.ts
@@ -74,9 +74,10 @@ describe("coingecko", function () {
       "0x6B3595068778DD592e39A122f4f5a5cF09C90fE2",
       "0x5F64Ab1544D28732F0A24F4713c2C8ec0dA089f0",
     ];
-    const result = await cg.getContractPrices(addresses);
+
+    const result: CoinGeckoPrice[] = await cg.getContractPrices(addresses);
     assert.equal(result.length, addresses.length);
-    result.forEach((result) => {
+    result.forEach((result: CoinGeckoPrice) => {
       assert.ok(result.price);
       assert.ok(result.timestamp);
       assert.ok(result.address);

--- a/src/coingecko/Coingecko.ts
+++ b/src/coingecko/Coingecko.ts
@@ -21,9 +21,19 @@ export type CoinGeckoPrice = {
   price: number;
 };
 
+type PriceCache = {
+  [chain: string]: {
+    [currency: string]: {
+      [address: string]: CoinGeckoPrice;
+    };
+  };
+};
+
 // Singleton Coingecko class.
 export class Coingecko {
   private static instance: Coingecko | undefined;
+  private prices: PriceCache;
+  private _maxPriceAge = 300; // seconds
 
   // Retry configuration.
   private retryDelay = 1;
@@ -41,12 +51,31 @@ export class Coingecko {
     return this.instance;
   }
 
-  private constructor(
+  get maxPriceAge(): number {
+    return this._maxPriceAge;
+  }
+
+  set maxPriceAge(age: number) {
+    assert(age >= 0);
+    this.logger.debug({
+      at: "Coingecko#maxPriceAge",
+      message: `Setting maxPriceAge (S) ${this._maxPriceAge} => ${age}.`
+    });
+    this._maxPriceAge = age;
+  }
+
+  protected constructor(
     private readonly host: string,
     private readonly proHost: string,
     private readonly logger: Logger,
     private readonly apiKey?: string
-  ) {}
+  ) {
+    this.prices = {
+      ethereum: {
+        usd: {},
+      },
+    };
+  }
 
   // Fetch historic prices for a `contract` denominated in `currency` between timestamp `from` and `to`. Note timestamps
   // are assumed to be js timestamps and are converted to unixtimestamps by dividing by 1000.
@@ -72,8 +101,42 @@ export class Coingecko {
     currency = "usd",
     platform_id = "ethereum"
   ): Promise<[string, number]> {
-    const result: CoinGeckoPrice[] = await this.getContractPrices([contract_address], currency, platform_id);
-    return [result[0].timestamp.toString(), result[0].price];
+    const priceCache: { [addr: string]: CoinGeckoPrice } = this.getPriceCache(currency, platform_id);
+    const now: number = msToS(Date.now());
+    let tokenPrice: CoinGeckoPrice | undefined = priceCache[contract_address];
+
+    if (tokenPrice === undefined || tokenPrice.timestamp + this.maxPriceAge <= now) {
+      if (this.maxPriceAge > 0) {
+        this.logger.debug({
+          at: "Coingecko#getCurrentPriceByContract",
+          message: `Cache miss on ${platform_id}/${currency} for ${contract_address}`,
+          maxPriceAge: this.maxPriceAge,
+          tokenPrice: tokenPrice,
+        });
+      }
+
+      try {
+        // Force price cache update.
+        await this.getContractPrices([contract_address], currency, platform_id);
+      } catch (err) {
+        const errMsg = `Failed to retrieve ${platform_id}/${currency} price for ${contract_address} (${err})`;
+        this.logger.warn({
+          at: "Coingecko#getCurrentPriceByContract",
+          message: errMsg,
+        });
+        throw new Error(errMsg);
+      }
+      tokenPrice = priceCache[contract_address];
+    } else {
+      this.logger.debug({
+        at: "Coingecko#getCurrentPriceByContract",
+        message: `Cache hit on token ${contract_address} (age ${now - tokenPrice.timestamp} S).`,
+        price: tokenPrice,
+      });
+    }
+
+    assert(tokenPrice !== undefined);
+    return [tokenPrice.timestamp.toString(), tokenPrice.price];
   }
   // Return an array of spot prices for an array of collateral addresses in one async call. Note we might in future
   // This was adapted from packages/merkle-distributor/kpi-options-helpers/calculate-uma-tvl.ts
@@ -82,30 +145,74 @@ export class Coingecko {
     currency = "usd",
     platform_id = "ethereum"
   ): Promise<CoinGeckoPrice[]> {
-    // Generate a unique set with no repeated. join the set with the required coingecko delimiter.
-    const contract_addresses = Array.from(new Set(addresses.filter((n) => n).values()));
+    const priceCache: { [addr: string]: CoinGeckoPrice } = this.getPriceCache(currency, platform_id);
+
+    // Pre-populate price cache with requested token addresses
+    addresses.forEach((addr: string) => {
+      if (priceCache[addr] === undefined) {
+        priceCache[addr] = { address: addr, price: 0, timestamp: 0 };
+      }
+    });
+
+    // Collect all known token addresses (requested + other cached).
+    const contract_addresses: string[] = Object.keys(priceCache);
     assert(contract_addresses.length > 0, "Must supply at least 1 contract address");
-    // coingecko returns lowercase addresses, so if you expect checksummed addresses, this lookup table will convert them back without having to add ethers as a dependency
-    const lookup = Object.fromEntries(
-      contract_addresses.map((address) => {
-        return [address.toLowerCase(), address];
-      })
-    );
+    this.logger.debug({
+      at: "Coingecko#getContractPrices",
+      message: `Updating ${platform_id}/${currency} token prices.`,
+      tokens: contract_addresses,
+    });
+
     // annoying, but have to type this to iterate over entries
-    type Result = {
-      [address: string]: {
-        usd: number;
-        last_updated_at: number;
-      };
+    type CGTokenPrice = {
+      [currency: string]: number;
+      last_updated_at: number;
     };
+    type Result = {
+      [address: string]: CGTokenPrice;
+    };
+    // Coingecko expects a comma-delimited (%2c) list.
     const result: Result = await this.call(
       `simple/token_price/${platform_id}?contract_addresses=${contract_addresses.join(
         "%2C"
       )}&vs_currencies=${currency}&include_last_updated_at=true`
     );
-    return Object.entries(result).map(([key, value]) => {
-      return { address: lookup[key], timestamp: value.last_updated_at, price: value.usd };
+
+    // Note: contract_addresses is a reliable reference for the price lookup.
+    // priceCache might have been updated subsequently by concurrent price requests.
+    const updated: string[] = [];
+    contract_addresses.forEach((addr) => {
+      const cgPrice: CGTokenPrice | undefined = result[addr.toLowerCase()];
+
+      if (cgPrice === undefined) {
+        this.logger.debug({
+          at: "Coingecko#getContractPrices",
+          message: `Token ${addr} not included in CoinGecko response.`,
+        });
+      } else if (cgPrice.last_updated_at > priceCache[addr].timestamp) {
+        priceCache[addr] = {
+          address: addr,
+          price: cgPrice[currency],
+          timestamp: cgPrice.last_updated_at,
+        };
+        updated.push(addr);
+      } else if (cgPrice.last_updated_at === priceCache[addr].timestamp) {
+        this.logger.debug({
+          at: "Coingecko#getContractPrices",
+          message: `No new price available for token ${addr}.`,
+          token: cgPrice,
+        });
+      }
     });
+
+    if (updated.length > 0) {
+      this.logger.debug({
+        at: "Coingecko#updatePriceCache",
+        message: `Updated ${platform_id}/${currency} token price cache.`,
+        tokens: updated,
+      });
+    }
+    return addresses.map((addr: string) => priceCache[addr]);
   }
 
   async getPlatforms(): Promise<CoinGeckoAssetPlatform[]> {
@@ -137,6 +244,12 @@ export class Coingecko {
 
     // Note: If a pro API key is configured, there is no need to retry as the Pro API will act as the basic's fall back.
     return retry(sendRequest, this.apiKey === undefined ? this.numRetries : 0, this.retryDelay);
+  }
+
+  protected getPriceCache(currency: string, platform_id: string): { [addr: string]: CoinGeckoPrice }  {
+    if (this.prices[platform_id] === undefined) this.prices[platform_id] = {};
+    if (this.prices[platform_id][currency] === undefined) this.prices[platform_id][currency] = {};
+    return this.prices[platform_id][currency];
   }
 
   private async _callBasic(path: string, timeout?: number) {


### PR DESCRIPTION
This PR adds two new capabilities to the Coingecko price feed.

 - Maintain a local cache of all known network/currency/price
   combinations. Allow the cache duration to be configurable,
   defaulting to 300 seconds (5 minutes).
 - For each new price cache miss, perform a new price lookup.
   As part of this lookup, opportunistically bundle in all known
   token addresses for the requested network and currency.

The combination of these new features should ideally help to
significantly reduce the number of CoinGecko price queries
that are submitted by via the API backend.

Ref: ACX-194