### PR TITLE
Fix: Utils exports

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,5 @@
 export * from "./common";
-export * from "./DepositUtils";
 export * from "./EventUtils";
-export * from "./FillUtils";
 export * from "./ObjectUtils";
 export * from "./TimeUtils";
 export * from "./TypeGuards";


### PR DESCRIPTION
The error was caused by unfortunate timing on the merging of the previous two commits.