### PR TITLE
fix: export spoke pool client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -1,2 +1,3 @@
 export { GLOBAL_CONFIG_STORE_KEYS, AcrossConfigStoreClient } from "./AcrossConfigStoreClient";
 export { HubPoolClient } from "./HubPoolClient";
+export { SpokePoolClient } from "./SpokePoolClient";


### PR DESCRIPTION
This change exports the SpokePool Client in the SDK-V2.