### PR TITLE
fix(gasPriceOracle): Fix tests

### DIFF
--- a/src/gasPriceOracle/oracle.e2e.ts
+++ b/src/gasPriceOracle/oracle.e2e.ts
@@ -77,7 +77,7 @@ describe("Gas Price Oracle", function () {
         maxFeePerGas: stdMaxFeePerGas,
         maxPriorityFeePerGas: stdMaxPriorityFeePerGas,
       };
-      provider.gasPrice = (provider.feeData as FeeData).gasPrice;
+      provider.gasPrice = stdGasPrice; // Required: same as provider.feeData.gasPrice.
     }
   });
 


### PR DESCRIPTION
Evaldo's latest PR ratcheted up the CI quality demands, and my code was found wanting... This is
currently a blocking issue for any other PRs going into this repo, since it's blocking CI.

This change eases some of the type mangling that occurs in the oracle.e2e test, such that the linter and transpiler are a little less offended by it.