### PR TITLE
refactor(utils): Migrate relayer-v2 typeguards

### DIFF
--- a/src/utils/TypeGuards.ts
+++ b/src/utils/TypeGuards.ts
@@ -1,0 +1,15 @@
+export function isPromiseFulfilled<T>(
+  promiseSettledResult: PromiseSettledResult<T>
+): promiseSettledResult is PromiseFulfilledResult<T> {
+  return promiseSettledResult.status === "fulfilled";
+}
+
+export function isPromiseRejected<T>(
+  promiseSettledResult: PromiseSettledResult<T>
+): promiseSettledResult is PromiseRejectedResult {
+  return promiseSettledResult.status === "rejected";
+}
+
+export function isDefined<T>(input: T | null | undefined): input is T {
+  return input !== null && input !== undefined;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,6 +2,7 @@ export * from "./common";
 export * from "./EventUtils";
 export * from "./ObjectUtils";
 export * from "./TimeUtils";
+export * from "./TypeGuards";
 export * from "./TypeUtils";
 export * from "./TokenUtils";
 export * from "./LogUtils";


### PR DESCRIPTION
Can reasonably foresee a need for these in the sdk-v2 repository, given some of the migrations that are occurring. Will subsequently update the relayer-v2 repository to import these after bumping the SDK version.

Copied from https://github.com/across-protocol/relayer-v2/blob/master/src/utils/TypeGuards.ts