### PR TITLE
chore: Bump ts 4.6.2 -> 4.9.5

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -15314,9 +15314,9 @@ typescript@^3.7.3:
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
 typescript@^4.6.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
-  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Initial motivation: https://github.com/microsoft/TypeScript/issues/50583.

Changes:
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-8.html
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html

Something that caught my eye is [auto-accessors](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html#a-nameauto-accessors-in-classes-auto-accessors-in-classes) (added in 4.9). I will look forward to using that, at least.