### PR TITLE
improve(Error): Support nested Ethers Errors

### DIFF
--- a/src/interfaces/Error.ts
+++ b/src/interfaces/Error.ts
@@ -1,4 +1,5 @@
 export type EthersError = Error & {
   code: string;
   reason: string;
+  error?: Error;
 };


### PR DESCRIPTION
This borrows from ethers v6, where the EthersError type is defined as having an optional error member. v5 typically does the same thing, by nesting errors, though without explicitly defining the EthersError type.

Sourced from (as at 026c5bb13724756f8ae5c64a0692789c1e27361c):
  https://github.com/ethers-io/ethers.js/blob/main/src.ts/utils/errors.ts#L156