### PR TITLE
chore(UBA): Tweak outflowIsFill predicate

### DIFF
--- a/src/interfaces/UBA.ts
+++ b/src/interfaces/UBA.ts
@@ -11,7 +11,7 @@ export type UbaRunningRequest = {
 };
 
 export const isUbaInflow = (flow: UbaFlow): flow is UbaInflow => {
-  return (flow as UbaInflow).quoteTimestamp !== undefined;
+  return (flow as UbaInflow)?.quoteTimestamp !== undefined;
 };
 
 export const isUbaOutflow = (flow: UbaFlow): flow is UbaOutflow => {
@@ -19,9 +19,9 @@ export const isUbaOutflow = (flow: UbaFlow): flow is UbaOutflow => {
 };
 
 export const outflowIsFill = (outflow: UbaOutflow): outflow is FillWithBlock => {
-  return (outflow as FillWithBlock).isSlowRelay !== undefined;
+  return (outflow as FillWithBlock)?.repaymentChainId !== undefined;
 };
 
 export const outflowIsRefund = (outflow: UbaOutflow): outflow is RefundRequestWithBlock => {
-  return (outflow as RefundRequestWithBlock).fillBlock !== undefined;
+  return (outflow as RefundRequestWithBlock)?.fillBlock !== undefined;
 };


### PR DESCRIPTION
isSlowRelay was an unfortunate choice, because it gets relocated as part of the new SpokePool migration. Instead, use repaymentChainId because it's unique to a fill and is not impacted by the new ABI.