### PR TITLE
fix: browser env bundle

### DIFF
--- a/src/UBAFeeCalculator/UBAFeeUtility.ts
+++ b/src/UBAFeeCalculator/UBAFeeUtility.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from "ethers";
-import { MAX_SAFE_JS_INT } from "@uma/common/dist/constants";
+import { MAX_SAFE_JS_INT } from "@uma/common/dist/Constants";
 import { toBN } from "../utils";
 
 /**

--- a/src/UBAFeeCalculator/UBAFeeUtility.ts
+++ b/src/UBAFeeCalculator/UBAFeeUtility.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from "ethers";
-import { MAX_SAFE_JS_INT } from "@uma/common";
+import { MAX_SAFE_JS_INT } from "@uma/common/dist/constants";
 import { toBN } from "../utils";
 
 /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,1 @@
-export { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "@across-protocol/contracts-v2";
+export { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "@across-protocol/contracts-v2/dist/utils/constants";

--- a/src/contracts/acrossConfigStore.ts
+++ b/src/contracts/acrossConfigStore.ts
@@ -1,5 +1,5 @@
 import { Provider } from "@ethersproject/providers";
-import { AcrossConfigStore, AcrossConfigStore__factory } from "@across-protocol/contracts-v2";
+import { AcrossConfigStore, AcrossConfigStore__factory } from "../typechain";
 import { object, string, Infer, assert, mask, record, optional } from "superstruct";
 import type { CallOverrides } from "@ethersproject/contracts";
 

--- a/src/contracts/hubPool.ts
+++ b/src/contracts/hubPool.ts
@@ -1,4 +1,4 @@
-import { HubPool, HubPool__factory, HubPoolInterface } from "@across-protocol/contracts-v2";
+import { HubPool, HubPool__factory, HubPoolInterface } from "../typechain";
 
 import type { SignerOrProvider, GetEventType, SerializableEvent } from "@uma/sdk";
 import * as uma from "@uma/sdk";

--- a/src/interfaces/Common.ts
+++ b/src/interfaces/Common.ts
@@ -1,4 +1,4 @@
-import { MerkleTree } from "@across-protocol/contracts-v2";
+import { MerkleTree } from "@across-protocol/contracts-v2/dist/utils/MerkleTree";
 import { BigNumber } from "ethers";
 
 export interface SortableEvent {

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -1,8 +1,7 @@
 import { BigNumber } from "ethers";
 import { SortableEvent } from "./Common";
 
-// TODO: see if there's a way to get typechain to directly export this event type.
-export type { FundsDepositedEvent } from "@across-protocol/contracts-v2/dist/typechain/SpokePool";
+export type { FundsDepositedEvent } from "../typechain";
 
 export interface Deposit {
   depositId: number;

--- a/src/merkleDistributor/MerkleDistributor.ts
+++ b/src/merkleDistributor/MerkleDistributor.ts
@@ -1,4 +1,4 @@
-import { MerkleTree } from "@across-protocol/contracts-v2";
+import { MerkleTree } from "@across-protocol/contracts-v2/dist/utils/MerkleTree";
 import { ethers } from "ethers";
 import { DistributionRecipientsWithProofs, DistributionRecipient } from "./model";
 

--- a/src/pool/poolClient.ts
+++ b/src/pool/poolClient.ts
@@ -15,8 +15,8 @@ import {
   AcceleratingDistributor__factory,
   MerkleDistributor,
   MerkleDistributor__factory,
-} from "@across-protocol/across-token";
-import { TypedEvent } from "@across-protocol/across-token/dist/typechain/common";
+  TypedEvent,
+} from "../typechain";
 
 const { erc20 } = uma.clients;
 const { loop } = uma.utils;

--- a/src/relayFeeCalculator/chain-queries/baseQuery.ts
+++ b/src/relayFeeCalculator/chain-queries/baseQuery.ts
@@ -1,5 +1,5 @@
-import { SpokePool, SpokePool__factory } from "@across-protocol/contracts-v2";
-import { L2Provider } from "@eth-optimism/sdk";
+import { SpokePool, SpokePool__factory } from "../../typechain";
+import { L2Provider } from "@eth-optimism/sdk/dist/interfaces/l2-provider";
 import { providers } from "ethers";
 import { Coingecko } from "../../coingecko";
 import { CHAIN_IDs } from "../../constants";

--- a/src/relayFeeCalculator/chain-queries/optimism.ts
+++ b/src/relayFeeCalculator/chain-queries/optimism.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_LOGGER, Logger } from "../relayFeeCalculator";
 import { providers } from "ethers";
 import { TOKEN_SYMBOLS_MAP } from "../../constants";
-import { asL2Provider } from "@eth-optimism/sdk";
+import { asL2Provider } from "@eth-optimism/sdk/dist/l2-provider";
 import QueryBase from "./baseQuery";
 
 export class OptimismQueries extends QueryBase {

--- a/src/transfers-history/adapters/web3/SpokePoolEventsQuerier.ts
+++ b/src/transfers-history/adapters/web3/SpokePoolEventsQuerier.ts
@@ -1,5 +1,4 @@
-import { SpokePool } from "@across-protocol/contracts-v2";
-import { TypedEvent, TypedEventFilter } from "@across-protocol/contracts-v2/dist/typechain/common";
+import { SpokePool, TypedEvent, TypedEventFilter } from "../../../typechain";
 import { getSamplesBetween } from "../../../utils";
 import { Web3Error, Web3ErrorCode } from "./model";
 import { Logger } from "../logger";

--- a/src/transfers-history/client.ts
+++ b/src/transfers-history/client.ts
@@ -3,15 +3,16 @@ import { clientConfig } from "./config";
 import { SpokePoolEventsQueryService } from "./services/SpokePoolEventsQueryService";
 import { Logger, LogLevel } from "./adapters/logger";
 import { BigNumber, providers } from "ethers";
-import { SpokePool, SpokePool__factory } from "@across-protocol/contracts-v2";
 import { ChainId } from "./adapters/web3/model";
 import { SpokePoolEventsQuerier } from "./adapters/web3";
 import { TransfersRepository } from "./adapters/db/transfers-repository";
 import {
+  SpokePool,
+  SpokePool__factory,
   FilledRelayEvent,
   FundsDepositedEvent,
   RequestedSpeedUpDepositEvent,
-} from "@across-protocol/contracts-v2/dist/typechain/ArbitrumSpokePool";
+} from "../typechain";
 import { Transfer } from "./model";
 
 export enum TransfersHistoryEvent {

--- a/src/transfers-history/services/SpokePoolEventsQueryService.ts
+++ b/src/transfers-history/services/SpokePoolEventsQueryService.ts
@@ -1,9 +1,4 @@
-import { TypedEvent } from "@across-protocol/contracts-v2/dist/typechain/common";
-import {
-  FundsDepositedEvent,
-  FilledRelayEvent,
-  RequestedSpeedUpDepositEvent,
-} from "@across-protocol/contracts-v2/dist/typechain/SpokePool";
+import { FundsDepositedEvent, FilledRelayEvent, RequestedSpeedUpDepositEvent, TypedEvent } from "../../typechain";
 import { providers } from "ethers";
 import { Logger } from "../adapters/logger";
 import { ISpokePoolContractEventsQuerier } from "../adapters/web3";

--- a/src/typechain.ts
+++ b/src/typechain.ts
@@ -1,0 +1,42 @@
+/**
+ * This file re-exports some of the typechain bindings so that they can be tree-shaken in the final frontend bundle.
+ * Currently, the packages `@across-protocol/contracts-v2` and `@across-protocol/across-token` are not optimized for tree-shaking
+ * and contain modules that are not compatible in a browser environment. This is a temporary solution until we can fix the issue upstream.
+ */
+export { AcrossMerkleDistributor__factory } from "@across-protocol/contracts-v2/dist/typechain/factories/AcrossMerkleDistributor__factory";
+export { AcrossConfigStore__factory } from "@across-protocol/contracts-v2/dist/typechain/factories/AcrossConfigStore__factory";
+export { HubPool__factory } from "@across-protocol/contracts-v2/dist/typechain/factories/HubPool__factory";
+export { SpokePool__factory } from "@across-protocol/contracts-v2/dist/typechain/factories/SpokePool__factory";
+export { ERC20__factory } from "@across-protocol/contracts-v2/dist/typechain/factories/ERC20__factory";
+
+export { AcceleratingDistributor__factory } from "@across-protocol/across-token/dist/typechain/factories/AcceleratingDistributor__factory";
+export { ClaimAndStake__factory } from "@across-protocol/across-token/dist/typechain/factories/ClaimAndStake__factory";
+export { MerkleDistributor__factory } from "@across-protocol/across-token/dist/typechain/factories/MerkleDistributor__factory";
+
+export type {
+  AcrossMerkleDistributor,
+  AcrossMerkleDistributorInterface,
+} from "@across-protocol/contracts-v2/dist/typechain/AcrossMerkleDistributor";
+export type {
+  AcrossConfigStore,
+  AcrossConfigStoreInterface,
+} from "@across-protocol/contracts-v2/dist/typechain/AcrossConfigStore";
+export type { HubPool, HubPoolInterface } from "@across-protocol/contracts-v2/dist/typechain/HubPool";
+export type {
+  SpokePool,
+  SpokePoolInterface,
+  FundsDepositedEvent,
+  FilledRelayEvent,
+  RequestedSpeedUpDepositEvent,
+} from "@across-protocol/contracts-v2/dist/typechain/SpokePool";
+export type { TypedEvent, TypedEventFilter } from "@across-protocol/contracts-v2/dist/typechain/common";
+
+export type {
+  AcceleratingDistributor,
+  AcceleratingDistributorInterface,
+} from "@across-protocol/across-token/dist/typechain/AcceleratingDistributor";
+export type { ClaimAndStake, ClaimAndStakeInterface } from "@across-protocol/across-token/dist/typechain/ClaimAndStake";
+export type {
+  MerkleDistributor,
+  MerkleDistributorInterface,
+} from "@across-protocol/across-token/dist/typechain/MerkleDistributor";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,9 @@
 import { BigNumber, ethers, PopulatedTransaction, providers, VoidSigner } from "ethers";
 import * as uma from "@uma/sdk";
 import Decimal from "decimal.js";
-import { isL2Provider as isOptimismL2Provider, L2Provider } from "@eth-optimism/sdk";
-import { SpokePool } from "@across-protocol/contracts-v2";
+import { isL2Provider as isOptimismL2Provider } from "@eth-optimism/sdk/dist/l2-provider";
+import { L2Provider } from "@eth-optimism/sdk/dist/interfaces/l2-provider";
+import { SpokePool } from "./typechain";
 import assert from "assert";
 import { GasPriceEstimate, getGasPriceEstimate } from "./gasPriceOracle";
 import { TypedMessage } from "./interfaces/TypedData";


### PR DESCRIPTION
The latest stable version 0.5.3 of the SDK fails to compile on the FE or in a browser environment with 
```
Failed to compile.

./node_modules/@across-protocol/sdk-v2/node_modules/@uma/common/dist/HardhatConfig.js
Cannot find module: 'hardhat-tracer'. Make sure this package is installed.

You can install this package by running: yarn add hardhat-tracer.
```
Or
```
Creating an optimized production build...
Failed to compile.

./node_modules/@across-protocol/contracts-v2/node_modules/hardhat/internal/util/fs-utils.js
Cannot find module: 'fs/promises'. Make sure this package is installed.

You can install this package by running: yarn add fs/promises.
```

AFAICT this is due to browser-incompatible packages (e.g. `@uma/common`, `@across-protocol/contracts-v2@^2.2.0`) that are not optimized for tree-shaking. Therefore the bundler tries to pack the whole package which contains server-only dependencies.

This PR fixes this by explicitly importing required modules so the bundler can tree-shake and ignore server-only modules. I guess at some point the upstream package should be optimized for tree-shaking and browser environments.