### PR TITLE
fix(UBAFeeCalculator): Refine `calculateHistoricalRunningBalance`

### DIFF
--- a/src/UBAFeeCalculator/UBAFeeSpokeCalculator.ts
+++ b/src/UBAFeeCalculator/UBAFeeSpokeCalculator.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from "ethers";
-import { TokenRunningBalance, UBAFlowRange, UbaFlow } from "../interfaces";
+import { TokenRunningBalance, UbaFlow } from "../interfaces";
 import UBAConfig, { ThresholdBoundType } from "./UBAFeeConfig";
 import { TokenRunningBalanceWithNetSend, UBAFlowFee } from "./UBAFeeTypes";
 import { calculateHistoricalRunningBalance, getEventFee } from "./UBAFeeSpokeCalculatorAnalog";
@@ -80,20 +80,15 @@ export default class UBAFeeSpokeCalculator {
    * A convenience method for resolving the event fee for the spoke and the given symbol and a given flow type
    * @param amount The amount of tokens to simulate
    * @param flowType The flow type to simulate
-   * @param flowRange The range of the flow to simulate the event for. Defaults to undefined to simulate the event for the entire flow.
    * @returns The event fee for the spoke and the given symbol and a given flow type
    */
-  protected getEventFee(amount: BigNumber, flowType: "inflow" | "outflow", flowRange?: UBAFlowRange): UBAFlowFee {
+  protected getEventFee(amount: BigNumber, flowType: "inflow" | "outflow"): UBAFlowFee {
     return getEventFee(
       amount,
       flowType,
-      this.recentRequestFlow.filter(
-        (_, idx) => !flowRange || (idx >= flowRange.startIndex && idx <= flowRange.endIndex)
-      ),
       this.lastValidatedRunningBalance,
       this.lastValidatedIncentiveRunningBalance,
       this.chainId,
-      this.symbol,
       this.config
     );
   }
@@ -101,11 +96,10 @@ export default class UBAFeeSpokeCalculator {
   /**
    * Calculates the fee for a simulated deposit operation
    * @param amount The amount of tokens to deposit
-   * @param flowRange The range of the flow to simulate the deposit for. Defaults to undefined to simulate the deposit for the entire flow.
    * @returns The fee for the simulated deposit operation
    */
-  public getDepositFee(amount: BigNumber, flowRange?: UBAFlowRange): UBAFlowFee {
-    return this.getEventFee(amount, "inflow", flowRange);
+  public getDepositFee(amount: BigNumber): UBAFlowFee {
+    return this.getEventFee(amount, "inflow");
   }
 
   /**
@@ -114,7 +108,7 @@ export default class UBAFeeSpokeCalculator {
    * @param flowRange The range of the flow to simulate the refund for. Defaults to undefined to simulate the refund for the entire flow.
    * @returns The fee for the simulated refund operation
    */
-  public getRefundFee(amount: BigNumber, flowRange?: UBAFlowRange): UBAFlowFee {
-    return this.getEventFee(amount, "outflow", flowRange);
+  public getRefundFee(amount: BigNumber): UBAFlowFee {
+    return this.getEventFee(amount, "outflow");
   }
 }

--- a/src/UBAFeeCalculator/UBAFeeSpokeCalculatorAnalog.ts
+++ b/src/UBAFeeCalculator/UBAFeeSpokeCalculatorAnalog.ts
@@ -105,17 +105,17 @@ export function calculateHistoricalRunningBalance(
  * Returns the balancing fee for a given event that produces a flow of `flowType` of size `amount`.
  * @param amount Amount of inflow or outflow produced by event that we're computing a balancing fee for.
  * @param flowType Inflow or Outflow.
- * @param latestRunningBalance The latest running balance preceding this event.
- * @param latestIncentiveBalance The latest incentive balance preceding this event.
- * @param chainId
- * @param config
+ * @param lastRunningBalance The latest running balance preceding this event.
+ * @param lastIncentiveBalance The latest incentive balance preceding this event.
+ * @param chainId The chain id of the spoke chain
+ * @param config The UBAConfig to use for the calculation
  * @returns
  */
 export function getEventFee(
   amount: BigNumber,
   flowType: "inflow" | "outflow",
-  latestRunningBalance: BigNumber,
-  latestIncentiveBalance: BigNumber,
+  lastRunningBalance: BigNumber,
+  lastIncentiveBalance: BigNumber,
   chainId: number,
   config: UBAConfig
 ): UBAFlowFee {
@@ -135,7 +135,7 @@ export function getEventFee(
   // to the running balance of the spoke + the amount
   let balancingFee = computePiecewiseLinearFunction(
     flowCurve,
-    latestRunningBalance,
+    lastRunningBalance,
     amount.mul(flowType === "inflow" ? 1 : -1)
   );
 
@@ -147,8 +147,8 @@ export function getEventFee(
 
   // if the chainId is not found in the config
   // If P << uncappedIncentiveFee, discountFactor approaches 100%. Capped at 100%
-  if (balancingFee.gt(latestIncentiveBalance)) {
-    const discountFactor = min(BigNumber.from(1), balancingFee.sub(latestIncentiveBalance).div(balancingFee));
+  if (balancingFee.gt(lastIncentiveBalance)) {
+    const discountFactor = min(BigNumber.from(1), balancingFee.sub(lastIncentiveBalance).div(balancingFee));
     balancingFee = balancingFee.mul(BigNumber.from(1).sub(discountFactor));
   }
 

--- a/src/UBAFeeCalculator/UBAFeeSpokeCalculatorAnalog.ts
+++ b/src/UBAFeeCalculator/UBAFeeSpokeCalculatorAnalog.ts
@@ -10,8 +10,7 @@ import { computePiecewiseLinearFunction } from "./UBAFeeUtility";
 /**
  * Calculates the running balances for a given token on a spoke chain produced by the set of flows and beginning with
  * the validated running balances.
- * @param flows The flows to calculate the running balance for. These must all be within the same root bundle period
- * follows the one that snapshotted the last validated running balances.
+ * @param flows The flows to calculate the running balance for.
  * @param lastValidatedRunningBalance The last validated running balance for the token and chain ID validated in
  * a root bundle in the HubPool.
  * @param lastValidatedIncentiveRunningBalance The last validated incentive running balance for the token and chain ID

--- a/src/clients/UBAClient/UBAClientBase.ts
+++ b/src/clients/UBAClient/UBAClientBase.ts
@@ -144,13 +144,19 @@ export abstract class BaseUBAClient extends BaseAbstractClient {
     const flows = (specificBundleState?.flows ?? []).filter(
       (flow) => flow.flow.blockNumber <= balancingActionBlockNumber
     );
-    const { balancingFee } = analog.feeCalculationFunctionsForUBA[feeType](
-      amount,
+    const { runningBalance, incentiveBalance } = analog.calculateHistoricalRunningBalance(
       flows.map(({ flow }) => flow),
       specificBundleState.openingBalance,
       specificBundleState.openingIncentiveBalance,
       chainId,
       tokenSymbol,
+      specificBundleState.config.ubaConfig
+    );
+    const { balancingFee } = analog.feeCalculationFunctionsForUBA[feeType](
+      amount,
+      runningBalance,
+      incentiveBalance,
+      chainId,
       specificBundleState.config.ubaConfig
     );
     return {

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -322,20 +322,16 @@ export async function updateUBAClient(
               );
             const { balancingFee: depositBalancingFee } = getDepositFee(
               flow.amount,
-              previousFlows,
-              constructedBundle.openingBalance,
-              constructedBundle.openingIncentiveBalance,
+              runningBalance,
+              incentiveBalance,
               chainId,
-              tokenSymbol,
               constructedBundle.config.ubaConfig
             );
             const { balancingFee: relayerBalancingFee } = getRefundFee(
               flow.amount,
-              previousFlows,
-              constructedBundle.openingBalance,
-              constructedBundle.openingIncentiveBalance,
+              runningBalance,
+              incentiveBalance,
               chainId,
-              tokenSymbol,
               constructedBundle.config.ubaConfig
             );
             const lpFee = await computeLpFeeForRefresh(

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -259,7 +259,7 @@ export async function updateUBAClient(
           const {
             blockNumber: startingBundleBlockNumber,
             spokePoolBalance,
-            incentiveBalance,
+            incentiveBalance: initialIncentiveBalance,
           } = getOpeningTokenBalances(chainId, l1TokenAddress, hubPoolClient, endingBundleBlockNumber);
           const tokenMappingLookup = (
             TOKEN_SYMBOLS_MAP as Record<string, { addresses: { [x: number]: string }; decimals: number }>
@@ -283,7 +283,7 @@ export async function updateUBAClient(
             flows: [],
             openingBlockNumberForSpokeChain: startingBundleBlockNumber,
             openingBalance: spokePoolBalance,
-            openingIncentiveBalance: incentiveBalance,
+            openingIncentiveBalance: initialIncentiveBalance,
             config: {
               ubaConfig: getUBAFeeConfig(
                 hubPoolClient.configStoreClient,
@@ -311,26 +311,29 @@ export async function updateUBAClient(
           for (const flow of recentFlows) {
             const previousFlows = constructedBundle.flows.map((flow) => flow.flow);
             const previousFlowsIncludingCurrent = previousFlows.concat(flow);
-            const { runningBalance, incentiveBalance, netRunningBalanceAdjustment } =
-              analog.calculateHistoricalRunningBalance(
-                previousFlowsIncludingCurrent,
-                constructedBundle.openingBalance,
-                constructedBundle.openingIncentiveBalance,
-                chainId,
-                tokenSymbol,
-                constructedBundle.config.ubaConfig
-              );
+            const {
+              runningBalance: lastRunningBalance,
+              incentiveBalance: lastIncentiveBalance,
+              netRunningBalanceAdjustment,
+            } = analog.calculateHistoricalRunningBalance(
+              previousFlowsIncludingCurrent,
+              constructedBundle.openingBalance,
+              constructedBundle.openingIncentiveBalance,
+              chainId,
+              tokenSymbol,
+              constructedBundle.config.ubaConfig
+            );
             const { balancingFee: depositBalancingFee } = getDepositFee(
               flow.amount,
-              runningBalance,
-              incentiveBalance,
+              lastRunningBalance,
+              lastIncentiveBalance,
               chainId,
               constructedBundle.config.ubaConfig
             );
             const { balancingFee: relayerBalancingFee } = getRefundFee(
               flow.amount,
-              runningBalance,
-              incentiveBalance,
+              lastRunningBalance,
+              lastIncentiveBalance,
               chainId,
               constructedBundle.config.ubaConfig
             );
@@ -357,8 +360,8 @@ export async function updateUBAClient(
 
             constructedBundle.flows.push({
               flow,
-              runningBalance,
-              incentiveBalance,
+              runningBalance: lastRunningBalance,
+              incentiveBalance: lastIncentiveBalance,
               netRunningBalanceAdjustment,
               relayerFee: {
                 relayerBalancingFee,

--- a/src/interfaces/UBA.ts
+++ b/src/interfaces/UBA.ts
@@ -29,5 +29,3 @@ export type UBASpokeBalanceType = {
 };
 
 export type UBAFeeResult = { depositorFee: BigNumber; refundFee: BigNumber; totalUBAFee: BigNumber };
-
-export type UBAFlowRange = { startIndex: number; endIndex: number };


### PR DESCRIPTION
- We need to make sure we're only passing the snapshotted running balances back and forth between `getEventFee` and `calculateHistoricalRunningBalance`
- Add clarifying comments as to the usage of these functions