### PR TITLE
DepositWithBlock.originBlockNumber -> quoteBlockNumber

### DIFF
--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -21,7 +21,7 @@ export interface Deposit {
 }
 
 export interface DepositWithBlock extends Deposit, SortableEvent {
-  originBlockNumber: number;
+  quoteBlockNumber: number;
 }
 export interface Fill {
   amount: BigNumber;


### PR DESCRIPTION
This helps to keep DepositWithBlock aligned with the commonly used tools that work on SortableEvent types.