### PR TITLE
chore: bump contracts version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.6.1",
+  "version": "0.6.3",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -22,7 +22,10 @@
     "lint-check": "eslint src",
     "prepare": "tsdx build && husky install",
     "size": "size-limit",
-    "analyze": "size-limit --why"
+    "analyze": "size-limit --why",
+    "bump-version:major": "yarn version --major --no-git-tag-version --no-commit-hooks",
+    "bump-version:minor": "yarn version --minor --no-git-tag-version --no-commit-hooks",
+    "bump-version:patch": "yarn version --patch --no-git-tag-version --no-commit-hooks"
   },
   "lint-staged": {
     "*.ts": "yarn lint"
@@ -71,7 +74,7 @@
   },
   "dependencies": {
     "@across-protocol/across-token": "^1.0.0",
-    "@across-protocol/contracts-v2": "2.2.2",
+    "@across-protocol/contracts-v2": "2.2.3",
     "@eth-optimism/sdk": "^1.6.0",
     "@uma/financial-templates-lib": "^2.32.11",
     "@uma/sdk": "^0.34.1",

--- a/src/transfers-history/adapters/web3/SpokePoolEventsQuerier.ts
+++ b/src/transfers-history/adapters/web3/SpokePoolEventsQuerier.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { SpokePool, TypedEvent, TypedEventFilter } from "../../../typechain";
 import { getSamplesBetween } from "../../../utils";
 import { Web3Error, Web3ErrorCode } from "./model";
@@ -86,11 +87,7 @@ export class SpokePoolEventsQuerier implements ISpokePoolContractEventsQuerier {
     return this.spokePool.filters.RequestedSpeedUpDeposit();
   }
 
-  private async getEvents(
-    from: number,
-    to: number,
-    filters: TypedEventFilter<TypedEvent<any>[], any>
-  ): Promise<TypedEvent<any>[]> {
+  private async getEvents(from: number, to: number, filters: TypedEventFilter<TypedEvent>): Promise<TypedEvent<any>[]> {
     let events: TypedEvent<any>[] = [];
     let retryWithLowerBatchSize;
 

--- a/src/typechain.ts
+++ b/src/typechain.ts
@@ -3,11 +3,11 @@
  * Currently, the packages `@across-protocol/contracts-v2` and `@across-protocol/across-token` are not optimized for tree-shaking
  * and contain modules that are not compatible in a browser environment. This is a temporary solution until we can fix the issue upstream.
  */
-export { AcrossMerkleDistributor__factory } from "@across-protocol/contracts-v2/dist/typechain/factories/AcrossMerkleDistributor__factory";
-export { AcrossConfigStore__factory } from "@across-protocol/contracts-v2/dist/typechain/factories/AcrossConfigStore__factory";
-export { HubPool__factory } from "@across-protocol/contracts-v2/dist/typechain/factories/HubPool__factory";
-export { SpokePool__factory } from "@across-protocol/contracts-v2/dist/typechain/factories/SpokePool__factory";
-export { ERC20__factory } from "@across-protocol/contracts-v2/dist/typechain/factories/ERC20__factory";
+export { AcrossMerkleDistributor__factory } from "@across-protocol/contracts-v2/dist/typechain/factories/contracts/merkle-distributor/AcrossMerkleDistributor__factory";
+export { AcrossConfigStore__factory } from "@across-protocol/contracts-v2/dist/typechain/factories/contracts/AcrossConfigStore__factory";
+export { HubPool__factory } from "@across-protocol/contracts-v2/dist/typechain/factories/contracts/HubPool__factory";
+export { SpokePool__factory } from "@across-protocol/contracts-v2/dist/typechain/factories/contracts/SpokePool.sol/SpokePool__factory";
+export { ERC20__factory } from "@across-protocol/contracts-v2";
 
 export { AcceleratingDistributor__factory } from "@across-protocol/across-token/dist/typechain/factories/AcceleratingDistributor__factory";
 export { ClaimAndStake__factory } from "@across-protocol/across-token/dist/typechain/factories/ClaimAndStake__factory";
@@ -16,19 +16,19 @@ export { MerkleDistributor__factory } from "@across-protocol/across-token/dist/t
 export type {
   AcrossMerkleDistributor,
   AcrossMerkleDistributorInterface,
-} from "@across-protocol/contracts-v2/dist/typechain/AcrossMerkleDistributor";
+} from "@across-protocol/contracts-v2/dist/typechain/contracts/merkle-distributor/AcrossMerkleDistributor";
 export type {
   AcrossConfigStore,
   AcrossConfigStoreInterface,
-} from "@across-protocol/contracts-v2/dist/typechain/AcrossConfigStore";
-export type { HubPool, HubPoolInterface } from "@across-protocol/contracts-v2/dist/typechain/HubPool";
+} from "@across-protocol/contracts-v2/dist/typechain/contracts/AcrossConfigStore";
+export type { HubPool, HubPoolInterface } from "@across-protocol/contracts-v2/dist/typechain/contracts/HubPool";
 export type {
   SpokePool,
   SpokePoolInterface,
   FundsDepositedEvent,
   FilledRelayEvent,
   RequestedSpeedUpDepositEvent,
-} from "@across-protocol/contracts-v2/dist/typechain/SpokePool";
+} from "@across-protocol/contracts-v2/dist/typechain/contracts/SpokePool.sol/SpokePool";
 export type { TypedEvent, TypedEventFilter } from "@across-protocol/contracts-v2/dist/typechain/common";
 
 export type {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,13 +11,15 @@
     "@uma/common" "^2.17.0"
     hardhat "^2.9.3"
 
-"@across-protocol/contracts-v2@2.2.2":
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/@across-protocol/contracts-v2/-/contracts-v2-2.2.2.tgz#ff7684317e93678c88f440eca9e7d398bfbd485a"
-  integrity sha512-y4ouHyRafRv/+L3CgvYE4V4CFWgK9Qm7cOSVusc+l1XTlgdRNgh0JIA41fXE6pG7eu+V6GmayMSUO9tAbH9QDA==
+"@across-protocol/contracts-v2@2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@across-protocol/contracts-v2/-/contracts-v2-2.2.3.tgz#c3df3f8f60910fe6b6dfce32a7e1a224aa1a0396"
+  integrity sha512-JwYiNTLMRIjVcgm01GLMfra3x+pTPTtfdplpJ5DhLXbdin6LEirv7gwAOhykAG8rqYQcWbnwXuBxmWMM/4QY7g==
   dependencies:
     "@defi-wonderland/smock" "^2.3.4"
-    "@eth-optimism/contracts" "^0.5.11"
+    "@eth-optimism/contracts" "^0.5.40"
+    "@ethersproject/abstract-provider" "5.7.0"
+    "@ethersproject/abstract-signer" "5.7.0"
     "@openzeppelin/contracts" "4.8.3"
     "@openzeppelin/contracts-upgradeable" "4.8.3"
     "@uma/common" "^2.29.0"
@@ -1106,7 +1108,7 @@
     ethers "^5.7.0"
     hardhat "^2.9.6"
 
-"@eth-optimism/contracts@0.5.37", "@eth-optimism/contracts@^0.5.11", "@eth-optimism/contracts@^0.5.37", "@eth-optimism/contracts@^0.5.5":
+"@eth-optimism/contracts@0.5.37", "@eth-optimism/contracts@^0.5.37", "@eth-optimism/contracts@^0.5.5":
   version "0.5.37"
   resolved "https://registry.yarnpkg.com/@eth-optimism/contracts/-/contracts-0.5.37.tgz#3aaca1ca1f49ef895d4165cc7bf29c8d1f5b0f56"
   integrity sha512-HbNUUDIM1dUAM0hWPfGp3l9/Zte40zi8QhVbUSIwdYRA7jG7cZgbteqavrjW8wwFqxkWX9IrtA0KAR7pNlSAIQ==
@@ -1115,10 +1117,41 @@
     "@ethersproject/abstract-provider" "^5.7.0"
     "@ethersproject/abstract-signer" "^5.7.0"
 
+"@eth-optimism/contracts@^0.5.40":
+  version "0.5.40"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/contracts/-/contracts-0.5.40.tgz#d13a04a15ea947a69055e6fc74d87e215d4c936a"
+  integrity sha512-MrzV0nvsymfO/fursTB7m/KunkPsCndltVgfdHaT1Aj5Vi6R/doKIGGkOofHX+8B6VMZpuZosKCMQ5lQuqjt8w==
+  dependencies:
+    "@eth-optimism/core-utils" "0.12.0"
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+
 "@eth-optimism/core-utils@0.10.1", "@eth-optimism/core-utils@^0.10.1":
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/@eth-optimism/core-utils/-/core-utils-0.10.1.tgz#44515fbca627532a24c6fd433395f00be8525832"
   integrity sha512-IJvG5UtYvyz6An9QdohlCLoeB3NBFxx2lRJKlPzvYYlfugUNNCHsajRIWIwJTcPRRma0WPd46JUsKACLJDdNrA==
+  dependencies:
+    "@ethersproject/abi" "^5.7.0"
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/contracts" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/providers" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/web" "^5.7.0"
+    bufio "^1.0.7"
+    chai "^4.3.4"
+
+"@eth-optimism/core-utils@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/core-utils/-/core-utils-0.12.0.tgz#6337e4599a34de23f8eceb20378de2a2de82b0ea"
+  integrity sha512-qW+7LZYCz7i8dRa7SRlUKIo1VBU8lvN0HeXCxJR+z+xtMzMQpPds20XJNCMclszxYQHkXY00fOT6GvFw9ZL6nw==
   dependencies:
     "@ethersproject/abi" "^5.7.0"
     "@ethersproject/abstract-provider" "^5.7.0"


### PR DESCRIPTION
This PR bumps the `@across-protocol/contracts-v2` version to the latest version. To accomplish this, several typechain imports needed to be made. 

Three scripts have been added to let the package.json version be upgraded in a more convenient manner.