### PR TITLE
fix(gasPriceOracle): Assorted fixes

### DIFF
--- a/src/gasPriceOracle/adapters/arbitrum.ts
+++ b/src/gasPriceOracle/adapters/arbitrum.ts
@@ -1,0 +1,21 @@
+import { BigNumber, providers, utils as ethersUtils } from "ethers";
+import { GasPriceEstimate } from "../types";
+import { eip1559 } from "./ethereum";
+
+// Arbitrum Nitro implements EIP-1559 pricing, but the priority fee is always refunded to the caller. Further,
+// ethers typically hardcodes the priority fee to 1.5 Gwei. So, confirm that the priority fee supplied was 1.5
+// Gwei, and then drop it to 1 Wei. Reference: https://developer.arbitrum.io/faqs/gas-faqs#q-priority
+export async function eip1559_arbitrum(provider: providers.Provider, chainId: number): Promise<GasPriceEstimate> {
+  const { maxFeePerGas: _maxFeePerGas, maxPriorityFeePerGas } = await eip1559(provider, chainId);
+
+  // If this throws, ethers default behaviour has changed, or Arbitrum RPCs are returning something more sensible.
+  if (!maxPriorityFeePerGas.eq(ethersUtils.parseUnits("1.5", 9))) {
+    throw new Error(`Expected hardcoded 1.5 Gwei priority fee on Arbitrum, got ${maxPriorityFeePerGas}`);
+  }
+
+  // eip1559() sets maxFeePerGas = lastBaseFeePerGas + maxPriorityFeePerGas, so revert that.
+  // The caller may apply scaling as they wish afterwards.
+  const maxFeePerGas = _maxFeePerGas.sub(maxPriorityFeePerGas).add(1);
+
+  return { maxPriorityFeePerGas: BigNumber.from(1), maxFeePerGas };
+}

--- a/src/gasPriceOracle/adapters/ethereum.ts
+++ b/src/gasPriceOracle/adapters/ethereum.ts
@@ -3,7 +3,7 @@ import { GasPriceEstimate } from "../types";
 import { gasPriceError } from "../util";
 
 export async function eip1559(provider: providers.Provider, chainId: number): Promise<GasPriceEstimate> {
-  const feeData: providers.FeeData = await provider.getFeeData();
+  const feeData = await provider.getFeeData();
 
   [feeData.lastBaseFeePerGas, feeData.maxPriorityFeePerGas].forEach((field: BigNumber | null) => {
     if (!BigNumber.isBigNumber(field) || field.lt(0)) gasPriceError("getFeeData()", chainId, feeData);
@@ -12,10 +12,7 @@ export async function eip1559(provider: providers.Provider, chainId: number): Pr
   const maxPriorityFeePerGas = feeData.maxPriorityFeePerGas as BigNumber;
   const maxFeePerGas = maxPriorityFeePerGas.add(feeData.lastBaseFeePerGas as BigNumber);
 
-  return {
-    maxPriorityFeePerGas: maxPriorityFeePerGas,
-    maxFeePerGas: maxFeePerGas,
-  };
+  return { maxPriorityFeePerGas, maxFeePerGas };
 }
 
 export async function legacy(provider: providers.Provider, chainId: number): Promise<GasPriceEstimate> {

--- a/src/gasPriceOracle/adapters/index.ts
+++ b/src/gasPriceOracle/adapters/index.ts
@@ -1,2 +1,3 @@
 export * from "./ethereum";
+export * from "./arbitrum";
 export * from "./polygon";

--- a/src/gasPriceOracle/adapters/polygon.ts
+++ b/src/gasPriceOracle/adapters/polygon.ts
@@ -29,7 +29,7 @@ type GasStationArgs = BaseHTTPAdapterArgs & {
 class PolygonGasStation extends BaseHTTPAdapter {
   readonly chainId: number;
 
-  constructor({ chainId = 137, host, timeout = 3000, retries = 2 }: GasStationArgs = {}) {
+  constructor({ chainId = 137, host, timeout = 1500, retries = 1 }: GasStationArgs = {}) {
     host = host ?? chainId === 137 ? "gasstation.polygon.technology" : "gasstation-testnet.polygon.technology";
 
     super("Polygon Gas Station", host, { timeout, retries });
@@ -37,7 +37,7 @@ class PolygonGasStation extends BaseHTTPAdapter {
   }
 
   async getFeeData(strategy: "safeLow" | "standard" | "fast" = "fast"): Promise<GasPriceEstimate> {
-    const gas = await this.query("/v2", {});
+    const gas = await this.query("v2", {});
 
     const gasPrice: Polygon1559GasPrice = (gas as GasStationV2Response)?.[strategy];
     if (!this.isPolygon1559GasPrice(gasPrice)) {

--- a/src/gasPriceOracle/oracle.ts
+++ b/src/gasPriceOracle/oracle.ts
@@ -1,6 +1,5 @@
 import { providers } from "ethers";
-import { eip1559, legacy } from "./adapters/ethereum";
-import { polygonGasStation } from "./adapters/polygon";
+import { eip1559, eip1559_arbitrum, legacy, polygonGasStation } from "./adapters";
 import { GasPriceEstimate, GasPriceFeed } from "./types";
 
 /**
@@ -25,7 +24,7 @@ export async function getGasPriceEstimate(
     10: eip1559,
     137: polygonGasStation,
     288: legacy,
-    42161: legacy,
+    42161: eip1559_arbitrum,
   };
 
   let gasPriceFeed: GasPriceFeed = gasPriceFeeds[chainId];


### PR DESCRIPTION
I found several issues in the gasPriceOracle:
- Polygon gas station lookups are failing because the request resolves to <domain>//v2 instead of <domain>/v2. Polygon don't automatically squash the additional / characters, and instead respond with a 404. This hasn't impacted service because the adapter falls back to an on- chain price lookup, but it delays gas price resolution and probably gives less accurate results.

- After resolving the gas station issue, the oracle.e2e test needed fixing because the Polygon adapter no longer returns mocked gas prices.

- As part of the updates to the oracle.e2e test, I realised that the use of assert.ok() is node-specific and seems irrelevant to jest. So, use expect() instead. This makes the tests a bit more compact and easier to read.

Additionally:
- An Arbitrum-specific adapter has been added that effectively nulifieies the priority fee. It's set to 1 Wei because a priority fee of 0 Wei is used to signal a legacy (type 0) transaction.

- As part of this change I have also updated the RPC list used when local RPCs are not defined. These are the current high-performing publicly availably RPCs, as reported by chainlist.org.