### PR TITLE
fix(UBA): Fix RefundRequest validation

### DIFF
--- a/src/clients/UBAClient/UBAClientBase.ts
+++ b/src/clients/UBAClient/UBAClientBase.ts
@@ -1,10 +1,9 @@
 import winston from "winston";
-import { RefundRequestWithBlock, UbaFlow } from "../../interfaces";
+import { UbaFlow } from "../../interfaces";
 import { BigNumber } from "ethers";
 import { UBAActionType } from "../../UBAFeeCalculator/UBAFeeTypes";
 import {
   OpeningBalanceReturnType,
-  RequestValidReturnType,
   BalancingFeeReturnType,
   SystemFeeResult,
   RelayerFeeResult,
@@ -156,36 +155,6 @@ export abstract class BaseUBAClient {
           (fromBlock === undefined || flow.blockNumber >= fromBlock) &&
           (toBlock === undefined || flow.blockNumber <= toBlock)
       );
-  }
-
-  /**
-   * @description Evaluate an RefundRequest object for validity.
-   * @dev  Callers should evaluate 'valid' before 'reason' in the return object.
-   * @dev  The following RefundRequest attributes are not evaluated for validity and should be checked separately:
-   * @dev  - previousIdenticalRequests
-   * @dev  - Age of blockNumber (i.e. according to SpokePool finality)
-   * @param chainId       ChainId of SpokePool where refundRequest originated.
-   * @param refundRequest RefundRequest object to be evaluated for validity.
-   */
-  public refundRequestIsValid(chainId: number, refundRequest: RefundRequestWithBlock): RequestValidReturnType {
-    const result = this.getFlows(chainId, refundRequest.refundToken).some((flow) => {
-      return (
-        flow.logIndex == refundRequest.logIndex &&
-        flow.blockNumber == refundRequest.blockNumber &&
-        flow.transactionHash == refundRequest.transactionHash &&
-        flow.transactionIndex == refundRequest.transactionIndex
-      );
-    });
-    if (!result) {
-      return {
-        valid: false,
-        reason: "RefundRequest is not a valid flow because it didn't appear in the list of validated flows.",
-      };
-    } else {
-      return {
-        valid: true,
-      };
-    }
   }
 
   /**

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -401,9 +401,9 @@ async function getFlows(
     return validWithinBounds || hasMatchingDeposit;
   });
 
-  const refundRequests: UbaFlow[] = spokePoolClient
-    .getRefundRequests(fromBlock, toBlock)
-    .filter(async (refundRequest) => {
+  const refundRequests: UbaFlow[] = await filterAsync(
+    spokePoolClient.getRefundRequests(fromBlock, toBlock),
+    async (refundRequest) => {
       const result = await refundRequestIsValid(chainIdIndices, spokePoolClients, hubPoolClient, refundRequest);
       if (!result.valid && logger !== undefined) {
         logger.info({

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -401,19 +401,21 @@ async function getFlows(
     return validWithinBounds || hasMatchingDeposit;
   });
 
-  const refundRequests: UbaFlow[] = spokePoolClient.getRefundRequests(fromBlock, toBlock).filter((refundRequest) => {
-    const result = refundRequestIsValid(chainId, chainIdIndices, spokePoolClients, hubPoolClient, refundRequest);
-    if (!result.valid && logger !== undefined) {
-      logger.info({
-        at: "UBAClient::getFlows",
-        message: `Excluding RefundRequest on chain ${chainId}`,
-        reason: result.reason,
-        refundRequest,
-      });
-    }
+  const refundRequests: UbaFlow[] = spokePoolClient
+    .getRefundRequests(fromBlock, toBlock)
+    .filter(async (refundRequest) => {
+      const result = await refundRequestIsValid(chainIdIndices, spokePoolClients, hubPoolClient, refundRequest);
+      if (!result.valid && logger !== undefined) {
+        logger.info({
+          at: "UBAClient::getFlows",
+          message: `Excluding RefundRequest on chain ${chainId}`,
+          reason: result.reason,
+          refundRequest,
+        });
+      }
 
-    return result.valid;
-  });
+      return result.valid;
+    });
 
   // This is probably more expensive than we'd like... @todo: optimise.
   const flows = sortEventsAscending(deposits.concat(fills).concat(refundRequests));
@@ -430,32 +432,38 @@ async function getFlows(
  * @param refundRequest The refund request to validate
  * @returns Whether or not the refund request is valid
  */
-function refundRequestIsValid(
-  chainId: number,
+async function refundRequestIsValid(
   chainIdIndices: number[],
   spokePoolClients: SpokePoolClients,
   hubPoolClient: HubPoolClient,
   refundRequest: RefundRequestWithBlock
-): RequestValidReturnType {
-  const { relayer, amount, refundToken, depositId, originChainId, destinationChainId, realizedLpFeePct, fillBlock } =
-    refundRequest;
+): Promise<RequestValidReturnType> {
+  const {
+    relayer,
+    amount,
+    refundToken,
+    depositId,
+    originChainId,
+    destinationChainId,
+    repaymentChainId,
+    realizedLpFeePct,
+    fillBlock,
+  } = refundRequest;
 
   if (!chainIdIndices.includes(originChainId)) {
     return { valid: false, reason: "Invalid originChainId" };
   }
-  const originSpoke = spokePoolClients[originChainId];
 
-  if (!chainIdIndices.includes(destinationChainId) || destinationChainId === chainId) {
+  if (!chainIdIndices.includes(destinationChainId) || destinationChainId === repaymentChainId) {
     return { valid: false, reason: "Invalid destinationChainId" };
   }
   const destSpoke = spokePoolClients[destinationChainId];
 
   if (fillBlock.lt(destSpoke.deploymentBlock) || fillBlock.gt(destSpoke.latestBlockNumber)) {
+    const { deploymentBlock, latestBlockNumber } = destSpoke;
     return {
       valid: false,
-      reason:
-        `FillBlock (${fillBlock} out of SpokePool range` +
-        ` [${destSpoke.deploymentBlock}, ${destSpoke.latestBlockNumber}]`,
+      reason: `FillBlock (${fillBlock} out of SpokePool range [${deploymentBlock}, ${latestBlockNumber}]`,
     };
   }
 
@@ -475,7 +483,7 @@ function refundRequestIsValid(
     return { valid: false, reason: "Unable to find matching fill" };
   }
 
-  const deposit = originSpoke.getDepositForFill(fill);
+  const deposit = await resolveCorrespondingDepositForFill(fill, spokePoolClients);
   if (!isDefined(deposit)) {
     return { valid: false, reason: "Unable to find matching deposit" };
   }
@@ -485,7 +493,7 @@ function refundRequestIsValid(
   // @todo: Resolve to the HubPool block number at the time of the RefundRequest ?
   const hubPoolBlockNumber = hubPoolClient.latestBlockNumber ?? hubPoolClient.deploymentBlock - 1;
   try {
-    hubPoolClient.getL1TokenCounterpartAtBlock(chainId, refundToken, hubPoolBlockNumber);
+    hubPoolClient.getL1TokenCounterpartAtBlock(repaymentChainId, refundToken, hubPoolBlockNumber);
   } catch {
     return { valid: false, reason: `Refund token unknown at HubPool block ${hubPoolBlockNumber}` };
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,7 @@
 export * from "./common";
+export * from "./DepositUtils";
 export * from "./EventUtils";
+export * from "./FillUtils";
 export * from "./ObjectUtils";
 export * from "./TimeUtils";
 export * from "./TypeGuards";


### PR DESCRIPTION
Refund Request validation has been wrong since it was first added, because it relied on the deposits having previously been validated, and that wasn't the case. It also needs to be async because it must be able to search for old fills and deposits via an RPC provider.

While here, remove refundRequestIsValid() from UBAClientBase because it's unlikely to be used in its current form, and refund request validation belongs between the UBAClient and SpokePoolClients.