### PR TITLE
fix(lpFeeCalculator): Handle divide by 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/lpFeeCalculator/lpFeeCalculator.test.ts
+++ b/src/lpFeeCalculator/lpFeeCalculator.test.ts
@@ -44,12 +44,18 @@ describe("Realized liquidity provision calculation", function () {
       { utilA: toBNWei("0"), utilB: toBNWei("1.00"), apy: "229000000000000000", wpy: "3973000000000000" },
     ];
 
+    // Test special rate model case where dividing by 0 can occur
+    const zeroRateModel = { UBar: toBNWei(0), R0: toBNWei(0), R1: toBNWei(0), R2: toBNWei(0) };
+
     testedIntervals.forEach((interval) => {
       const apyFeePct = calculateApyFromUtilization(rateModel, interval.utilA, interval.utilB);
       assert.equal(apyFeePct.toString(), interval.apy);
 
       const realizedLpFeePct = calculateRealizedLpFeePct(rateModel, interval.utilA, interval.utilB).toString();
       assert.equal(realizedLpFeePct.toString(), interval.wpy);
+
+      assert.ok(calculateApyFromUtilization(zeroRateModel, interval.utilA, interval.utilB));
+      assert.ok(calculateRealizedLpFeePct(zeroRateModel, interval.utilA, interval.utilB));
     });
     testedIntervalsTruncated.forEach((interval) => {
       const apyFeePct = calculateApyFromUtilization(rateModel, interval.utilA, interval.utilB);

--- a/src/lpFeeCalculator/lpFeeCalculator.test.ts
+++ b/src/lpFeeCalculator/lpFeeCalculator.test.ts
@@ -55,7 +55,9 @@ describe("Realized liquidity provision calculation", function () {
       assert.equal(realizedLpFeePct.toString(), interval.wpy);
 
       assert.ok(calculateApyFromUtilization(zeroRateModel, interval.utilA, interval.utilB));
+      assert.equal(calculateApyFromUtilization(zeroRateModel, interval.utilA, interval.utilB).toString(), "0");
       assert.ok(calculateRealizedLpFeePct(zeroRateModel, interval.utilA, interval.utilB));
+      assert.equal(calculateRealizedLpFeePct(zeroRateModel, interval.utilA, interval.utilB).toString(), "0");
     });
     testedIntervalsTruncated.forEach((interval) => {
       const apyFeePct = calculateApyFromUtilization(rateModel, interval.utilA, interval.utilB);

--- a/src/lpFeeCalculator/lpFeeCalculator.ts
+++ b/src/lpFeeCalculator/lpFeeCalculator.ts
@@ -16,7 +16,10 @@ export interface RateModel {
 
 // Calculate the rate for a 0 sized deposit (infinitesimally small).
 export function calculateInstantaneousRate(rateModel: RateModel, utilization: BigNumberish) {
-  const beforeKink = min(utilization, rateModel.UBar).mul(rateModel.R1).div(rateModel.UBar);
+  const beforeKink =
+    rateModel.UBar.toString() === "0"
+      ? toBN(0)
+      : min(utilization, rateModel.UBar).mul(rateModel.R1).div(rateModel.UBar);
   const afterKink = max(toBN("0"), toBN(utilization).sub(rateModel.UBar))
     .mul(rateModel.R2)
     .div(toBNWei("1").sub(rateModel.UBar));

--- a/src/lpFeeCalculator/lpFeeCalculator.ts
+++ b/src/lpFeeCalculator/lpFeeCalculator.ts
@@ -16,6 +16,7 @@ export interface RateModel {
 
 // Calculate the rate for a 0 sized deposit (infinitesimally small).
 export function calculateInstantaneousRate(rateModel: RateModel, utilization: BigNumberish) {
+  // Assuming utilization >= 0, if UBar = 0 then the value beforeKink is 0 since min(>=0, 0) = 0.
   const beforeKink =
     rateModel.UBar.toString() === "0"
       ? toBN(0)


### PR DESCRIPTION
New issue discovered when using rate model with UBAR=0
