### PR TITLE
Fix: CI Node version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,14 +5,14 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install deps
-        uses: borales/actions-yarn@v3.0.0
+        uses: actions/setup-node@v3
         with:
           node-version: 16
-          cmd: install
+          cmd: npm install
       - name: Run lint
-        uses: borales/actions-yarn@v3.0.0
+        uses: actions/setup-node@v3
         with:
           node-version: 16
-          cmd: lint
+          cmd: npm lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,15 +5,9 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-      - name: Install deps
-        uses: actions/setup-node@v3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
-        run: yarn install
-      - name: Run lint
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-        run: yarn lint
+      - run: yarn install
+      - run: yarn lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,14 +5,15 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repo
+        uses: actions/checkout@v3
       - name: Install deps
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          run: npm install
+        run: yarn install
       - name: Run lint
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          run: npm lint
+        run: yarn lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          cmd: npm install
+          run: npm install
       - name: Run lint
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          cmd: npm lint
+          run: npm lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,8 +9,10 @@ jobs:
       - name: Install deps
         uses: borales/actions-yarn@v3.0.0
         with:
+          node-version: 16
           cmd: install
       - name: Run lint
         uses: borales/actions-yarn@v3.0.0
         with:
+          node-version: 16
           cmd: lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,14 +6,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install deps
-        uses: borales/actions-yarn@v3.0.0
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cmd: install
       - name: Run tests
-        uses: borales/actions-yarn@v3.0.0
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cmd: test --ci --coverage --maxWorkers=2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,15 +5,9 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-      - name: Install deps
-        uses: actions/setup-node@v3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
-        run: npm install
-      - name: Run tests
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-        run: npm test --ci --coverage --maxWorkers=2
+      - run: yarn install
+      - run: yarn test --ci --coverage --maxWorkers=2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          cmd: install
+          run: npm install
       - name: Run tests
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          cmd: test --ci --coverage --maxWorkers=2
+          run: npm test --ci --coverage --maxWorkers=2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,10 @@ jobs:
       - name: Install deps
         uses: borales/actions-yarn@v3.0.0
         with:
+          node-version: 16
           cmd: install
       - name: Run tests
         uses: borales/actions-yarn@v3.0.0
         with:
+          node-version: 16
           cmd: test --ci --coverage --maxWorkers=2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          run: npm install
+        run: npm install
       - name: Run tests
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          run: npm test --ci --coverage --maxWorkers=2
+        run: npm test --ci --coverage --maxWorkers=2


### PR DESCRIPTION
[Node LTS version](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#2022-10-25-version-18120-hydrogen-lts-ruyadorno-and-rafaelgss) changed recently, and some packages still using old LTS. Version is now fixed on code. 

Signed-off-by: Evaldo Felipe <contato@evaldofelipe.com>