### PR TITLE
fix: Fix APR and APY's to 18 precision

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -166,14 +166,14 @@ export const calcPeriodicCompoundInterest = (
   const P = new Decimal(startAmount);
   const t = new Decimal(periodsPerYear).div(periodsElapsed);
   const one = new Decimal(1);
-  return Decimal.max(
-    n.mul(
+  return n
+    .mul(
       A.div(P)
         .pow(one.div(n.div(t)))
         .sub(one)
-    ),
-    0
-  ).toString();
+    )
+    .toFixed(18)
+    .toString();
 };
 
 /**
@@ -190,10 +190,13 @@ export const calcApr = (
   periodsElapsed: Decimalish,
   periodsPerYear: Decimalish
 ): string => {
-  return Decimal.max(
-    new Decimal(endAmount).sub(startAmount).div(startAmount).mul(periodsPerYear).div(periodsElapsed),
-    0
-  ).toString();
+  return new Decimal(endAmount)
+    .sub(startAmount)
+    .div(startAmount)
+    .mul(periodsPerYear)
+    .div(periodsElapsed)
+    .toFixed(18)
+    .toString();
 };
 /**
  * Takes two values and returns a list of number intervals

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -166,13 +166,14 @@ export const calcPeriodicCompoundInterest = (
   const P = new Decimal(startAmount);
   const t = new Decimal(periodsPerYear).div(periodsElapsed);
   const one = new Decimal(1);
-  return n
-    .mul(
+  return Decimal.max(
+    n.mul(
       A.div(P)
         .pow(one.div(n.div(t)))
         .sub(one)
-    )
-    .toString();
+    ),
+    0
+  ).toString();
 };
 
 /**
@@ -189,7 +190,10 @@ export const calcApr = (
   periodsElapsed: Decimalish,
   periodsPerYear: Decimalish
 ): string => {
-  return new Decimal(endAmount).sub(startAmount).div(startAmount).mul(periodsPerYear).div(periodsElapsed).toString();
+  return Decimal.max(
+    new Decimal(endAmount).sub(startAmount).div(startAmount).mul(periodsPerYear).div(periodsElapsed),
+    0
+  ).toString();
 };
 /**
  * Takes two values and returns a list of number intervals

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -172,8 +172,7 @@ export const calcPeriodicCompoundInterest = (
         .pow(one.div(n.div(t)))
         .sub(one)
     )
-    .toFixed(18)
-    .toString();
+    .toFixed(18);
 };
 
 /**
@@ -190,13 +189,7 @@ export const calcApr = (
   periodsElapsed: Decimalish,
   periodsPerYear: Decimalish
 ): string => {
-  return new Decimal(endAmount)
-    .sub(startAmount)
-    .div(startAmount)
-    .mul(periodsPerYear)
-    .div(periodsElapsed)
-    .toFixed(18)
-    .toString();
+  return new Decimal(endAmount).sub(startAmount).div(startAmount).mul(periodsPerYear).div(periodsElapsed).toFixed(18);
 };
 /**
  * Takes two values and returns a list of number intervals


### PR DESCRIPTION
when utilized reserves is < 0, apr's can get so small they toString() into scientific notation