### PR TITLE
fix(mock): Don't override generated fill destinationToken

### DIFF
--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -2,6 +2,7 @@ import { Contract, Event } from "ethers";
 import { random } from "lodash";
 import winston from "winston";
 import { randomAddress } from "@across-protocol/contracts-v2/dist/test-utils";
+import { ZERO_ADDRESS } from "../../constants";
 import { DepositWithBlock, FillWithBlock, RefundRequestWithBlock } from "../../interfaces";
 import { toBN, toBNWei } from "../../utils";
 import { SpokePoolClient, SpokePoolUpdate } from "../SpokePoolClient";
@@ -149,7 +150,7 @@ export class MockSpokePoolClient extends SpokePoolClient {
       realizedLpFeePct: fill.realizedLpFeePct ?? toBNWei(random(0.00001, 0.0001).toPrecision(6)),
       relayerFeePct,
       depositId,
-      destinationToken: randomAddress(),
+      destinationToken: fill.destinationToken ?? ZERO_ADDRESS, // resolved via HubPoolClient.
       relayer: fill.relayer ?? randomAddress(),
       depositor,
       recipient,


### PR DESCRIPTION
The SpokePoolClient tries to resolve the destinationToken against the set of known tokens in the HubPoolClient, so it's important to propagate the value supplied by the caller. If no value has been supplied, sub in the ZERO_ADDRESS, because this is what the SpokePoolClient resolves when it has no reference for the HubPoolClient.

In the mean time, there are workarounds in some relayer-v2 tests to plaster over the issue. They will be fixed once this change migrates back to relayer-v2 via an sdk-v2 bump.