### PR TITLE
chore(package): Bump version -> 0.4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
0.4.7 includes a broken test, but this didn't prevent it from being packaged and pushed to npm.
Bumping to 0.4.8 is now necessary to get the fixed version to npm.