### PR TITLE
refactor: Relocate UBA type predicates + test

### DIFF
--- a/src/interfaces/UBA.ts
+++ b/src/interfaces/UBA.ts
@@ -9,19 +9,3 @@ export type UbaRunningRequest = {
   type: "refund" | "deposit";
   amount: BigNumber;
 };
-
-export const isUbaInflow = (flow: UbaFlow): flow is UbaInflow => {
-  return (flow as UbaInflow).quoteTimestamp !== undefined;
-};
-
-export const isUbaOutflow = (flow: UbaFlow): flow is UbaOutflow => {
-  return !isUbaInflow(flow) && (outflowIsFill(flow) || outflowIsRefund(flow));
-};
-
-export const outflowIsFill = (outflow: UbaOutflow): outflow is FillWithBlock => {
-  return (outflow as FillWithBlock).isSlowRelay !== undefined;
-};
-
-export const outflowIsRefund = (outflow: UbaOutflow): outflow is RefundRequestWithBlock => {
-  return (outflow as RefundRequestWithBlock).fillBlock !== undefined;
-};

--- a/src/typeguards/UBA.test.ts
+++ b/src/typeguards/UBA.test.ts
@@ -1,16 +1,7 @@
 import { random } from "lodash";
 import { toBN, toBNWei } from "../utils";
-import {
-  DepositWithBlock,
-  FillWithBlock,
-  RefundRequestWithBlock,
-  UbaFlow,
-  UbaOutflow,
-  isUbaInflow,
-  isUbaOutflow,
-  outflowIsFill,
-  outflowIsRefund,
-} from "./";
+import { DepositWithBlock, FillWithBlock, RefundRequestWithBlock, UbaFlow, UbaOutflow } from "../interfaces";
+import { isUbaInflow, isUbaOutflow, outflowIsFill, outflowIsRefund } from "./";
 
 const common = {
   depositId: random(1, 1000, false),

--- a/src/typeguards/UBA.ts
+++ b/src/typeguards/UBA.ts
@@ -1,0 +1,17 @@
+import { FillWithBlock, RefundRequestWithBlock, UbaFlow, UbaInflow, UbaOutflow } from "../interfaces";
+
+export const isUbaInflow = (flow: UbaFlow): flow is UbaInflow => {
+  return (flow as UbaInflow).quoteTimestamp !== undefined;
+};
+
+export const isUbaOutflow = (flow: UbaFlow): flow is UbaOutflow => {
+  return !isUbaInflow(flow) && (outflowIsFill(flow) || outflowIsRefund(flow));
+};
+
+export const outflowIsFill = (outflow: UbaOutflow): outflow is FillWithBlock => {
+  return (outflow as FillWithBlock).isSlowRelay !== undefined;
+};
+
+export const outflowIsRefund = (outflow: UbaOutflow): outflow is RefundRequestWithBlock => {
+  return (outflow as RefundRequestWithBlock).fillBlock !== undefined;
+};

--- a/src/typeguards/index.ts
+++ b/src/typeguards/index.ts
@@ -1,1 +1,2 @@
 export * from "./error";
+export * from "./UBA";


### PR DESCRIPTION
Continuing on from discussion here: https://github.com/across-protocol/sdk-v2/pull/170#pullrequestreview-1385628719

My gut feel is that it's probably premature to split these and that it's more convenient to keep them in the same file.