### PR TITLE
improve(UBAFeeConfig): Add possibility for user to set a default for `balanceTriggerThreshold`

### DIFF
--- a/src/UBAFeeCalculator/UBAFeeCalculator.test.ts
+++ b/src/UBAFeeCalculator/UBAFeeCalculator.test.ts
@@ -9,7 +9,7 @@ import {
   getRefundBalancingFee,
   performLinearIntegration,
 } from "./UBAFeeUtility";
-import { FlowTupleParameters } from "./UBAFeeConfig";
+import { FlowTupleParameters } from "./UBAFeeTypes";
 import { MAX_SAFE_JS_INT } from "@uma/common";
 import { parseEther, parseUnits } from "ethers/lib/utils";
 import { BigNumber } from "ethers";
@@ -41,7 +41,12 @@ describe("UBA Fee Calculations", () => {
           [toBN("9000000"), parseUnits("0.4", 18)],
         ],
       },
-      {},
+      {
+        default: {
+          lowerBound: { target: toBN("0"), threshold: toBN("0") },
+          upperBound: { target: toBN("0"), threshold: toBN("0") },
+        },
+      },
       { default: [] },
       {},
       {}

--- a/src/UBAFeeCalculator/UBAFeeSpokeCalculator.ts
+++ b/src/UBAFeeCalculator/UBAFeeSpokeCalculator.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from "ethers";
 import { TokenRunningBalance, UbaFlow } from "../interfaces";
-import UBAConfig, { ThresholdBoundType } from "./UBAFeeConfig";
-import { TokenRunningBalanceWithNetSend, UBAFlowFee } from "./UBAFeeTypes";
+import UBAConfig from "./UBAFeeConfig";
+import { TokenRunningBalanceWithNetSend, UBAFlowFee, ThresholdBoundType } from "./UBAFeeTypes";
 import { calculateHistoricalRunningBalance, getEventFee } from "./UBAFeeSpokeCalculatorAnalog";
 
 /**

--- a/src/UBAFeeCalculator/UBAFeeSpokeCalculatorAnalog.ts
+++ b/src/UBAFeeCalculator/UBAFeeSpokeCalculatorAnalog.ts
@@ -6,7 +6,6 @@ import { TokenRunningBalanceWithNetSend, UBAActionType, UBAFlowFee } from "./UBA
 import UBAConfig from "./UBAFeeConfig";
 import { min, toBN } from "../utils";
 import { computePiecewiseLinearFunction } from "./UBAFeeUtility";
-import { isTriggerHurdleDefined } from "../typeguards/uba";
 
 /**
  * Calculates the running balances for a given token on a spoke chain produced by the set of flows and beginning with

--- a/src/UBAFeeCalculator/UBAFeeSpokeCalculatorAnalog.ts
+++ b/src/UBAFeeCalculator/UBAFeeSpokeCalculatorAnalog.ts
@@ -62,10 +62,10 @@ export function calculateHistoricalRunningBalance(
       // organically grow the running balance to. If the running balance exceeds the trigger hurdle,
       // we need to return the trigger hurdle as the running balance because at this point the dataworker
       // will be triggered to rebalance the running balance.
-      if (upperBoundTriggerHurdle !== undefined && resultant.runningBalance.gt(upperBoundTriggerHurdle.threshold)) {
-        // If we are over the target, subtract the difference from the net running balance adjustment
-        // so that the dataworker can instruct the spoke pool to return funds to the hub pool.
-        resultant.netRunningBalanceAdjustment = resultant.netRunningBalanceAdjustment.sub(
+      if (upperBoundTriggerHurdle.threshold.gt(0) && resultant.runningBalance.gt(upperBoundTriggerHurdle.threshold)) {
+        // Update the net running balance adjustment to reflect the difference between the running balance
+        // and the trigger hurdle
+        resultant.netRunningBalanceAdjustment = resultant.netRunningBalanceAdjustment.add(
           resultant.runningBalance.sub(upperBoundTriggerHurdle.target)
         );
         // Set the running balance to the trigger hurdle
@@ -78,7 +78,7 @@ export function calculateHistoricalRunningBalance(
       // we need to return the trigger hurdle as the running balance because at this point the dataworker
       // will be triggered to rebalance the running balance.
       else if (
-        lowerBoundTriggerHurdle !== undefined &&
+        lowerBoundTriggerHurdle.threshold.gt(0) &&
         resultant.runningBalance.lt(lowerBoundTriggerHurdle.threshold)
       ) {
         // If we are under the target, add the difference to the net running balance adjustment

--- a/src/UBAFeeCalculator/UBAFeeSpokeCalculatorAnalog.ts
+++ b/src/UBAFeeCalculator/UBAFeeSpokeCalculatorAnalog.ts
@@ -63,8 +63,8 @@ export function calculateHistoricalRunningBalance(
       // we need to return the trigger hurdle as the running balance because at this point the dataworker
       // will be triggered to rebalance the running balance.
       if (upperBoundTriggerHurdle.threshold.gt(0) && resultant.runningBalance.gt(upperBoundTriggerHurdle.threshold)) {
-        // Update the net running balance adjustment to reflect the difference between the running balance
-        // and the trigger hurdle
+        // If we are over the target, subtract the difference from the net running balance adjustment
+        // so that the dataworker can instruct the spoke pool to return funds to the hub pool.
         resultant.netRunningBalanceAdjustment = resultant.netRunningBalanceAdjustment.sub(
           resultant.runningBalance.sub(upperBoundTriggerHurdle.target)
         );

--- a/src/UBAFeeCalculator/UBAFeeTypes.ts
+++ b/src/UBAFeeCalculator/UBAFeeTypes.ts
@@ -13,3 +13,8 @@ export type TokenRunningBalanceWithNetSend = TokenRunningBalance & {
 export type UBAFlowFee = {
   balancingFee: BigNumber;
 };
+
+export type TupleParameter = [BigNumber, BigNumber];
+export type FlowTupleParameters = TupleParameter[];
+export type ThresholdType = { target: BigNumber; threshold: BigNumber };
+export type ThresholdBoundType = { lowerBound: ThresholdType; upperBound: ThresholdType };

--- a/src/UBAFeeCalculator/index.ts
+++ b/src/UBAFeeCalculator/index.ts
@@ -2,3 +2,4 @@ export { default as UBAFeeConfig } from "./UBAFeeConfig";
 export { default as UBAFeeSpokeCalculator } from "./UBAFeeSpokeCalculator";
 export * as UBAFeeUtility from "./UBAFeeUtility";
 export * as analog from "./UBAFeeSpokeCalculatorAnalog";
+export * from "./UBAFeeTypes";

--- a/src/clients/UBAClient/UBAClientTypes.ts
+++ b/src/clients/UBAClient/UBAClientTypes.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from "ethers";
 import { UbaFlow } from "../../interfaces";
-import { UBAActionType } from "../../UBAFeeCalculator/UBAFeeTypes";
-import UBAConfig, { FlowTupleParameters } from "../../UBAFeeCalculator/UBAFeeConfig";
+import { UBAActionType, FlowTupleParameters } from "../../UBAFeeCalculator/UBAFeeTypes";
+import UBAConfig from "../../UBAFeeCalculator/UBAFeeConfig";
 
 export type RequestValidReturnType = { valid: false; reason: string } | { valid: true };
 export type BalancingFeeReturnType = { balancingFee: BigNumber; actionType: UBAActionType };

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -166,6 +166,7 @@ export function getUBAFeeConfig(
 
   const threshold = ubaConfig.rebalance[String(chainId)];
 
+  const chainTokenCombination = `${chainId}-${token}`;
   return new UBAFeeConfig(
     {
       default: ubaConfig.alpha["default"],
@@ -178,14 +179,26 @@ export function getUBAFeeConfig(
       ),
     },
     {
-      [chainId]: {
+      default: {
         lowerBound: {
-          target: threshold.target_lower,
-          threshold: threshold.threshold_lower,
+          target: toBN(0),
+          threshold: toBN(0),
         },
         upperBound: {
-          target: threshold.target_upper,
-          threshold: threshold.threshold_upper,
+          target: toBN(0),
+          threshold: toBN(0),
+        },
+      },
+      override: {
+        [chainTokenCombination]: {
+          lowerBound: {
+            target: threshold.target_lower,
+            threshold: threshold.threshold_lower,
+          },
+          upperBound: {
+            target: threshold.target_upper,
+            threshold: threshold.threshold_upper,
+          },
         },
       },
     },

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import { BigNumber } from "ethers";
 import { HubPoolClient } from "../HubPoolClient";
 import { calculateUtilizationBoundaries, computePiecewiseLinearFunction } from "../../UBAFeeCalculator/UBAFeeUtility";
-import UBAFeeConfig, { FlowTupleParameters } from "../../UBAFeeCalculator/UBAFeeConfig";
+import UBAFeeConfig from "../../UBAFeeCalculator/UBAFeeConfig";
 import {
   SpokePoolClients,
   filterAsync,
@@ -14,7 +14,7 @@ import {
   toBN,
 } from "../../utils";
 import { ERC20__factory } from "../../typechain";
-import { UBAActionType } from "../../UBAFeeCalculator/UBAFeeTypes";
+import { UBAActionType, FlowTupleParameters } from "../../UBAFeeCalculator/UBAFeeTypes";
 import {
   RequestValidReturnType,
   UBABundleState,


### PR DESCRIPTION
## Breaking Changes
- `UBAFeeConfig` makes caller set a default for `balanceTriggerThreshold`, so that calling `getBalanceTriggerThreshold` never returns `undefined`.
- `UBAFeeSpokeCalculatorAnalog` can now assume that the lower/upper bound thresholds are always defined. If they are 0, ignore them.

## Non-Breaking Changes
- Makes all class variables `protected` rather than `private` so that a `MockUBAFeeConfig` can be built easier. When these variables are `private`, then the mock class needs to redefine them which is tedious
- Export types from `UBAFeeConfig` out of `UBAFeeTypes`