### PR TITLE
fix: remove contracts-v2 test utils dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/clients/mocks/MockEvents.ts
+++ b/src/clients/mocks/MockEvents.ts
@@ -1,7 +1,6 @@
 import { utils as ethersUtils, Event, providers } from "ethers";
 import { random } from "lodash";
-import { randomAddress } from "@across-protocol/contracts-v2/dist/test-utils";
-import { toBN } from "../../utils";
+import { toBN, randomAddress } from "../../utils";
 
 const { id, keccak256, toUtf8Bytes } = ethersUtils;
 

--- a/src/clients/mocks/MockHubPoolClient.ts
+++ b/src/clients/mocks/MockHubPoolClient.ts
@@ -1,7 +1,7 @@
 import { BigNumber, Contract, Event } from "ethers";
 import { random } from "lodash";
 import winston from "winston";
-import { randomAddress } from "@across-protocol/contracts-v2/dist/test-utils";
+import { randomAddress } from "../../utils";
 import { Deposit, L1Token, PendingRootBundle } from "../../interfaces";
 import { AcrossConfigStoreClient as ConfigStoreClient } from "../AcrossConfigStoreClient";
 import { HubPoolClient, HubPoolUpdate } from "../HubPoolClient";

--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -1,10 +1,9 @@
 import { Contract, Event } from "ethers";
 import { random } from "lodash";
 import winston from "winston";
-import { randomAddress } from "@across-protocol/contracts-v2/dist/test-utils";
 import { ZERO_ADDRESS } from "../../constants";
 import { DepositWithBlock, FillWithBlock, RefundRequestWithBlock } from "../../interfaces";
-import { toBN, toBNWei } from "../../utils";
+import { toBN, toBNWei, randomAddress } from "../../utils";
 import { SpokePoolClient, SpokePoolUpdate } from "../SpokePoolClient";
 import { EventManager } from "./MockEvents";
 

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -448,3 +448,7 @@ export function getUpdateDepositTypedData(
     },
   };
 }
+
+export function randomAddress() {
+  return ethers.utils.getAddress(ethers.utils.hexlify(ethers.utils.randomBytes(20)));
+}


### PR DESCRIPTION
Unfortunately, the import path `@across-protocol/contracts-v2/dist/test-utils` also breaks the frontend. Because we import only a simple utility from there, I copy-pasted it to the local utils file.