### PR TITLE
feat: allow passing `queriesMap` to relay fee calc config

### DIFF
--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -25,7 +25,7 @@ import {
 import { DepositWithBlock, FillWithBlock, RefundRequestWithBlock, UbaFlow } from "../../interfaces";
 import { Logger } from "winston";
 import { analog } from "../../UBAFeeCalculator";
-import { RelayFeeCalculator, RelayFeeCalculatorConfig } from "../../relayFeeCalculator";
+import { RelayFeeCalculator, RelayFeeCalculatorConfigWithMap } from "../../relayFeeCalculator";
 import { TOKEN_SYMBOLS_MAP } from "@across-protocol/contracts-v2";
 import { getDepositFee, getRefundFee } from "../../UBAFeeCalculator/UBAFeeSpokeCalculatorAnalog";
 import { AcrossConfigStoreClient } from "../AcrossConfigStoreClient";
@@ -207,7 +207,7 @@ export async function updateUBAClient(
   relevantTokenSymbols: string[],
   hubPoolBlockNumber: number,
   updateInternalClients = true,
-  relayFeeCalculatorConfig: RelayFeeCalculatorConfig,
+  relayFeeCalculatorConfig: RelayFeeCalculatorConfigWithMap,
   maxBundleStates: number
 ): Promise<UBAClientState> {
   if (updateInternalClients) {
@@ -348,7 +348,11 @@ export async function updateUBAClient(
               constructedBundle.config.ubaConfig.getLpGammaFunctionTuples(flow.destinationChainId)
             );
 
-            const relayFeeCalculator = new RelayFeeCalculator(relayFeeCalculatorConfig);
+            const relayFeeCalculator = new RelayFeeCalculator(
+              relayFeeCalculatorConfig,
+              undefined,
+              flow.destinationChainId
+            );
             const { capitalFeeTotal, relayFeeTotal, gasFeeTotal, isAmountTooLow } =
               await relayFeeCalculator.relayerFeeDetails(
                 flow.amount,

--- a/src/clients/UBAClient/UBAClientWithRefresh.ts
+++ b/src/clients/UBAClient/UBAClientWithRefresh.ts
@@ -3,7 +3,7 @@ import winston from "winston";
 import { HubPoolClient, SpokePoolClient } from "..";
 import { BaseUBAClient } from "./UBAClientBase";
 import { updateUBAClient } from "./UBAClientUtilities";
-import { RelayFeeCalculator, RelayFeeCalculatorConfig } from "../../relayFeeCalculator";
+import { RelayFeeCalculator, RelayFeeCalculatorConfigWithMap } from "../../relayFeeCalculator";
 import { UBAChainState } from "./UBAClientTypes";
 export class UBAClientWithRefresh extends BaseUBAClient {
   /**
@@ -19,7 +19,7 @@ export class UBAClientWithRefresh extends BaseUBAClient {
     readonly tokens: string[],
     protected readonly hubPoolClient: HubPoolClient,
     protected readonly spokePoolClients: { [chainId: number]: SpokePoolClient },
-    protected readonly relayerConfiguration: RelayFeeCalculatorConfig,
+    protected readonly relayerConfiguration: RelayFeeCalculatorConfigWithMap,
     readonly maxBundleStates: number,
     readonly logger?: winston.Logger
   ) {

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -39,7 +39,6 @@ export interface RelayFeeCalculatorConfigWithQueries extends BaseRelayFeeCalcula
 }
 export interface RelayFeeCalculatorConfigWithMap extends BaseRelayFeeCalculatorConfig {
   queriesMap: Record<number, QueryInterface>;
-  destinationChainId: number;
 }
 export type RelayFeeCalculatorConfig = RelayFeeCalculatorConfigWithQueries | RelayFeeCalculatorConfigWithMap;
 
@@ -91,12 +90,17 @@ export class RelayFeeCalculator {
   // be an object.
   private logger: Logger;
 
-  constructor(config: RelayFeeCalculatorConfig, logger: Logger = DEFAULT_LOGGER) {
+  constructor(config: RelayFeeCalculatorConfigWithQueries, logger?: Logger);
+  constructor(config: RelayFeeCalculatorConfigWithMap, logger?: Logger, destinationChainId?: number);
+  constructor(config?: RelayFeeCalculatorConfig, logger?: Logger, destinationChainId?: number) {
+    assert(config, "config must be provided");
+
     if ("queries" in config) {
       this.queries = config.queries;
     } else {
-      assert(config.queriesMap[config.destinationChainId], "No queries provided for destination chain");
-      this.queries = config.queriesMap[config.destinationChainId];
+      assert(destinationChainId !== undefined, "destinationChainId must be provided if queriesMap is provided");
+      assert(config.queriesMap[destinationChainId], "No queries provided for destination chain");
+      this.queries = config.queriesMap[destinationChainId];
     }
 
     this.gasDiscountPercent = config.gasDiscountPercent || 0;
@@ -127,7 +131,7 @@ export class RelayFeeCalculator {
       );
     }
 
-    this.logger = logger;
+    this.logger = logger || DEFAULT_LOGGER;
   }
 
   /**


### PR DESCRIPTION
While working on the `GET /uba-bundle-state` endpoint for the quote engine, I noticed that we pass the wrong (?) queries here https://github.com/across-protocol/sdk-v2/blob/use-correct-queries-relay-fee-calculator/src/clients/UBAClient/UBAClientUtilities.ts#L351. The old `RelayFeeCalculatorConfig` expects as a property an instance of `QueryInterface` which implements the respective `gasCosts`, `price`, `decimals` queries for a single chain. But AFAICT we need the queries of the respective destination chain.

This PR tries to fix this by allowing to instantiate an instance of `RelayerFeeCalculator` using a `queriesMap` and an additional `destinationChainId` parameter. I chose this approach in order to not break other code that uses the calculator. 
