### PR TITLE
fix: Revert to legacy gas pricing for Arbitrum

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/gasPriceOracle/adapters/index.ts
+++ b/src/gasPriceOracle/adapters/index.ts
@@ -1,2 +1,2 @@
-export * from "./eip1559";
+export * from "./ethereum";
 export * from "./polygon";

--- a/src/gasPriceOracle/oracle.e2e.ts
+++ b/src/gasPriceOracle/oracle.e2e.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import dotenv from "dotenv";
 import winston from "winston";
 import { BigNumber, providers } from "ethers";
-import { GasPriceEstimate, getGasPriceEstimate } from "./oracle";
+import { GasPriceEstimate, getGasPriceEstimate } from "./";
 dotenv.config({ path: ".env" });
 
 const dummyLogger = winston.createLogger({

--- a/src/gasPriceOracle/oracle.ts
+++ b/src/gasPriceOracle/oracle.ts
@@ -25,7 +25,7 @@ export async function getGasPriceEstimate(
     10: eip1559,
     137: polygonGasStation,
     288: legacy,
-    42161: eip1559,
+    42161: legacy,
   };
 
   let gasPriceFeed: GasPriceFeed = gasPriceFeeds[chainId];


### PR DESCRIPTION
Ethers hardcodes a price of 1.5 Gwei for the priority fee. On Arbitrum, the priority fee is refunded to the caller, so it doesn't makse sense to use that in gas computations since it results in over-estimation.