### PR TITLE
improve: Add general getFills() and getRefundRequest() helpers

### DIFF
--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -532,10 +532,6 @@ export async function getFills(
   const { originChainId, repaymentChainId, relayer, isSlowRelay, fromBlock } = filter;
 
   const fills = await filterAsync(spokePoolClient.getFills(), async (fill) => {
-    if (!isDefined(spokePoolClient)) {
-      return false;
-    }
-
     if (isDefined(fromBlock) && spokePoolClient.latestBlockNumber - fill.blockNumber > fromBlock) {
       return false;
     }

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -532,7 +532,7 @@ export async function getFills(
   const { originChainId, repaymentChainId, relayer, isSlowRelay, fromBlock } = filter;
 
   const fills = await filterAsync(spokePoolClient.getFills(), async (fill) => {
-    if (isDefined(fromBlock) && fill.blockNumber > fromBlock) {
+    if (isDefined(fromBlock) && fromBlock > fill.blockNumber) {
       return false;
     }
 
@@ -582,7 +582,7 @@ export async function getRefundRequests(
   const refundRequests = await filterAsync(spokePoolClient.getRefundRequests(), async (refundRequest) => {
     assert(refundRequest.repaymentChainId === chainId);
 
-    if (isDefined(fromBlock) && refundRequest.blockNumber > fromBlock) {
+    if (isDefined(fromBlock) && fromBlock > refundRequest.blockNumber) {
       return false;
     }
 

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -516,11 +516,13 @@ export type SpokePoolFillFilter = SpokePoolEventFilter & {
   isSlowRelay?: boolean;
 };
 
-// @description Search for fills recorded by a specific SpokePool.
-// @param chainId Chain ID of the relevant SpokePoolClient instance.
-// @param spokePoolClients Set of SpokePoolClient instances, mapped by chain ID.
-// @param filter  Optional filtering criteria.
-// @returns Array of FillWithBlock events matching the chain ID and optional filtering criteria.
+/**
+ * @description Search for fills recorded by a specific SpokePool.
+ * @param chainId Chain ID of the relevant SpokePoolClient instance.
+ * @param spokePoolClients Set of SpokePoolClient instances, mapped by chain ID.
+ * @param filter  Optional filtering criteria.
+ * @returns Array of FillWithBlock events matching the chain ID and optional filtering criteria.
+ */
 export async function getFills(
   chainId: number,
   spokePoolClients: SpokePoolClients,
@@ -560,13 +562,15 @@ export async function getFills(
   return fills;
 }
 
-// @description Search for refund requests recorded by a specific SpokePool.
-// @param chainId Chain ID of the relevant SpokePoolClient instance.
-// @param chainIdIndices Complete set of ordered chain IDs.
-// @param hubPoolClient HubPoolClient instance.
-// @param spokePoolClients Set of SpokePoolClient instances, mapped by chain ID.
-// @param filter  Optional filtering criteria.
-// @returns Array of RefundRequestWithBlock events matching the chain ID and optional filtering criteria.
+/**
+ *@description Search for refund requests recorded by a specific SpokePool.
+ * @param chainId Chain ID of the relevant SpokePoolClient instance.
+ * @param chainIdIndices Complete set of ordered chain IDs.
+ * @param hubPoolClient HubPoolClient instance.
+ * @param spokePoolClients Set of SpokePoolClient instances, mapped by chain ID.
+ * @param filter  Optional filtering criteria.
+ * @returns Array of RefundRequestWithBlock events matching the chain ID and optional filtering criteria.
+ */
 export async function getRefundRequests(
   chainId: number,
   chainIdIndices: number[],

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -532,7 +532,7 @@ export async function getFills(
   const { originChainId, repaymentChainId, relayer, isSlowRelay, fromBlock } = filter;
 
   const fills = await filterAsync(spokePoolClient.getFills(), async (fill) => {
-    if (isDefined(fromBlock) && spokePoolClient.latestBlockNumber - fill.blockNumber > fromBlock) {
+    if (isDefined(fromBlock) && fill.blockNumber > fromBlock) {
       return false;
     }
 
@@ -582,7 +582,7 @@ export async function getRefundRequests(
   const refundRequests = await filterAsync(spokePoolClient.getRefundRequests(), async (refundRequest) => {
     assert(refundRequest.repaymentChainId === chainId);
 
-    if (isDefined(fromBlock) && spokePoolClient.latestBlockNumber - refundRequest.blockNumber > fromBlock) {
+    if (isDefined(fromBlock) && refundRequest.blockNumber > fromBlock) {
       return false;
     }
 


### PR DESCRIPTION
These helpers interface to individual SpokePoolClient instances and handle the necessary filtering and validation on behalf of the caller. They should ultimately be migrated into a dedidated SpokePoolManager class, alongside some other select utilities in the UBAClientUtilities file.