### PR TITLE
improve(test): Singleton event manager in mocked clients

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -695,7 +695,7 @@ export class HubPoolClient extends BaseAbstractClient {
       // Safeguard
       if (executedRootBundle.runningBalances.length !== nTokens) {
         throw new Error(
-          `Invalid runningBalances length (${executedRootBundle.runningBalances.length} != ${nTokens})` +
+          `Invalid runningBalances length (${executedRootBundle.runningBalances.length} !== ${nTokens})` +
             ` for ConfigStore version ${version} in chain ${this.chainId} transaction ${event.transactionHash}`
         );
       }

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -694,7 +694,7 @@ export class HubPoolClient {
       // Safeguard
       if (executedRootBundle.runningBalances.length !== nTokens) {
         throw new Error(
-          `Invalid runningBalances length (${executedRootBundle.runningBalances.length})` +
+          `Invalid runningBalances length (${executedRootBundle.runningBalances.length} != ${nTokens})` +
             ` for ConfigStore version ${version} in chain ${this.chainId} transaction ${event.transactionHash}`
         );
       }

--- a/src/clients/mocks/MockEvents.ts
+++ b/src/clients/mocks/MockEvents.ts
@@ -1,6 +1,7 @@
+import assert from "assert";
 import { utils as ethersUtils, Event, providers } from "ethers";
 import { random } from "lodash";
-import { toBN, randomAddress } from "../../utils";
+import { isDefined, randomAddress, toBN } from "../../utils";
 
 const { id, keccak256, toUtf8Bytes } = ethersUtils;
 
@@ -19,6 +20,8 @@ type EthersEventTemplate = {
   transactionIndex?: number;
 };
 
+let eventManagers: { [chainId: number]: EventManager } = {};
+
 // May need to populate getTransaction and getTransactionReceipt if calling code starts using it.
 // https://docs.ethers.org/v5/api/providers/provider/#Provider-getTransaction
 const getTransaction = async (): Promise<TransactionResponse> => {
@@ -34,8 +37,19 @@ const removeListener = (): void => {
 
 export class EventManager {
   private logIndexes: Record<string, number> = {};
+  public readonly minBlockRange = 10;
+  public readonly eventSignatures: Record<string, string> = {};
 
-  constructor(public readonly eventSignatures: Record<string, string>) {}
+  constructor(public blockNumber = 0) {}
+
+  addEventSignatures(eventSignatures: Record<string, string>): void {
+    Object.entries(eventSignatures).forEach(([event, signature]) => {
+      if (isDefined(this.eventSignatures[event])) {
+        assert(signature === this.eventSignatures[event], `Event ${event} conflict detected.`);
+      }
+      this.eventSignatures[event] = signature;
+    });
+  }
 
   generateEvent(inputs: EthersEventTemplate): Event {
     const { address, event, topics: _topics, data, args } = inputs;
@@ -44,7 +58,12 @@ export class EventManager {
 
     let { blockNumber, transactionIndex } = inputs;
 
-    blockNumber = blockNumber ?? random(1, 100_000, false);
+    // Increment the block number by at least 1, by default. The caller may override
+    // to force the same block number to be used, but never a previous block number.
+    blockNumber = blockNumber ?? random(this.blockNumber + 1, this.blockNumber + this.minBlockRange, false);
+    assert(blockNumber >= this.blockNumber, `${blockNumber} < ${this.blockNumber}`);
+    this.blockNumber = blockNumber;
+
     transactionIndex = transactionIndex ?? random(1, 32, false);
     const transactionHash = id(`Across-v2-${event}-${blockNumber}-${transactionIndex}-${random(1, 100_000)}`);
 
@@ -94,4 +113,23 @@ export class EventManager {
       removeListener,
     } as Event;
   }
+}
+
+export function getEventManager(
+  chainId: number,
+  eventSignatures?: Record<string, string>,
+  blockNumber?: number
+): EventManager {
+  if (!isDefined(eventManagers[chainId])) {
+    eventManagers[chainId] = new EventManager(blockNumber);
+  }
+  const eventManager = eventManagers[chainId];
+  if (isDefined(eventSignatures)) {
+    eventManager.addEventSignatures(eventSignatures);
+  }
+  return eventManager;
+}
+
+export function resetEventManagers(): void {
+  eventManagers = {};
 }

--- a/src/clients/mocks/MockEvents.ts
+++ b/src/clients/mocks/MockEvents.ts
@@ -115,6 +115,13 @@ export class EventManager {
   }
 }
 
+/**
+ * @description Retrieve an instance of the EventManager for a specific chain, or instantiate a new one.
+ * @param chainId Chain ID to retrieve EventManager for.
+ * @param eventSignatures Event Signatures to append to EventManager instance.
+ * @param Initial blockNumber to use if a new EventManager is instantiated.
+ * @returns EventManager instance for chain ID.
+ */
 export function getEventManager(
   chainId: number,
   eventSignatures?: Record<string, string>,
@@ -128,8 +135,4 @@ export function getEventManager(
     eventManager.addEventSignatures(eventSignatures);
   }
   return eventManager;
-}
-
-export function resetEventManagers(): void {
-  eventManagers = {};
 }

--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -99,7 +99,7 @@ export class MockSpokePoolClient extends SpokePoolClient {
     let { depositId, depositor, destinationChainId } = deposit;
     depositId = depositId ?? this.numberOfDeposits;
     assert(depositId >= this.numberOfDeposits, `${depositId} < ${this.numberOfDeposits}`);
-    this.numberOfDeposits = ++depositId;
+    this.numberOfDeposits = depositId + 1;
 
     destinationChainId = destinationChainId ?? random(1, 42161, false);
     depositor = depositor ?? randomAddress();

--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -1,3 +1,4 @@
+import assert from "assert";
 import { Contract, Event } from "ethers";
 import { random } from "lodash";
 import winston from "winston";
@@ -5,21 +6,21 @@ import { ZERO_ADDRESS } from "../../constants";
 import { DepositWithBlock, FillWithBlock, RefundRequestWithBlock } from "../../interfaces";
 import { toBN, toBNWei, randomAddress } from "../../utils";
 import { SpokePoolClient, SpokePoolUpdate } from "../SpokePoolClient";
-import { EventManager } from "./MockEvents";
+import { EventManager, getEventManager } from "./MockEvents";
 
 // This class replaces internal SpokePoolClient functionality, enabling the
 // user to bypass on-chain queries and inject ethers Event objects directly.
 export class MockSpokePoolClient extends SpokePoolClient {
+  private eventManager: EventManager;
   private events: Event[] = [];
-  public readonly minBlockRange = 10;
   // Allow tester to set the numberOfDeposits() returned by SpokePool at a block height.
   public depositIdAtBlock: number[] = [];
-  private eventManager: EventManager;
+  public numberOfDeposits = 0;
 
   constructor(logger: winston.Logger, spokePool: Contract, chainId: number, deploymentBlock: number) {
     super(logger, spokePool, null, chainId, deploymentBlock);
     this.latestBlockNumber = deploymentBlock;
-    this.eventManager = new EventManager(this.eventSignatures);
+    this.eventManager = getEventManager(chainId, this.eventSignatures, deploymentBlock);
   }
 
   addEvent(event: Event): void {
@@ -51,7 +52,7 @@ export class MockSpokePoolClient extends SpokePoolClient {
     eventsToQuery.push("RefundRequested");
 
     // Generate new "on chain" responses.
-    const latestBlockNumber = this.latestBlockNumber + random(this.minBlockRange, this.minBlockRange * 5, false);
+    const latestBlockNumber = this.eventManager.blockNumber;
     const currentTime = Math.floor(Date.now() / 1000);
 
     // Ensure an array for every requested event exists, in the requested order.
@@ -94,8 +95,12 @@ export class MockSpokePoolClient extends SpokePoolClient {
   generateDeposit(deposit: DepositWithBlock): Event {
     const event = "FundsDeposited";
 
-    const { depositId, blockNumber, transactionIndex } = deposit;
-    let { depositor, destinationChainId } = deposit;
+    const { blockNumber, transactionIndex } = deposit;
+    let { depositId, depositor, destinationChainId } = deposit;
+    depositId = depositId ?? this.numberOfDeposits;
+    assert(depositId >= this.numberOfDeposits, `${depositId} < ${this.numberOfDeposits}`);
+    this.numberOfDeposits = ++depositId;
+
     destinationChainId = destinationChainId ?? random(1, 42161, false);
     depositor = depositor ?? randomAddress();
 
@@ -217,7 +222,6 @@ export class MockSpokePoolClient extends SpokePoolClient {
       address: this.spokePool.address,
       topics: topics.map((topic) => topic.toString()),
       args,
-      blockNumber: this.latestBlockNumber + 1,
     });
   }
 }


### PR DESCRIPTION
This change migrates to the use of a singleton for event managers, enabling multiple "client" classes to see consistent block number increments. This addresses a race condition in the relayer-v2 runningBalances test where the ConfigStoreClient and HubPoolClient can get out of sync and disagree about the applicable version.

While here, add an additional check to ensure that FundsDeposited events are generated with sequential (or at least incrementing) depositIds.