### PR TITLE
fix(gasPriceOracle): Revert to gasPrice for EIP-1559 chains

### DIFF
--- a/src/gasPriceOracle/oracle.e2e.ts
+++ b/src/gasPriceOracle/oracle.e2e.ts
@@ -13,10 +13,10 @@ const dummyLogger = winston.createLogger({
 type FeeData = providers.FeeData;
 
 class MockedProvider extends providers.JsonRpcProvider {
-  public feeData: any;
-  public gasPrice: any;
+  public feeData: BigNumber | number | string | undefined;
+  public gasPrice: BigNumber | number | string | undefined;
 
-  constructor(args: any) {
+  constructor(args: unknown) {
     super(args);
   }
 
@@ -68,7 +68,7 @@ describe("Gas Price Oracle", function () {
   });
 
   beforeEach(() => {
-    for (const [_chainId, provider] of Object.entries(providerInstances)) {
+    for (const [provider] of Object.values(providerInstances)) {
       provider.feeData = {
         gasPrice: stdGasPrice,
         maxFeePerGas: stdMaxFeePerGas,
@@ -133,7 +133,6 @@ describe("Gas Price Oracle", function () {
             (legacyChains.includes(chainId) && ["gasPrice"].includes(field))
           ) {
             await expect(getGasPriceEstimate(provider)).rejects.toThrow();
-
           } else {
             // Expect sane results to be returned; validate them.
             const gasPrice: GasPriceEstimate = await getGasPriceEstimate(provider);
@@ -151,7 +150,6 @@ describe("Gas Price Oracle", function () {
             if (eip1559Chains.includes(chainId)) {
               assert(gasPrice.maxFeePerGas.eq(stdMaxFeePerGas));
               assert(gasPrice.maxPriorityFeePerGas.eq(stdMaxPriorityFeePerGas));
-
             } else {
               // Legacy
               assert(gasPrice.maxFeePerGas.eq(stdGasPrice));

--- a/src/gasPriceOracle/oracle.ts
+++ b/src/gasPriceOracle/oracle.ts
@@ -34,7 +34,7 @@ async function eip1559(provider: providers.Provider, chainId: number): Promise<G
   });
 
   const maxPriorityFeePerGas = feeData.maxPriorityFeePerGas as BigNumber;
-  const maxFeePerGas = feeData.gasPrice as BigNumber; // note gasPrice is used.
+  const maxFeePerGas = maxPriorityFeePerGas.add(feeData.gasPrice as BigNumber); // note gasPrice is used.
 
   return {
     maxPriorityFeePerGas: maxPriorityFeePerGas,

--- a/src/gasPriceOracle/oracle.ts
+++ b/src/gasPriceOracle/oracle.ts
@@ -10,7 +10,7 @@ interface GasPriceFeed {
 }
 
 function error(method: string, chainId: number, data: providers.FeeData | BigNumber): void {
-  throw new Error(`Malformed ${method} response on chain ID ${chainId} (${JSON.stringify(data)}`);
+  throw new Error(`Malformed ${method} response on chain ID ${chainId} (${JSON.stringify(data)})`);
 }
 
 async function legacy(provider: providers.Provider, chainId: number): Promise<GasPriceEstimate> {

--- a/src/gasPriceOracle/oracle.ts
+++ b/src/gasPriceOracle/oracle.ts
@@ -24,17 +24,17 @@ async function legacy(provider: providers.Provider, chainId: number): Promise<Ga
   };
 }
 
-// @todo: Update to ethers 5.7.x to access FeeData.lastBaseFeePerGas
+// @todo: Update to ethers 5.7.x to access FeeData.lastBaseFeePerGas. Use feeData.gasPrice until then.
 // https://github.com/ethers-io/ethers.js/commit/8314236143a300ae81c1dcc27a7a36640df22061
 async function eip1559(provider: providers.Provider, chainId: number): Promise<GasPriceEstimate> {
   const feeData: providers.FeeData = await provider.getFeeData();
 
-  [feeData.maxFeePerGas, feeData.maxPriorityFeePerGas].forEach((field: BigNumber | null) => {
+  [feeData.gasPrice, feeData.maxPriorityFeePerGas].forEach((field: BigNumber | null) => {
     if (!BigNumber.isBigNumber(field) || field.lt(0)) error("getFeeData()", chainId, feeData);
   });
 
   const maxPriorityFeePerGas = feeData.maxPriorityFeePerGas as BigNumber;
-  const maxFeePerGas = feeData.maxFeePerGas as BigNumber;
+  const maxFeePerGas = feeData.gasPrice as BigNumber; // note gasPrice is used.
 
   return {
     maxPriorityFeePerGas: maxPriorityFeePerGas,


### PR DESCRIPTION
The existing use of maxFeePerGas gives a pessimistic view on the probable gas cost of the next transaction.