### PR TITLE
improve(relayFeeCalculator): Standardize isAmountTooLow with Vercel API's minDeposit calculation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -176,11 +176,11 @@ export class RelayFeeCalculator {
     // gas fee %: maxGasFeePercent = gasFeeTotal / minDeposit. Refactor this to figure out the minDeposit:
     // minDeposit = gasFeeTotal / maxGasFeePercent, and subsequently determine
     // isAmountTooLow = amountToRelay < minDeposit.
-    const maxGasFeePercent = max(toBNWei(this.feeLimitPercent / 100).sub(capitalFeePercent), BigNumber.from(0));
+    const maxGasFeePercent = max(toBNWei(this.feeLimitPercent / 100).sub(capitalFeePercent), toBN(0));
     // If maxGasFee % is 0, then the min deposit should be infinite because there is no deposit amount that would
     // incur a non zero gas fee % charge. In this case, isAmountTooLow should always be true.
     let minDeposit: BigNumber, isAmountTooLow: boolean;
-    if (maxGasFeePercent.eq("0")) {
+    if (maxGasFeePercent.eq(toBN(0))) {
       minDeposit = MAX_BIG_INT;
       isAmountTooLow = true;
     } else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,6 +10,7 @@ export type BigNumberish = string | number | BigNumber;
 export type BN = BigNumber;
 export type Decimalish = string | number | Decimal;
 export const AddressZero = ethers.constants.AddressZero;
+export const MAX_BIG_INT = BigNumber.from(Number.MAX_SAFE_INTEGER.toString());
 
 // Used as a signal to protect relayers from running code against an outdated version of the on-chain config store.
 export const CONFIG_STORE_VERSION = 1;


### PR DESCRIPTION
- API computes `maxGasFeePercent` and `minDeposit` in order to compute the minimum deposit for the /limits endpoint, we should standardize this and move the computation to the SDK-v2
- Fixes a divide-by-0 bug where we don't handle the `maxGasFeePercent = 0` case, arising when `feeLimitPercent` is set too low or `capitalFeePercent` is too high
- Returns `maxGasFeePercent` and `minDeposit` which can be used by the FE instead of recomputing [here](https://github.com/across-protocol/frontend-v2/blob/1c531768b36d77119dee9ce4a041f20729bb82ba/api/limits.ts#L197)