### PR TITLE
feat(PriceClient): Accept partial price responses

### DIFF
--- a/src/priceClient/adapters/coingecko.ts
+++ b/src/priceClient/adapters/coingecko.ts
@@ -45,11 +45,11 @@ export class PriceFeed extends BaseHTTPAdapter implements PriceFeedAdapter {
     if (!this.validateResponse(prices, currency))
       throw new Error(`Unexpected ${this.name} response: ${JSON.stringify(prices)}`);
 
-    return addresses.map((addr: string) => {
-      const price: CoinGeckoTokenPrice = prices[addr.toLowerCase()];
-      if (price === undefined) throw new Error(`Token ${addr} missing from ${this.name} response`);
+    return addresses.map((address: string) => {
+      const price: CoinGeckoTokenPrice = prices[address];
+      if (price === undefined) return price;
 
-      return { address: addr, price: price[currency], timestamp: price.last_updated_at };
+      return { address, price: price[currency], timestamp: price.last_updated_at };
     });
   }
 

--- a/src/priceClient/adapters/coingecko.ts
+++ b/src/priceClient/adapters/coingecko.ts
@@ -35,7 +35,7 @@ export class PriceFeed extends BaseHTTPAdapter implements PriceFeedAdapter {
 
   async getPricesByAddress(addresses: string[], currency = "usd"): Promise<TokenPrice[]> {
     const queryArgs: { [key: string]: boolean | string } = {
-      contract_addresses: addresses.join(","),
+      contract_addresses: addresses.map((address) => address.toLowerCase()).join(","),
       vs_currencies: currency,
       include_last_updated_at: true,
     };
@@ -45,12 +45,12 @@ export class PriceFeed extends BaseHTTPAdapter implements PriceFeedAdapter {
     if (!this.validateResponse(prices, currency))
       throw new Error(`Unexpected ${this.name} response: ${JSON.stringify(prices)}`);
 
-    return addresses.map((address: string) => {
-      const price: CoinGeckoTokenPrice = prices[address];
-      if (price === undefined) return price;
-
-      return { address, price: price[currency], timestamp: price.last_updated_at };
-    });
+    return addresses
+      .filter((address) => prices[address.toLowerCase()] !== undefined)
+      .map((address) => {
+        const price: CoinGeckoTokenPrice = prices[address.toLowerCase()];
+        return { address, price: price[currency], timestamp: price.last_updated_at };
+      });
   }
 
   private validateResponse(response: unknown, currency: string): response is CoinGeckoPriceResponse {

--- a/src/priceClient/adapters/defiLlama.ts
+++ b/src/priceClient/adapters/defiLlama.ts
@@ -58,7 +58,7 @@ export class PriceFeed extends BaseHTTPAdapter implements PriceFeedAdapter {
     if (!this.validateResponse(response))
       throw new Error(`Unexpected ${this.name} response: ${JSON.stringify(response)}`);
 
-    // Normalise the address format: "etherum:"<address> => <address>.
+    // Normalise the address format: "etherum:<address>" => "<address>".
     const tokenPrices: { [address: string]: DefiLlamaTokenPrice } = Object.fromEntries(
       Object.entries(response.coins).map(([identifier, tokenPrice]) => [identifier.split(":")[1], tokenPrice])
     );

--- a/src/priceClient/adapters/defiLlama.ts
+++ b/src/priceClient/adapters/defiLlama.ts
@@ -69,7 +69,7 @@ export class PriceFeed extends BaseHTTPAdapter implements PriceFeedAdapter {
       })
       .map(([address, tokenPrice]) => {
         const { price, timestamp } = tokenPrice;
-        return { address, price, timestamp } as TokenPrice;
+        return { address, price, timestamp };
       });
   }
 

--- a/src/priceClient/priceClient.e2e.ts
+++ b/src/priceClient/priceClient.e2e.ts
@@ -44,7 +44,8 @@ class TestPriceFeed implements PriceFeedAdapter {
   }
 }
 
-const maxPriceAge = 600;
+// Don't be too strict on obtaining recent prices.
+const maxPriceAge = 60 * 60 * 30; // seconds
 
 // ACX must be defined separately until it is supported by CoinGecko.
 const acxAddr = "0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f";

--- a/src/priceClient/priceClient.e2e.ts
+++ b/src/priceClient/priceClient.e2e.ts
@@ -4,7 +4,7 @@ import winston from "winston";
 import { Logger, msToS, PriceCache, PriceClient, PriceFeedAdapter, TokenPrice } from "./priceClient";
 import { acrossApi, coingecko, defiLlama } from "./adapters";
 
-dotenv.config({ path: ".env" });
+dotenv.config();
 
 class TestPriceClient extends PriceClient {
   constructor(logger: Logger, priceFeeds: PriceFeedAdapter[]) {

--- a/src/priceClient/priceClient.e2e.ts
+++ b/src/priceClient/priceClient.e2e.ts
@@ -273,10 +273,10 @@ describe("PriceClient", function () {
   });
 
   test("getPricesByAddress: Price request reduction", async function () {
-    // Test Price Feed #1 does not know about ACX, so it provide an incomplete
+    // Test Price Feed #1 does not know about ACX, so it provides an incomplete
     // response. Verify that the response from Test Price Feed #1 includes all
     // known tokens, and that the PriceClient proceeds to query Test Price Feed
-    // #2 for *only* the remaining delta addres.
+    // #2 for *only* the remaining delta address.
     const testPriceFeeds: TestPriceFeed[] = [
       new TestPriceFeed("Test Price Feed #1"),
       new TestPriceFeed("Test Price Feed #2"),

--- a/src/priceClient/priceClient.e2e.ts
+++ b/src/priceClient/priceClient.e2e.ts
@@ -3,9 +3,8 @@ import dotenv from "dotenv";
 import winston from "winston";
 import { Logger, msToS, PriceCache, PriceClient, PriceFeedAdapter, TokenPrice } from "./priceClient";
 import { acrossApi, coingecko } from "./adapters";
-dotenv.config({ path: ".env" });
 
-const maxPriceAge = 300;
+dotenv.config({ path: ".env" });
 
 class TestPriceClient extends PriceClient {
   constructor(logger: Logger, priceFeeds: PriceFeedAdapter[]) {
@@ -16,6 +15,19 @@ class TestPriceClient extends PriceClient {
     return this.getPriceCache(currency);
   }
 }
+
+const maxPriceAge = 300;
+
+// ACX must be defined separately until it is supported by CoinGecko.
+const acxAddr = "0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f";
+const addresses: { [symbol: string]: string } = {
+  // lower-case
+  UMA: "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
+  // checksummed
+  DAI: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+  USDC: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+  WETH: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+};
 
 function validateTokenPrice(tokenPrice: TokenPrice, address: string, timestamp: number) {
   assert.ok(tokenPrice);
@@ -34,15 +46,6 @@ describe("PriceClient", function () {
     level: "debug",
     transports: [new winston.transports.Console()],
   });
-
-  const addresses: { [symbol: string]: string } = {
-    // lower-case
-    UMA: "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
-    // checksummed
-    DAI: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
-    USDC: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-    WETH: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-  };
 
   const testAddress = addresses["UMA"];
   const baseCurrency = "usd";

--- a/src/priceClient/priceClient.ts
+++ b/src/priceClient/priceClient.ts
@@ -153,7 +153,7 @@ export class PriceClient implements PriceFeedAdapter {
 
     expected.forEach((address: string) => {
       const addr = address.toLowerCase(); // for internal priceCache lookup.
-      const tokenPrice: TokenPrice | undefined = prices.find((price) => price.address.toLowerCase() === addr);
+      const tokenPrice: TokenPrice | undefined = prices.find((price) => price?.address?.toLowerCase() === addr);
 
       if (tokenPrice === undefined) {
         skipped[address] = "Not included in price feed response.";

--- a/src/priceClient/priceClient.ts
+++ b/src/priceClient/priceClient.ts
@@ -67,6 +67,9 @@ export class PriceClient implements PriceFeedAdapter {
     return tokenPrices[0];
   }
 
+  // note: Input addresses are *always* converted to lower case for storage as
+  // keys in the PriceClient cache. Adapters will therefore always receive
+  // addresses in lower case form.
   async getPricesByAddress(addresses: string[], currency = "usd"): Promise<TokenPrice[]> {
     assert(this.priceFeeds.length > 0, "No price feeds are registered.");
     const priceCache = this.getPriceCache(currency);

--- a/src/priceClient/priceClient.ts
+++ b/src/priceClient/priceClient.ts
@@ -96,9 +96,9 @@ export class PriceClient implements PriceFeedAdapter {
       this.updateCache(priceCache, prices, requestAddresses);
     }
 
-    return addresses.map((addr: string) => {
-      const { price, timestamp } = priceCache[addr.toLowerCase()];
-      return { address: addr, price, timestamp };
+    return addresses.map((address: string) => {
+      const { price, timestamp } = priceCache[address.toLowerCase()];
+      return { address, price, timestamp };
     });
   }
 


### PR DESCRIPTION
This change restores the PriceClient's ability to fall back to alternative
price feeds in the event of a price resolution failure.

The PriceClient currently requires each PriceFeedAdapter instance to return
a complete response to any price lookup. This effectively renders CoinGecko
unusable as a price source now that the ACX token is included in price
lookups.

This change modifies the PriceClient such that it will accept an incomplete
response, thereby restoring most of the fallback capability. A price lookup
failure against ACX alone will still cause an exception to be thrown, because
there are no other fallback sources. Some additional thought could be
directed at how to make that more robust in future.