### PR TITLE
fix: Remove off-by-one error in SpokePoolClient

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -420,7 +420,7 @@ export class SpokePoolClient {
     });
 
     const timerStart = Date.now();
-    const [latestDepositId, currentTime, ...events] = await Promise.all([
+    const [numberOfDeposits, currentTime, ...events] = await Promise.all([
       this.spokePool.numberOfDeposits({ blockTag: searchConfig.toBlock }),
       this.spokePool.getCurrentTime({ blockTag: searchConfig.toBlock }),
       ...eventSearchConfigs.map((config) => paginatedEventQuery(this.spokePool, config.filter, config.searchConfig)),
@@ -442,7 +442,7 @@ export class SpokePoolClient {
       currentTime: currentTime.toNumber(), // uint32
       firstDepositId,
       latestBlockNumber,
-      latestDepositId,
+      latestDepositId: Math.max(0, numberOfDeposits - 1),
       searchEndBlock: searchConfig.toBlock,
       events,
     };

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -442,7 +442,7 @@ export class SpokePoolClient {
       currentTime: currentTime.toNumber(), // uint32
       firstDepositId,
       latestBlockNumber,
-      latestDepositId: Math.max(0, numberOfDeposits - 1),
+      latestDepositId: Math.max(numberOfDeposits - 1, 0),
       searchEndBlock: searchConfig.toBlock,
       events,
     };


### PR DESCRIPTION
The SpokePool "numberOfDeposits" state variable is the depositId of the _next_
deposit to be confirmed; not the last one.

I'm not aware of any cases where this has caused an error, but the bots sometimes
log that they can't find a specific deposit during periods of RPC instability. Fixing
this allows us to rule it out as a potential error source.