### PR TITLE
chore(UBA): Export UBA fee calculator types

### DIFF
--- a/src/clients/UBAClient/index.ts
+++ b/src/clients/UBAClient/index.ts
@@ -1,2 +1,3 @@
+export { UBAActionType } from "../../UBAFeeCalculator/UBAFeeTypes";
 export { UBAClientManual } from "./UBAClientWithManual";
 export { UBAClientWithRefresh as UBAClient } from "./UBAClientWithRefresh";


### PR DESCRIPTION
Necessary for external users now that the UBAClient exposes public methods that require this type as an input.

Note: I exported this directly from the UBAClient directory because the user of the UBAClient should be able to import everything it needs from that directory. But we might want to do a little re-org to make sure that the type itself is defined in the right place. @james-a-morris I assume you'll have an idea about how to do it nicely.