### PR TITLE
improve: Remove debug level logs

### DIFF
--- a/src/coingecko/Coingecko.ts
+++ b/src/coingecko/Coingecko.ts
@@ -219,8 +219,7 @@ export class Coingecko {
 
   async call(path: string) {
     const sendRequest = async () => {
-      const { host, proHost } = this;
-      this.logger.debug({ at: "sdk-v2/coingecko", message: `Sending GET request to host ${host}` });
+      const { proHost } = this;
 
       // If no pro api key, only send basic request:
       if (this.apiKey === undefined) {

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -158,15 +158,8 @@ export class RelayFeeCalculator {
   async relayerFeeDetails(amountToRelay: BigNumberish, tokenSymbol: string, tokenPrice?: number) {
     let isAmountTooLow = false;
     const gasFeePercent = await this.gasFeePercent(amountToRelay, tokenSymbol, tokenPrice);
-    this.logger.debug({
-      at: "sdk-v2/relayerFeeDetails",
-      message: "Computed gasFeePercent",
-      gasFeePercent,
-      overriddenTokenPrice: tokenPrice,
-    });
     const gasFeeTotal = gasFeePercent.mul(amountToRelay).div(fixedPointAdjustment);
     const capitalFeePercent = await this.capitalFeePercent(amountToRelay, tokenSymbol);
-    this.logger.debug({ at: "sdk-v2/relayerFeeDetails", message: "Computed capitalFeePercent", capitalFeePercent });
     const capitalFeeTotal = capitalFeePercent.mul(amountToRelay).div(fixedPointAdjustment);
     const relayFeePercent = gasFeePercent.add(capitalFeePercent);
     const relayFeeTotal = gasFeeTotal.add(capitalFeeTotal);


### PR DESCRIPTION
Let clients that import SDK add logs, we shouldn't add logs from an imported library without client's explicit permission