### PR TITLE
improve(SpokePoolClient): Add repaymentChainId to RefundRequest objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -574,8 +574,12 @@ export class SpokePoolClient {
           earliestEvent: refundRequests[0].blockNumber,
         });
       }
+      // repaymentChainId is not part of the on-chain event, so add it here.
       for (const refundRequest of refundRequests) {
-        this.refundRequests.push(spreadEventWithBlockNumber(refundRequest) as RefundRequestWithBlock);
+        this.refundRequests.push({
+          ...spreadEventWithBlockNumber(refundRequest),
+          repaymentChainId: this.chainId,
+        } as RefundRequestWithBlock);
       }
     }
 

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -90,6 +90,7 @@ export interface RefundRequest {
   amount: BigNumber;
   originChainId: number;
   destinationChainId: number;
+  repaymentChainId: number;
   realizedLpFeePct: BigNumber;
   depositId: number;
   fillBlock: BigNumber;

--- a/src/interfaces/UBA.test.ts
+++ b/src/interfaces/UBA.test.ts
@@ -63,6 +63,7 @@ const sampleRefundRequest = {
   realizedLpFeePct: toBNWei(0.0001),
   fillBlock: toBN(random(1, 1000, false)),
   previousIdenticalRequests: toBN(0),
+  repaymentChainId: 137,
 };
 
 describe("UBA Interface", function () {

--- a/src/interfaces/UBA.ts
+++ b/src/interfaces/UBA.ts
@@ -14,7 +14,7 @@ export const isUbaOutflow = (flow: UbaFlow): flow is UbaOutflow => {
 };
 
 export const outflowIsFill = (outflow: UbaOutflow): outflow is FillWithBlock => {
-  return (outflow as FillWithBlock)?.repaymentChainId !== undefined;
+  return (outflow as FillWithBlock)?.updatableRelayData !== undefined;
 };
 
 export const outflowIsRefund = (outflow: UbaOutflow): outflow is RefundRequestWithBlock => {


### PR DESCRIPTION
The chain ID of the SpokePool where the RefundRequest event was emitted is not part of the event itself, so append it here. This is useful for filtering further up in the stack.