### PR TITLE
fix(UBA): Tweak predicates and add test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/interfaces/UBA.test.ts
+++ b/src/interfaces/UBA.test.ts
@@ -1,0 +1,85 @@
+import { random } from "lodash";
+import { toBN, toBNWei } from "../utils";
+import {
+  DepositWithBlock,
+  FillWithBlock,
+  RefundRequestWithBlock,
+  UbaFlow,
+  UbaOutflow,
+  isUbaInflow,
+  isUbaOutflow,
+  outflowIsFill,
+  outflowIsRefund,
+} from "./";
+
+const common = {
+  depositId: random(1, 1000, false),
+  amount: toBNWei(0.01),
+  originChainId: 1,
+  destinationChainId: 10,
+  blockNumber: 1,
+  transactionIndex: 0,
+  logIndex: 0,
+  transactionHash: "",
+};
+
+const sampleDeposit = {
+  depositor: "",
+  recipient: "",
+  originToken: "",
+  relayerFeePct: toBNWei(0.0001),
+  quoteTimestamp: Math.floor(Date.now() / 1000),
+  realizedLpFeePct: toBNWei(0.00001),
+  destinationToken: "",
+  originBlockNumber: 1,
+};
+
+const sampleFill = {
+  totalFilledAmount: toBNWei(0.01),
+  fillAmount: toBNWei(0.01),
+  repaymentChainId: 10,
+  relayerFeePct: toBNWei(0.0001),
+  appliedRelayerFeePct: toBNWei(0.0001),
+  realizedLpFeePct: toBNWei(0.00001),
+  destinationToken: "",
+  relayer: "",
+  depositor: "",
+  recipient: "",
+  isSlowRelay: true,
+  destinationChainId: 10,
+};
+
+const sampleRefundRequest = {
+  relayer: "",
+  refundToken: "",
+  realizedLpFeePct: toBNWei(0.0001),
+  fillBlock: toBN(random(1, 1000, false)),
+  previousIdenticalRequests: toBN(0),
+};
+
+describe("UBA Interface", function () {
+  test("Predicates", function () {
+    const deposit: DepositWithBlock = { ...common, ...sampleDeposit };
+    const fill: FillWithBlock = { ...common, ...sampleFill };
+    const refundRequest: RefundRequestWithBlock = { ...common, ...sampleRefundRequest };
+
+    // FundsDeposited event. All UbaInflows are Deposits.
+    expect(isUbaInflow(deposit as UbaFlow)).toBe(true);
+    expect(isUbaOutflow(deposit as UbaFlow)).toBe(false);
+
+    // FilledRelay event
+    for (const slowRelay of [true, false]) {
+      fill.isSlowRelay = slowRelay;
+      expect(isUbaInflow(fill as UbaFlow)).toBe(false);
+      expect(isUbaOutflow(fill as UbaFlow)).toBe(true);
+      expect(outflowIsFill(fill as UbaOutflow)).toBe(true);
+      expect(outflowIsRefund(fill as UbaOutflow)).toBe(false);
+    }
+
+    // RefundRequested event
+    expect(isUbaInflow(refundRequest as UbaFlow)).toBe(false);
+    expect(isUbaOutflow(refundRequest as UbaFlow)).toBe(true);
+    expect(outflowIsFill(refundRequest as UbaOutflow)).toBe(false);
+    expect(outflowIsRefund(refundRequest as UbaOutflow)).toBe(true);
+  });
+});

--- a/src/interfaces/UBA.ts
+++ b/src/interfaces/UBA.ts
@@ -11,9 +11,17 @@ export type UbaRunningRequest = {
 };
 
 export const isUbaInflow = (flow: UbaFlow): flow is UbaInflow => {
-  return (flow as UbaInflow).depositId !== undefined;
+  return (flow as UbaInflow).quoteTimestamp !== undefined;
 };
 
 export const isUbaOutflow = (flow: UbaFlow): flow is UbaOutflow => {
-  return !isUbaInflow(flow);
+  return !isUbaInflow(flow) && (outflowIsFill(flow) || outflowIsRefund(flow));
+};
+
+export const outflowIsFill = (outflow: UbaOutflow): outflow is FillWithBlock => {
+  return (outflow as FillWithBlock).isSlowRelay !== undefined;
+};
+
+export const outflowIsRefund = (outflow: UbaOutflow): outflow is RefundRequestWithBlock => {
+  return (outflow as RefundRequestWithBlock).fillBlock !== undefined;
 };


### PR DESCRIPTION
The existing predicates didn't quite work as expected because the
depositId field exists on all of the UbaFlow union types. This change
changes the isUbaInflow() predicate to look at the deposit-exclusive
quoteTimestamp field, and adds some additional predicates to support
sub-classifying a UbaOutflow. While here, add some tests.