### PR TITLE
chore: Bump typescript ^4.6.2 => ^5.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "tsdx": "^0.14.1",
     "tslib": "^2.3.1",
     "typechain": "^7.0.1",
-    "typescript": "^4.6.2",
+    "typescript": "^5.0.4",
     "winston": "^3.8.1"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17368,10 +17368,10 @@ typescript@^3.7.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
-typescript@^4.6.2:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Aligns with current relayer-v2. nb. This is predicated on https://github.com/across-protocol/sdk-v2/pull/202 being resolved.