### PR TITLE
improve(PriceClient): Simplify PriceFeed constructor arguments

### DIFF
--- a/src/priceClient/adapters/acrossApi.ts
+++ b/src/priceClient/adapters/acrossApi.ts
@@ -10,7 +10,7 @@ type AcrossApiArgs = {
 const defaultTimeout = 5000; // mS
 
 export class PriceFeed extends BaseHTTPAdapter implements PriceFeedAdapter {
-  constructor(args?: AcrossApiArgs) {
+  constructor(args: AcrossApiArgs = {}) {
     // Allow host to be overridden for test or alternative deployments.
     super(args?.name ?? "Across API", args?.host ?? "across.to", { timeout: args?.timeout ?? defaultTimeout });
   }

--- a/src/priceClient/adapters/acrossApi.ts
+++ b/src/priceClient/adapters/acrossApi.ts
@@ -10,9 +10,9 @@ type AcrossApiArgs = {
 const defaultTimeout = 5000; // mS
 
 export class PriceFeed extends BaseHTTPAdapter implements PriceFeedAdapter {
-  constructor(args: AcrossApiArgs = {}) {
+  constructor({ name = "Across API", host = "across.to", timeout = defaultTimeout }: AcrossApiArgs = {}) {
     // Allow host to be overridden for test or alternative deployments.
-    super(args?.name ?? "Across API", args?.host ?? "across.to", { timeout: args?.timeout ?? defaultTimeout });
+    super(name, host, { timeout });
   }
 
   async getPriceByAddress(address: string, currency = "usd"): Promise<TokenPrice> {

--- a/src/priceClient/adapters/acrossApi.ts
+++ b/src/priceClient/adapters/acrossApi.ts
@@ -2,12 +2,17 @@ import { msToS, PriceFeedAdapter, TokenPrice } from "../priceClient";
 import { BaseHTTPAdapter } from "./baseAdapter";
 
 type AcrossPrice = { price: number };
+type AcrossApiArgs = {
+  name?: string;
+  host?: string;
+  timeout?: number;
+};
 const defaultTimeout = 5000; // mS
 
 export class PriceFeed extends BaseHTTPAdapter implements PriceFeedAdapter {
-  constructor(name: string, { host, timeout }: { host?: string; timeout?: number }) {
+  constructor(args?: AcrossApiArgs) {
     // Allow host to be overridden for test or alternative deployments.
-    super(name, host ?? "across.to", { timeout: timeout ?? defaultTimeout });
+    super(args?.name ?? "Across API", args?.host ?? "across.to", { timeout: args?.timeout ?? defaultTimeout });
   }
 
   async getPriceByAddress(address: string, currency = "usd"): Promise<TokenPrice> {

--- a/src/priceClient/adapters/coingecko.ts
+++ b/src/priceClient/adapters/coingecko.ts
@@ -12,14 +12,22 @@ type CoinGeckoPriceResponse = {
 
 const defaultTimeout = 5000; // mS
 
+type CoinGeckoArgs = {
+  name?: string;
+  timeout?: number;
+  apiKey?: string;
+};
+
 export class PriceFeed extends BaseHTTPAdapter implements PriceFeedAdapter {
   private readonly apiKey: string | undefined = undefined;
 
-  constructor(name: string, { timeout, apiKey }: { timeout?: number; apiKey?: string }) {
-    super(name, apiKey ? "pro-api.coingecko.com" : "api.coingecko.com", {
-      timeout: timeout ?? defaultTimeout,
-    });
-    this.apiKey = apiKey;
+  constructor(args?: CoinGeckoArgs) {
+    super(
+      args?.name ?? args?.apiKey ? "CoinGecko Pro" : "CoinGecko Free",
+      args?.apiKey ? "pro-api.coingecko.com" : "api.coingecko.com",
+      { timeout: args?.timeout ?? defaultTimeout }
+    );
+    this.apiKey = args?.apiKey;
   }
 
   async getPriceByAddress(address: string, currency = "usd"): Promise<TokenPrice> {

--- a/src/priceClient/adapters/coingecko.ts
+++ b/src/priceClient/adapters/coingecko.ts
@@ -21,13 +21,11 @@ type CoinGeckoArgs = {
 export class PriceFeed extends BaseHTTPAdapter implements PriceFeedAdapter {
   private readonly apiKey: string | undefined = undefined;
 
-  constructor(args: CoinGeckoArgs = {}) {
-    super(
-      args?.name ?? args?.apiKey ? "CoinGecko Pro" : "CoinGecko Free",
-      args?.apiKey ? "pro-api.coingecko.com" : "api.coingecko.com",
-      { timeout: args?.timeout ?? defaultTimeout }
-    );
-    this.apiKey = args?.apiKey;
+  constructor({ name, apiKey, timeout = defaultTimeout }: CoinGeckoArgs = {}) {
+    super(name ?? apiKey ? "CoinGecko Pro" : "CoinGecko Free", apiKey ? "pro-api.coingecko.com" : "api.coingecko.com", {
+      timeout,
+    });
+    this.apiKey = apiKey;
   }
 
   async getPriceByAddress(address: string, currency = "usd"): Promise<TokenPrice> {

--- a/src/priceClient/adapters/coingecko.ts
+++ b/src/priceClient/adapters/coingecko.ts
@@ -21,7 +21,7 @@ type CoinGeckoArgs = {
 export class PriceFeed extends BaseHTTPAdapter implements PriceFeedAdapter {
   private readonly apiKey: string | undefined = undefined;
 
-  constructor(args?: CoinGeckoArgs) {
+  constructor(args: CoinGeckoArgs = {}) {
     super(
       args?.name ?? args?.apiKey ? "CoinGecko Pro" : "CoinGecko Free",
       args?.apiKey ? "pro-api.coingecko.com" : "api.coingecko.com",

--- a/src/priceClient/priceClient.e2e.ts
+++ b/src/priceClient/priceClient.e2e.ts
@@ -150,7 +150,6 @@ describe("PriceClient", function () {
 
       for (const [baseCurrency, address] of parityTokens) {
         const tokenPrice: TokenPrice = await pc.getPriceByAddress(address, baseCurrency);
-        dummyLogger.debug({ at: "PITA test..:", message: `Got tokenPrice for addr ${address}.`, tokenPrice });
         validateTokenPrice(tokenPrice, address, beginTs);
         assert.ok(Math.abs(tokenPrice.price - 1) < 0.05);
       }


### PR DESCRIPTION
Per this comment to the use of PriceClient in the relayer-v2 repo: https://github.com/across-protocol/relayer-v2/pull/334#discussion_r1003809539.

This reduces some redundancy and makes it easier to instantiate a PriceFeed
instance. Also, name is now an optional argument that can be supplied as part
of the args object; if not supplied then a sensible per-feed default will be used.