### PR TITLE
chore(across-v2): Add basic UBA types

### DIFF
--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -65,6 +65,20 @@ export interface SlowFill {
   recipient: string;
 }
 
+export interface RefundRequest {
+  relayer: string;
+  refundToken: string;
+  amount: BigNumber;
+  originChainId: number;
+  destinationChainId: number;
+  realizedLpFeePct: BigNumber;
+  depositId: number;
+  fillBlock: BigNumber;
+  previousIdenticalRequests: BigNumber;
+}
+
+export interface RefundRequestWithBlock extends RefundRequest, SortableEvent {}
+
 export interface RootBundleRelay {
   rootBundleId: number;
   relayerRefundRoot: string;

--- a/src/interfaces/UBA.ts
+++ b/src/interfaces/UBA.ts
@@ -1,7 +1,5 @@
-// import { DepositWithBlock, FillWithBlock, RefundRequestedWithBlock } from "./SpokePool";
-import { DepositWithBlock, FillWithBlock } from "./SpokePool";
+import { DepositWithBlock, FillWithBlock, RefundRequestWithBlock } from "./";
 
 export type UbaInflow = DepositWithBlock;
-// export type UbaOutflow = FillWithBlock | RefundRequestedWithBlock;
-export type UbaOutflow = FillWithBlock;
+export type UbaOutflow = FillWithBlock | RefundRequestWithBlock;
 export type UbaFlow = UbaInflow | UbaOutflow;

--- a/src/interfaces/UBA.ts
+++ b/src/interfaces/UBA.ts
@@ -1,0 +1,7 @@
+// import { DepositWithBlock, FillWithBlock, RefundRequestedWithBlock } from "./SpokePool";
+import { DepositWithBlock, FillWithBlock } from "./SpokePool";
+
+export type UbaInflow = DepositWithBlock;
+// export type UbaOutflow = FillWithBlock | RefundRequestedWithBlock;
+export type UbaOutflow = FillWithBlock;
+export type UbaFlow = UbaInflow | UbaOutflow;

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -3,3 +3,4 @@ export * from "./ConfigStore";
 export * from "./HubPool";
 export * from "./SpokePool";
 export * from "./Bridge";
+export * from "./UBA";


### PR DESCRIPTION
This change simply establishes some basic types to be used as part of the UBA ecosystem. Note that the Outflow type is incomplete because it depends on the RefundRequested event, which hasn't been merged yet.