### PR TITLE
feat: add base-client extension to all clients

### DIFF
--- a/src/clients/AcrossConfigStoreClient.ts
+++ b/src/clients/AcrossConfigStoreClient.ts
@@ -30,6 +30,7 @@ import {
   DisabledChainsUpdate,
 } from "../interfaces";
 import { across } from "@uma/sdk";
+import { BaseAbstractClient } from "./BaseAbstractClient";
 
 type _ConfigStoreUpdate = {
   success: true;
@@ -54,7 +55,7 @@ export const GLOBAL_CONFIG_STORE_KEYS = {
   DISABLED_CHAINS: "DISABLED_CHAINS",
 };
 
-export class AcrossConfigStoreClient {
+export class AcrossConfigStoreClient extends BaseAbstractClient {
   public cumulativeRateModelUpdates: across.rateModel.RateModelEvent[] = [];
   public cumulativeRouteRateModelUpdates: RouteRateModelUpdate[] = [];
   public cumulativeTokenTransferUpdates: L1TokenTransferThreshold[] = [];
@@ -70,8 +71,6 @@ export class AcrossConfigStoreClient {
 
   public hasLatestConfigStoreVersion = false;
 
-  public isUpdated = false;
-
   constructor(
     readonly logger: winston.Logger,
     readonly configStore: Contract,
@@ -79,6 +78,7 @@ export class AcrossConfigStoreClient {
     readonly configStoreVersion: number,
     readonly enabledChainIds: number[]
   ) {
+    super();
     this.firstBlockToSearch = eventSearchConfig.fromBlock;
     this.rateModelDictionary = new across.rateModel.RateModelDictionary();
   }

--- a/src/clients/BaseAbstractClient.ts
+++ b/src/clients/BaseAbstractClient.ts
@@ -21,7 +21,7 @@ export abstract class BaseAbstractClient {
    * @param value Whether the client has been updated since it was created.
    * @throws Error if the client has already been updated and the value is false.
    */
-  protected set isUpdated(value: boolean) {
+  public set isUpdated(value: boolean) {
     if (this._isUpdated === true && !value) {
       throw new Error("Cannot set isUpdated to false once it is true");
     }

--- a/src/clients/BaseAbstractClient.ts
+++ b/src/clients/BaseAbstractClient.ts
@@ -1,0 +1,39 @@
+/**
+ * Base class for all clients to extend.
+ */
+export abstract class BaseAbstractClient {
+  private _isUpdated: boolean;
+
+  constructor() {
+    this._isUpdated = false;
+  }
+
+  /**
+   * Indicates whether the client has been updated since it was created.
+   * @returns Whether the client has been updated since it was created.
+   */
+  public get isUpdated(): boolean {
+    return this._isUpdated;
+  }
+
+  /**
+   * Sets whether the client has been updated since it was created.
+   * @param value Whether the client has been updated since it was created.
+   * @throws Error if the client has already been updated and the value is false.
+   */
+  protected set isUpdated(value: boolean) {
+    if (this._isUpdated === true && !value) {
+      throw new Error("Cannot set isUpdated to false once it is true");
+    }
+    this._isUpdated = value;
+  }
+
+  /**
+   * Asserts that the client has been updated.
+   */
+  protected assertUpdated(): void {
+    if (!this.isUpdated) {
+      throw new Error("Client not updated");
+    }
+  }
+}

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -18,6 +18,7 @@ import { ExecutedRootBundle, PendingRootBundle, ProposedRootBundle } from "../in
 import { CrossChainContractsSet, DestinationTokenWithBlock, SetPoolRebalanceRoot } from "../interfaces";
 import * as lpFeeCalculator from "../lpFeeCalculator";
 import { AcrossConfigStoreClient as ConfigStoreClient } from "./";
+import { BaseAbstractClient } from "./BaseAbstractClient";
 
 type _HubPoolUpdate = {
   success: true;
@@ -42,7 +43,7 @@ type HubPoolEvent =
 type L1TokensToDestinationTokens = {
   [l1Token: string]: { [destinationChainId: number]: string };
 };
-export class HubPoolClient {
+export class HubPoolClient extends BaseAbstractClient {
   // L1Token -> destinationChainId -> destinationToken
   protected l1TokensToDestinationTokens: L1TokensToDestinationTokens = {};
   protected l1Tokens: L1Token[] = []; // L1Tokens and their associated info.
@@ -57,7 +58,6 @@ export class HubPoolClient {
   } = {};
   protected pendingRootBundle: PendingRootBundle | undefined;
 
-  public isUpdated = false;
   public firstBlockToSearch: number;
   public latestBlockNumber: number | undefined;
   public currentTime: number | undefined;
@@ -78,6 +78,7 @@ export class HubPoolClient {
       ignoredHubProposedBundles: [],
     }
   ) {
+    super();
     this.latestBlockNumber = deploymentBlock === 0 ? deploymentBlock : deploymentBlock - 1;
     this.firstBlockToSearch = eventSearchConfig.fromBlock;
 

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -31,6 +31,7 @@ import {
 import { HubPoolClient } from ".";
 import { ZERO_ADDRESS } from "../constants";
 import { getNetworkName } from "../utils/NetworkUtils";
+import { BaseAbstractClient } from "./BaseAbstractClient";
 
 type _SpokePoolUpdate = {
   success: boolean;
@@ -47,7 +48,7 @@ export type SpokePoolUpdate = { success: false } | _SpokePoolUpdate;
  * SpokePoolClient is a client for the SpokePool contract. It is responsible for querying the SpokePool contract
  * for events and storing them in memory. It also provides some convenience methods for querying the stored events.
  */
-export class SpokePoolClient {
+export class SpokePoolClient extends BaseAbstractClient {
   protected currentTime = 0;
   protected depositHashes: { [depositHash: string]: DepositWithBlock } = {};
   protected depositHashesToFills: { [depositHash: string]: FillWithBlock[] } = {};
@@ -62,7 +63,6 @@ export class SpokePoolClient {
   public latestDepositIdQueried = 0;
   public firstDepositIdForSpokePool = Number.MAX_SAFE_INTEGER;
   public lastDepositIdForSpokePool = Number.MAX_SAFE_INTEGER;
-  public isUpdated = false;
   public firstBlockToSearch: number;
   public latestBlockNumber = 0;
   public deposits: { [DestinationChainId: number]: DepositWithBlock[] } = {};
@@ -87,6 +87,7 @@ export class SpokePoolClient {
     public deploymentBlock: number,
     readonly eventSearchConfig: MakeOptional<EventSearchConfig, "toBlock"> = { fromBlock: 0, maxBlockLookBack: 0 }
   ) {
+    super();
     this.firstBlockToSearch = eventSearchConfig.fromBlock;
     this.queryableEventNames = Object.keys(this._queryableEventNames());
   }

--- a/src/clients/UBAClient/UBAClientBase.ts
+++ b/src/clients/UBAClient/UBAClientBase.ts
@@ -16,12 +16,13 @@ import {
 import { computeLpFeeStateful } from "./UBAClientUtilities";
 import { findLast } from "../../utils/ArrayUtils";
 import { analog } from "../../UBAFeeCalculator";
+import { BaseAbstractClient } from "../BaseAbstractClient";
 
 /**
  * UBAClient is a base class for UBA functionality. It provides a common interface for UBA functionality to be implemented on top of or extended.
  * This class is not intended to be used directly, but rather extended by other classes that implement the abstract methods.
  */
-export abstract class BaseUBAClient {
+export abstract class BaseUBAClient extends BaseAbstractClient {
   /**
    * A mapping of Token Symbols to a mapping of ChainIds to a list of bundle states.
    * @note The bundle states are sorted in ascending order by block number.
@@ -41,6 +42,7 @@ export abstract class BaseUBAClient {
     protected readonly maxBundleStates: number,
     protected readonly logger?: winston.Logger
   ) {
+    super();
     this.bundleStates = {};
   }
 
@@ -358,6 +360,7 @@ export abstract class BaseUBAClient {
     if (state) {
       this.bundleStates = state;
     }
+    this.isUpdated = true;
     return Promise.resolve();
   }
 }

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -415,7 +415,8 @@ async function getFlows(
       }
 
       return result.valid;
-    });
+    }
+  );
 
   // This is probably more expensive than we'd like... @todo: optimise.
   const flows = sortEventsAscending(deposits.concat(fills).concat(refundRequests));

--- a/src/clients/UBAClient/UBAClientWithRefresh.ts
+++ b/src/clients/UBAClient/UBAClientWithRefresh.ts
@@ -39,7 +39,7 @@ export class UBAClientWithRefresh extends BaseUBAClient {
     }
     // Update the clients if the necessary clients have not been updated at least once.
     // Also update if forceClientRefresh is true.
-    if (forceClientRefresh || !this.areNecessaryClientsUpdated()) {
+    if (forceClientRefresh || !this.isUpdated) {
       // Update the Across config store
       await this.hubPoolClient.configStoreClient.update();
       // Update the HubPool
@@ -61,22 +61,12 @@ export class UBAClientWithRefresh extends BaseUBAClient {
     );
   }
 
-  /**
-   * Performs and assert that the necessary clients have been updated at least once.
-   */
-  protected assertNecessaryClientsUpdated(): void {
-    assert(this.areNecessaryClientsUpdated(), "UBAClientWithRefresh: Clients not updated");
-  }
-
-  /**
-   * Verifies that the necessary clients have been updated at least once.
-   * @returns true if all necessary clients have been updated at least once.
-   */
-  protected areNecessaryClientsUpdated(): boolean {
+  public get isUpdated(): boolean {
     return (
       this.hubPoolClient.configStoreClient.isUpdated &&
       this.hubPoolClient.isUpdated &&
-      Object.values(this.spokePoolClients).every((spokePoolClient) => spokePoolClient.isUpdated)
+      Object.values(this.spokePoolClients).every((spokePoolClient) => spokePoolClient.isUpdated) &&
+      this.isUpdated
     );
   }
 }


### PR DESCRIPTION
This PR essentially adds a base-client that is extended by all of our bot clients. The reason being: we have common `isUpdated` logic in all clients and that should be strictly enforced.