### PR TITLE
fix(relay-fee-calculator): Divide by 1e18 for Optimism gas cost 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/contracts/hubPool.ts
+++ b/src/contracts/hubPool.ts
@@ -10,7 +10,7 @@ export const Factory = HubPool__factory;
 export type Interface = HubPoolInterface;
 
 export function connect(address: string, provider: SignerOrProvider): Instance {
-  return Factory.connect(address, provider as unknown as Signer);
+  return Factory.connect(address, provider as Signer);
 }
 
 export type LiquidityAdded = GetEventType<Instance, "LiquidityAdded">;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -256,7 +256,10 @@ export async function estimateTotalGasRequiredByUnsignedTransaction(
     assert(isOptimismL2Provider(provider), `Unexpected provider for chain ID ${network.chainId}.`);
     assert(gasPrice === undefined, `Gas price (${gasPrice}) supplied for Optimism gas estimation (unused).`);
     const populatedTransaction = await voidSigner.populateTransaction(unsignedTx);
-    return (await provider.estimateTotalGasCost(populatedTransaction)).mul(gasTotalMultiplier).toString();
+    return (await provider.estimateTotalGasCost(populatedTransaction))
+      .mul(gasTotalMultiplier)
+      .div(toBNWei(1))
+      .toString();
   }
 
   if (!gasPrice) {
@@ -269,7 +272,7 @@ export async function estimateTotalGasRequiredByUnsignedTransaction(
 
   // Find the total gas cost by taking the product of the gas price & the
   // estimated number of gas units needed.
-  return BigNumber.from(gasPrice).mul(gasTotalMultiplier).div(toBNWei(1)).mul(estimatedGasUnits).toString();
+  return BigNumber.from(gasPrice).mul(gasTotalMultiplier).mul(estimatedGasUnits).div(toBNWei(1)).toString();
 }
 
 /**


### PR DESCRIPTION
https://github.com/across-protocol/sdk-v2/commit/7abcbfa7b4690e9706bd6ae91ae66de041427906

correctly divided by 1e18 after toBNWei-ing the gasMultiplier but forgot to add the same division for the Optimism special case