### PR TITLE
chore(UBA): Define HubPool TokenRunningBalance type

### DIFF
--- a/src/interfaces/HubPool.ts
+++ b/src/interfaces/HubPool.ts
@@ -50,6 +50,11 @@ export interface ExecutedRootBundle extends SortableEvent {
   proof: string[];
 }
 
+export type TokenRunningBalance = {
+  runningBalance: BigNumber;
+  incentiveBalance: BigNumber;
+};
+
 export interface RelayerRefundLeafWithGroup extends RelayerRefundLeaf {
   groupIndex: number;
 }


### PR DESCRIPTION
This is needed so that tests defined in the relayer-v2 repository can import this type and use it in tests.