### PR TITLE
improve(Coingecko): Bump Coingecko timeout

### DIFF
--- a/src/coingecko/Coingecko.ts
+++ b/src/coingecko/Coingecko.ts
@@ -38,7 +38,7 @@ export class Coingecko {
   // Retry configuration.
   private retryDelay = 1;
   private numRetries = 0; // Most failures are due to 429 rate-limiting, so there is no point in retrying.
-  private basicApiTimeout = 250; // ms
+  private basicApiTimeout = 500; // ms
 
   public static get(logger: Logger, apiKey?: string) {
     if (!this.instance)


### PR DESCRIPTION
250 => 500 mS, per observation that timeouts are by far the leading cause of Pro lookups.