### PR TITLE
refactor(ConfigStoreClient): Backport relayer-v2 modifications

### DIFF
--- a/src/clients/mocks/MockConfigStoreClient.ts
+++ b/src/clients/mocks/MockConfigStoreClient.ts
@@ -1,0 +1,14 @@
+import { DEFAULT_CONFIG_STORE_VERSION } from "../../utils";
+import { AcrossConfigStoreClient } from "../AcrossConfigStoreClient";
+
+export class MockConfigStoreClient extends AcrossConfigStoreClient {
+  public configStoreVersion = DEFAULT_CONFIG_STORE_VERSION;
+
+  setConfigStoreVersion(version: number): void {
+    this.configStoreVersion = version;
+  }
+
+  isValidConfigStoreVersion(_version: number): boolean {
+    return this.configStoreVersion >= _version;
+  }
+}

--- a/src/clients/mocks/index.ts
+++ b/src/clients/mocks/index.ts
@@ -1,2 +1,3 @@
+export * from "./MockConfigStoreClient";
 export * from "./MockHubPoolClient";
 export * from "./MockSpokePoolClient";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,9 @@
 export { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "@across-protocol/contracts-v2/dist/utils/constants";
 export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+// This list contains all chains that Across supports, although some of the chains could be currently disabled.
+// The order of the chains is important to not change, as the dataworker proposes "bundle block numbers" per chain
+// in the same order as the following list. To add a new chain ID, append it to the end of the list. Never delete
+// a chain ID. The on-chain ConfigStore should store a list of enabled/disabled chain ID's that are a subset
+// of this list, so this list is simply the list of all possible Chain ID's that Across could support.
+export const CHAIN_ID_LIST_INDICES = [1, 10, 137, 288, 42161];

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -14,8 +14,11 @@ export type Decimalish = string | number | Decimal;
 export const AddressZero = ethers.constants.AddressZero;
 export const MAX_BIG_INT = BigNumber.from(Number.MAX_SAFE_INTEGER.toString());
 
-// Used as a signal to protect relayers from running code against an outdated version of the on-chain config store.
+// Used as a signal to protect bots from running code against an outdated version of the on-chain config store.
 export const CONFIG_STORE_VERSION = 1;
+
+// Version 0 is the implicit version before the config store version was introduced. Required by the ConfigStoreClient.
+export const DEFAULT_CONFIG_STORE_VERSION = 0; // **Do not change this value.**
 
 const { ConvertDecimals } = uma.utils;
 // These are distances used to traverse when looking for a block with desired lookback.


### PR DESCRIPTION
This change backports some relayer-v2 ConfigStoreClient customisations to the sdk-v2 repository. No behaviour is changed, though there is a small tweak in the way the ConfigStoreClient is instantiated. As part of this, also migrate some constants from relayer-v2, which are anyway more at home in sdk-v2.