### PR TITLE
improve(HubPoolClient): Track deploymentBlock

### DIFF
--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -60,6 +60,7 @@ export class HubPoolClient {
   constructor(
     readonly logger: winston.Logger,
     readonly hubPool: Contract,
+    public deploymentBlock = 0,
     readonly chainId: number = 1,
     readonly eventSearchConfig: MakeOptional<EventSearchConfig, "toBlock"> = { fromBlock: 0, maxBlockLookBack: 0 },
     protected readonly configOverride: {
@@ -70,6 +71,7 @@ export class HubPoolClient {
       ignoredHubProposedBundles: [],
     }
   ) {
+    this.latestBlockNumber = deploymentBlock === 0 ? deploymentBlock : deploymentBlock - 1;
     this.firstBlockToSearch = eventSearchConfig.fromBlock;
   }
 


### PR DESCRIPTION
Also, set latestBlockNumber in the constructor. If no deploymentBlock is supplied, default to 0.

Once this is pulled into relayer-v2, we can make some follow-on adjustments there and then redefine latestBlockNumber as a number only, so callers don't need to consider the `undefined` scenario.

Fixes ACX-1048