### PR TITLE
fix(UBAClient): Add various fixes to updateUBAClients

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.13.3",
+  "version": "0.14.0",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/UBAFeeCalculator/UBAFeeConfig.ts
+++ b/src/UBAFeeCalculator/UBAFeeConfig.ts
@@ -108,11 +108,11 @@ class UBAConfig {
   /**
    * @description Get the balance trigger threshold for a given chain and token
    * @param chainId The chain id
-   * @param l1TokenAddress The token address
+   * @param tokenSymbol The token
    * @returns The balance trigger threshold if it exists
    */
-  public getBalanceTriggerThreshold(chainId: number, l1TokenAddress: string): ThresholdBoundType {
-    const chainTokenCombination = `${chainId}-${l1TokenAddress}`;
+  public getBalanceTriggerThreshold(chainId: number, tokenSymbol: string): ThresholdBoundType {
+    const chainTokenCombination = `${chainId}-${tokenSymbol}`;
     return this.balanceTriggerThreshold.override?.[chainTokenCombination] ?? this.balanceTriggerThreshold.default;
   }
 
@@ -123,8 +123,8 @@ class UBAConfig {
    * @param l1TokenAddress
    * @returns
    */
-  public getTargetBalance(chainId: number, l1TokenAddress: string): BigNumber {
-    const thresholdConfig = this.getBalanceTriggerThreshold(chainId, l1TokenAddress);
+  public getTargetBalance(chainId: number, tokenSymbol: string): BigNumber {
+    const thresholdConfig = this.getBalanceTriggerThreshold(chainId, tokenSymbol);
     return thresholdConfig?.upperBound?.target ?? BigNumber.from(0);
   }
 
@@ -132,9 +132,9 @@ class UBAConfig {
    * Get sum of all spoke target balances for all chains besides hub pool chain for l1TokenAddress.
    * This output should be used to compute LP fee based on total spoke target
    */
-  public getTotalSpokeTargetBalanceForComputingLpFee(l1TokenAddress: string): BigNumber {
+  public getTotalSpokeTargetBalanceForComputingLpFee(tokenSymbol: string): BigNumber {
     return CHAIN_ID_LIST_INDICES.filter((chainId) => chainId !== HUBPOOL_CHAIN_ID).reduce((sum, chainId) => {
-      return sum.add(this.getTargetBalance(chainId, l1TokenAddress));
+      return sum.add(this.getTargetBalance(chainId, tokenSymbol));
     }, BigNumber.from(0));
   }
 

--- a/src/UBAFeeCalculator/UBAFeeConfig.ts
+++ b/src/UBAFeeCalculator/UBAFeeConfig.ts
@@ -1,6 +1,6 @@
 import { BigNumber, ethers } from "ethers";
 import { ThresholdBoundType, FlowTupleParameters } from "./UBAFeeTypes";
-import { CHAIN_ID_LIST_INDICES, HUBPOOL_CHAIN_ID } from "../constants";
+import { CHAIN_ID_LIST_INDICES } from "../constants";
 
 type ChainId = number;
 type RouteCombination = string;
@@ -133,7 +133,7 @@ class UBAConfig {
    * This output should be used to compute LP fee based on total spoke target
    */
   public getTotalSpokeTargetBalanceForComputingLpFee(tokenSymbol: string): BigNumber {
-    return CHAIN_ID_LIST_INDICES.filter((chainId) => chainId !== HUBPOOL_CHAIN_ID).reduce((sum, chainId) => {
+    return CHAIN_ID_LIST_INDICES.reduce((sum, chainId) => {
       return sum.add(this.getTargetBalance(chainId, tokenSymbol));
     }, ethers.constants.Zero);
   }

--- a/src/UBAFeeCalculator/UBAFeeConfig.ts
+++ b/src/UBAFeeCalculator/UBAFeeConfig.ts
@@ -131,6 +131,8 @@ class UBAConfig {
   /**
    * Get sum of all spoke target balances for all chains besides hub pool chain for l1TokenAddress.
    * This output should be used to compute LP fee based on total spoke target
+   * @param tokenSymbol The token to find target balances for
+   * @returns The sum of token balances for a specific token symbol
    */
   public getTotalSpokeTargetBalanceForComputingLpFee(tokenSymbol: string): BigNumber {
     return CHAIN_ID_LIST_INDICES.reduce((sum, chainId) => {

--- a/src/UBAFeeCalculator/UBAFeeConfig.ts
+++ b/src/UBAFeeCalculator/UBAFeeConfig.ts
@@ -108,7 +108,7 @@ class UBAConfig {
   /**
    * @description Get the balance trigger threshold for a given chain and token
    * @param chainId The chain id
-   * @param tokenSymbol The token
+   * @param tokenSymbol The symbol of the token which will be resolved
    * @returns The balance trigger threshold if it exists
    */
   public getBalanceTriggerThreshold(chainId: number, tokenSymbol: string): ThresholdBoundType {

--- a/src/UBAFeeCalculator/UBAFeeConfig.ts
+++ b/src/UBAFeeCalculator/UBAFeeConfig.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "ethers";
+import { BigNumber, ethers } from "ethers";
 import { ThresholdBoundType, FlowTupleParameters } from "./UBAFeeTypes";
 import { CHAIN_ID_LIST_INDICES, HUBPOOL_CHAIN_ID } from "../constants";
 
@@ -125,7 +125,7 @@ class UBAConfig {
    */
   public getTargetBalance(chainId: number, tokenSymbol: string): BigNumber {
     const thresholdConfig = this.getBalanceTriggerThreshold(chainId, tokenSymbol);
-    return thresholdConfig?.upperBound?.target ?? BigNumber.from(0);
+    return thresholdConfig?.upperBound?.target ?? ethers.constants.Zero;
   }
 
   /**
@@ -135,7 +135,7 @@ class UBAConfig {
   public getTotalSpokeTargetBalanceForComputingLpFee(tokenSymbol: string): BigNumber {
     return CHAIN_ID_LIST_INDICES.filter((chainId) => chainId !== HUBPOOL_CHAIN_ID).reduce((sum, chainId) => {
       return sum.add(this.getTargetBalance(chainId, tokenSymbol));
-    }, BigNumber.from(0));
+    }, ethers.constants.Zero);
   }
 
   /**
@@ -144,7 +144,7 @@ class UBAConfig {
    * @returns The incentive pool adjustment. Defaults to 0 if not set
    */
   public getIncentivePoolAdjustment(chainId: string): BigNumber {
-    return this.incentivePoolAdjustment?.[chainId] ?? BigNumber.from(0); // Default to 0 if not set
+    return this.incentivePoolAdjustment?.[chainId] ?? ethers.constants.Zero; // Default to 0 if not set
   }
 
   /**
@@ -153,7 +153,7 @@ class UBAConfig {
    * @returns The UBA reward multiplier. Defaults to 1 if not set
    */
   public getUbaRewardMultiplier(chainId: string): BigNumber {
-    return this.ubaRewardMultiplier?.[chainId] ?? BigNumber.from(1); // Default to 1 if not set
+    return this.ubaRewardMultiplier?.[chainId] ?? ethers.constants.One; // Default to 1 if not set
   }
 }
 

--- a/src/UBAFeeCalculator/UBAFeeUtility.ts
+++ b/src/UBAFeeCalculator/UBAFeeUtility.ts
@@ -2,7 +2,6 @@ import { BigNumber } from "ethers";
 import { MAX_SAFE_JS_INT } from "@uma/common/dist/Constants";
 import { fixedPointAdjustment, toBN } from "../utils";
 import { HUBPOOL_CHAIN_ID } from "../constants";
-import { UBAActionType } from "./UBAFeeTypes";
 
 /**
  * Computes a linear integral over a piecewise function
@@ -319,26 +318,13 @@ export function calculateUtilization(
 }
 
 export function calculateUtilizationBoundaries(
-  action: {
-    actionType: UBAActionType;
-    amount: BigNumber;
-    chainId: number;
-  },
   decimals: number,
   hubBalance: BigNumber,
   hubEquity: BigNumber,
   ethSpokeBalance: BigNumber,
-  spokeTargets: { target: BigNumber; spokeChainId: number }[],
-  hubPoolChainId = HUBPOOL_CHAIN_ID
+  newEthSpokeBalance: BigNumber,
+  spokeTargets: { target: BigNumber; spokeChainId: number }[]
 ): { utilizationPostTx: BigNumber; utilizationPreTx: BigNumber } {
-  let newEthSpokeBalance = ethSpokeBalance;
-  if (action.chainId === hubPoolChainId) {
-    if (action.actionType === UBAActionType.Deposit) {
-      newEthSpokeBalance = newEthSpokeBalance.add(action.amount);
-    } else {
-      newEthSpokeBalance = newEthSpokeBalance.sub(action.amount);
-    }
-  }
   return {
     utilizationPreTx: calculateUtilization(decimals, hubBalance, hubEquity, ethSpokeBalance, spokeTargets),
     utilizationPostTx: calculateUtilization(decimals, hubBalance, hubEquity, newEthSpokeBalance, spokeTargets),

--- a/src/UBAFeeCalculator/UBAFeeUtility.ts
+++ b/src/UBAFeeCalculator/UBAFeeUtility.ts
@@ -290,44 +290,6 @@ export function computePiecewiseLinearFunction(
   return integral.mul(scale);
 }
 
-export function calculateUtilization(
-  decimals: number,
-  hubBalance: BigNumber,
-  hubLiquidReserves: BigNumber,
-  ethSpokeDelta: BigNumber,
-  cumulativeSpokeTargets: BigNumber
-) {
-  const numerator = hubLiquidReserves.add(ethSpokeDelta).add(cumulativeSpokeTargets);
-  const denominator = hubBalance;
-  const result = numerator.mul(fixedPointAdjustment).div(denominator); // We need to multiply by 1e18 to get the correct precision for the result
-  return BigNumber.from(10).pow(decimals).sub(result);
-}
-
-export function calculateUtilizationBoundaries(
-  decimals: number,
-  hubBalance: BigNumber,
-  hubLiquidReserves: BigNumber,
-  newEthSpokeBalance: BigNumber,
-  cumulativeSpokeTargets: BigNumber
-): { utilizationPostTx: BigNumber; utilizationPreTx: BigNumber } {
-  return {
-    utilizationPreTx: calculateUtilization(
-      decimals,
-      hubBalance,
-      hubLiquidReserves,
-      newEthSpokeBalance,
-      cumulativeSpokeTargets
-    ),
-    utilizationPostTx: calculateUtilization(
-      decimals,
-      hubBalance,
-      hubLiquidReserves,
-      newEthSpokeBalance,
-      cumulativeSpokeTargets
-    ),
-  };
-}
-
 /**
  * A mapping of the balancing fee functions to the inflow/outflow types. This is used to
  * as a convenience to avoid having to do multiple if/else statements in the UBAFeeCalculator

--- a/src/UBAFeeCalculator/UBAFeeUtility.ts
+++ b/src/UBAFeeCalculator/UBAFeeUtility.ts
@@ -290,25 +290,15 @@ export function computePiecewiseLinearFunction(
   return integral.mul(scale);
 }
 
-/**
- * Computes the utilization at a given point in time based on the
- * current balances and equity of the hub and spoke pool targets.
- * @param decimals The number of decimals for the token
- * @param hubBalance The current balance of the hub pool for the token
- * @param hubEquity The current equity of the hub pool for the token
- * @param ethSpokeBalance The current balance of the ETH spoke pool for the token
- * @param targetSpoke The current balance of the target spoke pool for the token - this is a list.
- * @returns The utilization of the hub pool
- */
 export function calculateUtilization(
   decimals: number,
   hubBalance: BigNumber,
-  hubEquity: BigNumber,
-  ethSpokeBalance: BigNumber,
+  hubLiquidReserves: BigNumber,
+  ethSpokeDelta: BigNumber,
   cumulativeSpokeTargets: BigNumber
 ) {
-  const numerator = hubBalance.add(ethSpokeBalance).add(cumulativeSpokeTargets);
-  const denominator = hubEquity;
+  const numerator = hubLiquidReserves.add(ethSpokeDelta).add(cumulativeSpokeTargets);
+  const denominator = hubBalance;
   const result = numerator.mul(fixedPointAdjustment).div(denominator); // We need to multiply by 1e18 to get the correct precision for the result
   return BigNumber.from(10).pow(decimals).sub(result);
 }
@@ -316,17 +306,22 @@ export function calculateUtilization(
 export function calculateUtilizationBoundaries(
   decimals: number,
   hubBalance: BigNumber,
-  hubEquity: BigNumber,
-  ethSpokeBalance: BigNumber,
+  hubLiquidReserves: BigNumber,
   newEthSpokeBalance: BigNumber,
   cumulativeSpokeTargets: BigNumber
 ): { utilizationPostTx: BigNumber; utilizationPreTx: BigNumber } {
   return {
-    utilizationPreTx: calculateUtilization(decimals, hubBalance, hubEquity, ethSpokeBalance, cumulativeSpokeTargets),
+    utilizationPreTx: calculateUtilization(
+      decimals,
+      hubBalance,
+      hubLiquidReserves,
+      newEthSpokeBalance,
+      cumulativeSpokeTargets
+    ),
     utilizationPostTx: calculateUtilization(
       decimals,
       hubBalance,
-      hubEquity,
+      hubLiquidReserves,
       newEthSpokeBalance,
       cumulativeSpokeTargets
     ),

--- a/src/apiClient/mockedClient.ts
+++ b/src/apiClient/mockedClient.ts
@@ -47,20 +47,20 @@ export default class MockedApiClient extends AbstractApiClient {
     return Promise.resolve(
       this.mockedData.SuggestedFees ?? {
         relayerFee: {
-          pct: ethers.BigNumber.from("1"),
-          total: ethers.BigNumber.from("1"),
+          pct: ethers.constants.One,
+          total: ethers.constants.One,
         },
         relayerCapitalFee: {
-          pct: ethers.BigNumber.from("1"),
-          total: ethers.BigNumber.from("1"),
+          pct: ethers.constants.One,
+          total: ethers.constants.One,
         },
         relayerGasFee: {
-          pct: ethers.BigNumber.from("1"),
-          total: ethers.BigNumber.from("1"),
+          pct: ethers.constants.One,
+          total: ethers.constants.One,
         },
         isAmountTooLow: false,
-        quoteBlock: ethers.BigNumber.from("1"),
-        quoteTimestamp: ethers.BigNumber.from("1"),
+        quoteBlock: ethers.constants.One,
+        quoteTimestamp: ethers.constants.One,
       }
     );
   }

--- a/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
+++ b/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
@@ -471,7 +471,7 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
    * @returns The UBA config for the given L1 token address and block number, or undefined if no config exists
    * before blockNumber.
    */
-  getUBAConfig(l1TokenAddress: string, blockNumber = Number.MAX_SAFE_INTEGER): UBAParsedConfigType | undefined {
+  public getUBAConfig(l1TokenAddress: string, blockNumber = Number.MAX_SAFE_INTEGER): UBAParsedConfigType | undefined {
     // We only care about searching on the block number and not any events that occurred in the same block
     // but with a lower transaction index. In other words, if the UBA config was updated as the absolute
     // last transaction in a block, the update still applies to all preceding UBA events in the same block.

--- a/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
+++ b/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
@@ -36,6 +36,7 @@ import { across } from "@uma/sdk";
 import { parseUBAConfigFromOnChain } from "./ConfigStoreParsingUtilities";
 import { BaseAbstractClient } from "../BaseAbstractClient";
 import { parseJSONWithNumericString } from "../../utils/JSONUtils";
+import { CHAIN_ID_LIST_INDICES } from "../../constants";
 
 type _ConfigStoreUpdate = {
   success: true;
@@ -462,11 +463,10 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
   }
 
   async getUBATargetSpokeBalances(
-    chainIds: number[],
     l1TokenAddress: string,
     blockNumber?: number
   ): Promise<{ spokeChainId: number; target: BigNumber }[]> {
-    return chainIds.map((chainId) => {
+    return CHAIN_ID_LIST_INDICES.map((chainId) => {
       const target = this.getSpokeTargetBalancesForBlock(l1TokenAddress, chainId, blockNumber).target;
       return { spokeChainId: chainId, target };
     });

--- a/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
+++ b/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
@@ -36,7 +36,6 @@ import { across } from "@uma/sdk";
 import { parseUBAConfigFromOnChain } from "./ConfigStoreParsingUtilities";
 import { BaseAbstractClient } from "../BaseAbstractClient";
 import { parseJSONWithNumericString } from "../../utils/JSONUtils";
-import { CHAIN_ID_LIST_INDICES } from "../../constants";
 
 type _ConfigStoreUpdate = {
   success: true;
@@ -90,6 +89,10 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
     this.rateModelDictionary = new across.rateModel.RateModelDictionary();
   }
 
+  // <-- START LEGACY CONFIGURATION OBJECTS -->
+  // @dev The following configuration objects are pre-UBA fee model configurations and are deprecated as of version
+  // 2 of the ConfigStore. They are kept here for backwards compatibility.
+
   getRateModelForBlockNumber(
     l1Token: string,
     originChainId: number | string,
@@ -137,6 +140,7 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
     const targetBalance = config?.spokeTargetBalances?.[chainId];
     return targetBalance || { target: toBN(0), threshold: toBN(0) };
   }
+  // <-- END LEGACY CONFIGURATION OBJECTS -->
 
   getMaxRefundCountForRelayerRefundLeafForBlock(blockNumber: number = Number.MAX_SAFE_INTEGER): number {
     const config = (sortEventsDescending(this.cumulativeMaxRefundCountUpdates) as GlobalConfigUpdate[]).find(
@@ -460,16 +464,6 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
     // If any chain ID's are not integers then ignore. UMIP-157 requires that this key cannot include
     // the chain ID 1.
     return disabledChains.filter((chainId: number) => !isNaN(chainId) && Number.isInteger(chainId) && chainId !== 1);
-  }
-
-  async getUBATargetSpokeBalances(
-    l1TokenAddress: string,
-    blockNumber?: number
-  ): Promise<{ spokeChainId: number; target: BigNumber }[]> {
-    return CHAIN_ID_LIST_INDICES.map((chainId) => {
-      const target = this.getSpokeTargetBalancesForBlock(l1TokenAddress, chainId, blockNumber).target;
-      return { spokeChainId: chainId, target };
-    });
   }
 
   /**

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -503,7 +503,7 @@ export class HubPoolClient extends BaseAbstractClient {
     return this.getRunningBalanceForToken(l1Token, executedRootBundle);
   }
 
-  getRunningBalanceForToken(l1Token: string, executedRootBundle: ExecutedRootBundle): TokenRunningBalance {
+  public getRunningBalanceForToken(l1Token: string, executedRootBundle: ExecutedRootBundle): TokenRunningBalance {
     let runningBalance = toBN(0);
     let incentiveBalance = toBN(0);
     if (executedRootBundle) {

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -500,6 +500,10 @@ export class HubPoolClient extends BaseAbstractClient {
       }
     ) as ExecutedRootBundle;
 
+    return this.getRunningBalanceForToken(l1Token, executedRootBundle);
+  }
+
+  getRunningBalanceForToken(l1Token: string, executedRootBundle: ExecutedRootBundle): TokenRunningBalance {
     let runningBalance = toBN(0);
     let incentiveBalance = toBN(0);
     if (executedRootBundle) {

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -15,7 +15,7 @@ import {
 import { toBN, paginatedEventQuery, spreadEventWithBlockNumber } from "../utils";
 import winston from "winston";
 
-import { Contract, BigNumber, Event, EventFilter } from "ethers";
+import { Contract, BigNumber, Event, EventFilter, ethers } from "ethers";
 
 import {
   Deposit,
@@ -261,7 +261,7 @@ export class SpokePoolClient extends BaseAbstractClient {
         const relayer = refundLeaf.refundAddresses[i];
         const refundAmount = refundLeaf.refundAmounts[i];
         if (executedTokenRefunds[relayer] === undefined) {
-          executedTokenRefunds[relayer] = BigNumber.from(0);
+          executedTokenRefunds[relayer] = ethers.constants.Zero;
         }
         executedTokenRefunds[relayer] = executedTokenRefunds[relayer].add(refundAmount);
       }

--- a/src/clients/UBAClient/UBAClientBase.ts
+++ b/src/clients/UBAClient/UBAClientBase.ts
@@ -218,7 +218,7 @@ export class BaseUBAClient extends BaseAbstractClient {
       }
       // TODO: Fix this by looking up the token address from the token symbol at the time of the hubPoolBlockNumber
       const tokenMappingLookup = (
-        TOKEN_SYMBOLS_MAP as Record<string, { addresses: { [x: number]: string }; decimals: number }>
+        TOKEN_SYMBOLS_MAP as Record<string, { addresses: { [x: number]: string }; decimals: number; symbol: string }>
       )[tokenSymbol];
       const hubPoolTokenAddress = tokenMappingLookup.addresses[hubPoolClient.chainId];
       const erc20 = ERC20__factory.connect(hubPoolTokenAddress, hubPoolClient.hubPool.provider);
@@ -229,8 +229,9 @@ export class BaseUBAClient extends BaseAbstractClient {
       ]);
       const ubaConfigForBundle = recentBundleState.config;
       // We will need to sum them all up for this token to compute the LP fee correctly.
-      const cumulativeSpokeTargets =
-        ubaConfigForBundle.getTotalSpokeTargetBalanceForComputingLpFee(hubPoolTokenAddress);
+      const cumulativeSpokeTargets = ubaConfigForBundle.getTotalSpokeTargetBalanceForComputingLpFee(
+        tokenMappingLookup.symbol
+      );
       overrides = {
         decimals: tokenMappingLookup.decimals,
         hubBalance,

--- a/src/clients/UBAClient/UBAClientBase.ts
+++ b/src/clients/UBAClient/UBAClientBase.ts
@@ -200,7 +200,7 @@ export class BaseUBAClient extends BaseAbstractClient {
    * @param hubPoolBlockNumber The block number to get the LP fee for
    * @returns The LP fee for the given token on the given chainId at the given block number
    */
-  protected async computeLpFee(
+  protected computeLpFee(
     hubPoolBlockNumber: number,
     amount: BigNumber,
     depositChainId: number,
@@ -208,7 +208,7 @@ export class BaseUBAClient extends BaseAbstractClient {
     tokenSymbol: string,
     hubBalance: BigNumber,
     hubLiquidReserves: BigNumber
-  ): Promise<BigNumber> {
+  ): BigNumber {
     // It doesn't actually matter which `chainId` we query the bundle state for. Its only important
     // that we return the bundle config for the correct token that was used at the time of the hubPoolBlockNumber.
     // To be safe, use the hub chain since its guaranteed to have a bundle state in memory.
@@ -248,7 +248,7 @@ export class BaseUBAClient extends BaseAbstractClient {
    * @param overrides The overrides to use for the LP fee calculation
    * @returns The system fee for the given token on the given chainId at the given block number
    */
-  public async computeSystemFee(
+  public computeSystemFee(
     hubPoolBlockNumber: number,
     amount: BigNumber,
     depositChainId: number,
@@ -256,8 +256,8 @@ export class BaseUBAClient extends BaseAbstractClient {
     tokenSymbol: string,
     hubBalance: BigNumber,
     hubLiquidReserves: BigNumber
-  ): Promise<SystemFeeResult> {
-    const lpFee = await this.computeLpFee(
+  ): SystemFeeResult {
+    const lpFee = this.computeLpFee(
       hubPoolBlockNumber,
       amount,
       depositChainId,

--- a/src/clients/UBAClient/UBAClientBase.ts
+++ b/src/clients/UBAClient/UBAClientBase.ts
@@ -69,7 +69,7 @@ export class BaseUBAClient extends BaseAbstractClient {
    * @param hubPoolBlockNumber The bundle state was proposed at or before this block
    * @param chainId
    * @param tokenSymbol
-   * @returns
+   * @returns the most recent bundle state for a given chain and token combination prior to the given block number.
    */
   public retrieveBundleStateForBlock(
     hubPoolBlockNumber: number,

--- a/src/clients/UBAClient/UBAClientBase.ts
+++ b/src/clients/UBAClient/UBAClientBase.ts
@@ -13,6 +13,7 @@ import { computeLpFeeStateful } from "./UBAClientUtilities";
 import { findLast } from "../../utils/ArrayUtils";
 import { analog } from "../../UBAFeeCalculator";
 import { BaseAbstractClient } from "../BaseAbstractClient";
+import _ from "lodash";
 
 /**
  * UBAClient is a base class for UBA functionality. It provides a common interface for UBA functionality to be implemented on top of or extended.
@@ -76,12 +77,8 @@ export class BaseUBAClient extends BaseAbstractClient {
     chainId: number,
     tokenSymbol: string
   ): UBABundleState | undefined {
-    const sortedDescendingBundleStates = [
-      ...this.retrieveBundleStates(chainId, tokenSymbol).sort(
-        (a, b) => b.openingBlockNumberForSpokeChain - a.openingBlockNumberForSpokeChain
-      ),
-    ];
-    return sortedDescendingBundleStates.find(
+    return _.findLast(
+      this.retrieveBundleStates(chainId, tokenSymbol),
       (bundleState: UBABundleState) => bundleState.openingBlockNumberForSpokeChain <= hubPoolBlockNumber
     );
   }

--- a/src/clients/UBAClient/UBAClientBase.ts
+++ b/src/clients/UBAClient/UBAClientBase.ts
@@ -227,21 +227,22 @@ export class BaseUBAClient extends BaseAbstractClient {
         erc20.balanceOf(hubPoolClient.hubPool.address, { blockTag: hubPoolBlockNumber }),
         erc20.balanceOf(hubPoolClient.hubPool.address, { blockTag: hubPoolBlockNumber }),
       ]);
-      const spokeTargets = await hubPoolClient.configStoreClient.getUBATargetSpokeBalances(
-        hubPoolTokenAddress,
-        hubPoolBlockNumber
-      );
+      const ubaConfigForBundle = recentBundleState.config.ubaConfig;
+      // We will need to sum them all up for this token to compute the LP fee correctly.
+      const cumulativeSpokeTargets =
+        ubaConfigForBundle.getTotalSpokeTargetBalanceForComputingLpFee(hubPoolTokenAddress);
       overrides = {
         decimals: recentBundleState.config.tokenDecimals,
         hubBalance,
         hubEquity,
         ethSpokeBalance,
-        spokeTargets,
+        cumulativeSpokeTargets,
         baselineFee: recentBundleState.config.ubaConfig.getBaselineFee(refundChainId ?? depositChainId, depositChainId),
         gammaCutoff: recentBundleState.config.ubaConfig.getLpGammaFunctionTuples(depositChainId),
       };
     }
-    const { decimals, hubBalance, hubEquity, ethSpokeBalance, spokeTargets, baselineFee, gammaCutoff } = overrides;
+    const { decimals, hubBalance, hubEquity, ethSpokeBalance, cumulativeSpokeTargets, baselineFee, gammaCutoff } =
+      overrides;
 
     return computeLpFeeStateful(
       amount,
@@ -252,7 +253,7 @@ export class BaseUBAClient extends BaseAbstractClient {
       hubBalance,
       hubEquity,
       ethSpokeBalance,
-      spokeTargets,
+      cumulativeSpokeTargets,
       baselineFee,
       gammaCutoff
     );

--- a/src/clients/UBAClient/UBAClientBase.ts
+++ b/src/clients/UBAClient/UBAClientBase.ts
@@ -153,14 +153,14 @@ export class BaseUBAClient extends BaseAbstractClient {
       specificBundleState.openingIncentiveBalance,
       chainId,
       tokenSymbol,
-      specificBundleState.config.ubaConfig
+      specificBundleState.config
     );
     const { balancingFee } = analog.feeCalculationFunctionsForUBA[feeType](
       amount,
       runningBalance,
       incentiveBalance,
       chainId,
-      specificBundleState.config.ubaConfig
+      specificBundleState.config
     );
     return {
       balancingFee: balancingFee,
@@ -227,18 +227,18 @@ export class BaseUBAClient extends BaseAbstractClient {
         erc20.balanceOf(hubPoolClient.hubPool.address, { blockTag: hubPoolBlockNumber }),
         erc20.balanceOf(hubPoolClient.hubPool.address, { blockTag: hubPoolBlockNumber }),
       ]);
-      const ubaConfigForBundle = recentBundleState.config.ubaConfig;
+      const ubaConfigForBundle = recentBundleState.config;
       // We will need to sum them all up for this token to compute the LP fee correctly.
       const cumulativeSpokeTargets =
         ubaConfigForBundle.getTotalSpokeTargetBalanceForComputingLpFee(hubPoolTokenAddress);
       overrides = {
-        decimals: recentBundleState.config.tokenDecimals,
+        decimals: tokenMappingLookup.decimals,
         hubBalance,
         hubEquity,
         ethSpokeBalance,
         cumulativeSpokeTargets,
-        baselineFee: recentBundleState.config.ubaConfig.getBaselineFee(refundChainId ?? depositChainId, depositChainId),
-        gammaCutoff: recentBundleState.config.ubaConfig.getLpGammaFunctionTuples(depositChainId),
+        baselineFee: recentBundleState.config.getBaselineFee(refundChainId ?? depositChainId, depositChainId),
+        gammaCutoff: recentBundleState.config.getLpGammaFunctionTuples(depositChainId),
       };
     }
     const { decimals, hubBalance, hubEquity, ethSpokeBalance, cumulativeSpokeTargets, baselineFee, gammaCutoff } =

--- a/src/clients/UBAClient/UBAClientTypes.ts
+++ b/src/clients/UBAClient/UBAClientTypes.ts
@@ -1,10 +1,15 @@
 import { BigNumber } from "ethers";
-import { FillWithBlock, UbaFlow } from "../../interfaces";
-import { UBAActionType, FlowTupleParameters } from "../../UBAFeeCalculator/UBAFeeTypes";
+import { DepositWithBlock, FillWithBlock, UbaFlow } from "../../interfaces";
+import { UBAActionType } from "../../UBAFeeCalculator/UBAFeeTypes";
 import UBAConfig from "../../UBAFeeCalculator/UBAFeeConfig";
 
 // @todo: Revert to this after bumping typescript: { valid: true, fill: FillWithBlock } | { valid: false, reason: string } ;
-export type RequestValidReturnType = { valid: boolean; reason?: string; matchingFill?: FillWithBlock };
+export type RequestValidReturnType = {
+  valid: boolean;
+  reason?: string;
+  matchingFill?: FillWithBlock;
+  matchingDeposit?: DepositWithBlock;
+};
 export type BalancingFeeReturnType = { balancingFee: BigNumber; actionType: UBAActionType };
 export type SystemFeeResult = { lpFee: BigNumber; depositBalancingFee: BigNumber; systemFee: BigNumber };
 export type RelayerFeeResult = {
@@ -39,16 +44,6 @@ export type UBABundleState = {
   openingBlockNumberForSpokeChain: number;
   config: UBAConfig;
   flows: ModifiedUBAFlow[];
-};
-
-export type UBALPFeeOverride = {
-  decimals: number;
-  hubBalance: BigNumber;
-  hubEquity: BigNumber;
-  ethSpokeBalance: BigNumber;
-  cumulativeSpokeTargets: BigNumber;
-  baselineFee: BigNumber;
-  gammaCutoff: FlowTupleParameters;
 };
 
 export type UBAClientState = {

--- a/src/clients/UBAClient/UBAClientTypes.ts
+++ b/src/clients/UBAClient/UBAClientTypes.ts
@@ -51,10 +51,7 @@ export type UBALPFeeOverride = {
   hubBalance: BigNumber;
   hubEquity: BigNumber;
   ethSpokeBalance: BigNumber;
-  spokeTargets: {
-    spokeChainId: number;
-    target: BigNumber;
-  }[];
+  cumulativeSpokeTargets: BigNumber;
   baselineFee: BigNumber;
   gammaCutoff: FlowTupleParameters;
 };

--- a/src/clients/UBAClient/UBAClientTypes.ts
+++ b/src/clients/UBAClient/UBAClientTypes.ts
@@ -33,16 +33,11 @@ export type ModifiedUBAFlow = {
   netRunningBalanceAdjustment: BigNumber;
 };
 
-type UBABundleConfig = {
-  ubaConfig: UBAConfig;
-  tokenDecimals: number;
-};
-
 export type UBABundleState = {
   openingBalance: BigNumber;
   openingIncentiveBalance: BigNumber;
   openingBlockNumberForSpokeChain: number;
-  config: UBABundleConfig;
+  config: UBAConfig;
   flows: ModifiedUBAFlow[];
 };
 

--- a/src/clients/UBAClient/UBAClientTypes.ts
+++ b/src/clients/UBAClient/UBAClientTypes.ts
@@ -8,11 +8,7 @@ export type RequestValidReturnType = { valid: boolean; reason?: string; matching
 export type BalancingFeeReturnType = { balancingFee: BigNumber; actionType: UBAActionType };
 export type SystemFeeResult = { lpFee: BigNumber; depositBalancingFee: BigNumber; systemFee: BigNumber };
 export type RelayerFeeResult = {
-  relayerGasFee: BigNumber;
-  relayerCapitalFee: BigNumber;
   relayerBalancingFee: BigNumber;
-  relayerFee: BigNumber;
-  amountTooLow: boolean;
 };
 
 export type UBAChainState = {
@@ -40,9 +36,6 @@ export type ModifiedUBAFlow = {
 type UBABundleConfig = {
   ubaConfig: UBAConfig;
   tokenDecimals: number;
-  hubBalance: BigNumber;
-  hubEquity: BigNumber;
-  hubPoolSpokeBalance: BigNumber;
   spokeTargets: {
     spokeChainId: number;
     target: BigNumber;

--- a/src/clients/UBAClient/UBAClientTypes.ts
+++ b/src/clients/UBAClient/UBAClientTypes.ts
@@ -36,10 +36,6 @@ export type ModifiedUBAFlow = {
 type UBABundleConfig = {
   ubaConfig: UBAConfig;
   tokenDecimals: number;
-  spokeTargets: {
-    spokeChainId: number;
-    target: BigNumber;
-  }[];
 };
 
 export type UBABundleState = {

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -364,10 +364,11 @@ export async function updateUBAClient(
           await Promise.all(
             relevantTokenSymbols.map(async (tokenSymbol) => {
               // TODO: Replace the following code by mapping by this entire client by l1TokenAddress instead of tokenSymbol.
-              const l1TokenAddress = hubPoolClient.getL1Tokens().find((token) => token.symbol === tokenSymbol)?.address;
-              if (!l1TokenAddress) {
+              const l1TokenInfo = hubPoolClient.getL1Tokens().find((token) => token.symbol === tokenSymbol);
+              if (!l1TokenInfo) {
                 throw new Error(`No L1 token address mapped to symbol ${tokenSymbol}`);
               }
+              const l1TokenAddress = l1TokenInfo.address;
 
               // Get the block number and opening balance for this token. This can be read directly from root bundle
               // data that we've already loaded.
@@ -388,7 +389,9 @@ export async function updateUBAClient(
                 startingBundleBlockNumber
               );
               // We will need to sum them all up for this token to compute the LP fee correctly.
-              cumulativeSpokeTargets = ubaConfigForBundle.getTotalSpokeTargetBalanceForComputingLpFee(l1TokenAddress);
+              cumulativeSpokeTargets = ubaConfigForBundle.getTotalSpokeTargetBalanceForComputingLpFee(
+                l1TokenInfo.symbol
+              );
 
               // Construct the bundle data for this token.
               const constructedBundle: UBABundleState = {

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -598,7 +598,7 @@ async function getFlows(
           }
           return {
             ...refundRequest,
-            quoteBlockNumber: result.matchingDeposit.quoteBlockNumber,
+            quoteBlockNumber: matchingDeposit.quoteBlockNumber,
           };
         } else {
           return undefined;

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -147,14 +147,14 @@ export function getUBAFeeConfig(
   configClient: AcrossConfigStoreClient,
   chainId: number,
   l1TokenAddress: string,
-  blockNumber: number | "latest" = "latest"
+  blockNumber?: number
 ): UBAFeeConfig {
   // If the config client has not been updated at least
   // once, throw
   if (!configClient.isUpdated) {
     throw new Error("Config client not updated");
   }
-  const ubaConfig = configClient.getUBAConfig(l1TokenAddress, blockNumber === "latest" ? undefined : blockNumber);
+  const ubaConfig = configClient.getUBAConfig(l1TokenAddress, blockNumber);
   if (ubaConfig === undefined) {
     throw new Error(`UBA config for blockTag ${blockNumber} not found`);
   }

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -210,6 +210,15 @@ export function getUBAFeeConfig(
   );
 }
 
+/**
+ * Returns most recent `maxBundleStates` bundle ranges for a given chain, in chronological ascending order.
+ * @param chainId
+ * @param maxBundleStates If this is larger than available validated bundles in the HubPoolClient, will throw an error.
+ * @param mostRecentHubPoolBlock Only returns the most recent validated bundles proposed before this block.
+ * @param hubPoolClient
+ * @param spokePoolClients
+ * @returns
+ */
 export function getMostRecentBundleBlockRanges(
   chainId: number,
   maxBundleStates: number,
@@ -235,7 +244,7 @@ export function getMostRecentBundleBlockRanges(
     // Make sure our spoke pool clients have the block ranges we need to look up data in this bundle range:
     if (blockRangesAreInvalidForSpokeClients(spokePoolClients, rootBundleBlockRanges)) {
       throw new Error(
-        `Spoke pool clients do not have the block ranges necessary to look up data for bundles ${
+        `Spoke pool clients do not have the block ranges necessary to look up data for bundle proposed at block ${
           latestExecutedRootBundle.blockNumber
         }: ${JSON.stringify(rootBundleBlockRanges)}`
       );
@@ -302,6 +311,7 @@ export async function updateUBAClient(
     };
 
     // Grab all bundle ranges for this chain. This logic is isolated into a function that we can unit test.
+    // The bundles are returned in ascending order.
     const bundleBounds = getMostRecentBundleBlockRanges(
       chainId,
       maxBundleStates,

--- a/src/clients/UBAClient/UBAClientWithRefresh.ts
+++ b/src/clients/UBAClient/UBAClientWithRefresh.ts
@@ -58,21 +58,19 @@ export class UBAClientWithRefresh extends BaseUBAClient {
    * @param depositChainId The chainId of the deposit
    * @param refundChainId The chainId of the refund
    * @param amount The amount that is being deposited
-   * @param hubPoolClient A hubpool client instance to query the hubpool
+   * @param hubPoolClient A hub pool client instance to query the hub pool
    * @param spokePoolClients A mapping of spoke chainIds to spoke pool clients
    * @returns The realized LP fee for the given token on the given chainId at the given block number
    */
-  public async computeLpFee(
+  public async computeRefreshedLpFee(
     hubPoolBlockNumber: number,
     amount: BigNumber,
     depositChainId: number,
     refundChainId: number,
-    tokenSymbol: string,
-    _hubBalance?: BigNumber,
-    _hubLiquidReserves?: BigNumber
+    tokenSymbol: string
   ): Promise<BigNumber> {
     const { hubBalance, hubLiquidReserves } = await getLpFeeParams(hubPoolBlockNumber, tokenSymbol, this.hubPoolClient);
-    return await super.computeLpFee(
+    return super.computeLpFee(
       hubPoolBlockNumber,
       amount,
       depositChainId,
@@ -83,17 +81,15 @@ export class UBAClientWithRefresh extends BaseUBAClient {
     );
   }
 
-  public async computeSystemFee(
+  public async computeRefreshedSystemFee(
     hubPoolBlockNumber: number,
     amount: BigNumber,
     depositChainId: number,
     destinationChainId: number,
-    tokenSymbol: string,
-    _hubBalance: BigNumber,
-    _hubLiquidReserves: BigNumber
+    tokenSymbol: string
   ): Promise<SystemFeeResult> {
     const { hubBalance, hubLiquidReserves } = await getLpFeeParams(hubPoolBlockNumber, tokenSymbol, this.hubPoolClient);
-    return await super.computeSystemFee(
+    return super.computeSystemFee(
       hubPoolBlockNumber,
       amount,
       depositChainId,

--- a/src/clients/UBAClient/UBAClientWithRefresh.ts
+++ b/src/clients/UBAClient/UBAClientWithRefresh.ts
@@ -2,9 +2,8 @@ import assert from "assert";
 import winston from "winston";
 import { HubPoolClient, SpokePoolClient } from "..";
 import { BaseUBAClient } from "./UBAClientBase";
-import { getLpFeeParams, updateUBAClient } from "./UBAClientUtilities";
-import { SystemFeeResult, UBAChainState } from "./UBAClientTypes";
-import { BigNumber } from "ethers";
+import { updateUBAClient } from "./UBAClientUtilities";
+import { UBAChainState } from "./UBAClientTypes";
 export class UBAClientWithRefresh extends BaseUBAClient {
   // @dev chainIdIndices supports indexing members of root bundle proposals submitted to the HubPool.
   //      It must include the complete set of chain IDs ever supported by the HubPool.
@@ -51,55 +50,6 @@ export class UBAClientWithRefresh extends BaseUBAClient {
       )
     );
   }
-
-  /**
-   * Compute the realized LP fee for a given amount.
-   * @param hubPoolTokenAddress The L1 token address to get the LP fee
-   * @param depositChainId The chainId of the deposit
-   * @param refundChainId The chainId of the refund
-   * @param amount The amount that is being deposited
-   * @param hubPoolClient A hub pool client instance to query the hub pool
-   * @param spokePoolClients A mapping of spoke chainIds to spoke pool clients
-   * @returns The realized LP fee for the given token on the given chainId at the given block number
-   */
-  public async computeRefreshedLpFee(
-    hubPoolBlockNumber: number,
-    amount: BigNumber,
-    depositChainId: number,
-    refundChainId: number,
-    tokenSymbol: string
-  ): Promise<BigNumber> {
-    const { hubBalance, hubLiquidReserves } = await getLpFeeParams(hubPoolBlockNumber, tokenSymbol, this.hubPoolClient);
-    return super.computeLpFee(
-      hubPoolBlockNumber,
-      amount,
-      depositChainId,
-      refundChainId,
-      tokenSymbol,
-      hubBalance,
-      hubLiquidReserves
-    );
-  }
-
-  public async computeRefreshedSystemFee(
-    hubPoolBlockNumber: number,
-    amount: BigNumber,
-    depositChainId: number,
-    destinationChainId: number,
-    tokenSymbol: string
-  ): Promise<SystemFeeResult> {
-    const { hubBalance, hubLiquidReserves } = await getLpFeeParams(hubPoolBlockNumber, tokenSymbol, this.hubPoolClient);
-    return super.computeSystemFee(
-      hubPoolBlockNumber,
-      amount,
-      depositChainId,
-      destinationChainId,
-      tokenSymbol,
-      hubBalance,
-      hubLiquidReserves
-    );
-  }
-
   public get isUpdated(): boolean {
     return (
       this.hubPoolClient.configStoreClient.isUpdated &&

--- a/src/clients/UBAClient/UBAClientWithRefresh.ts
+++ b/src/clients/UBAClient/UBAClientWithRefresh.ts
@@ -3,7 +3,6 @@ import winston from "winston";
 import { HubPoolClient, SpokePoolClient } from "..";
 import { BaseUBAClient } from "./UBAClientBase";
 import { updateUBAClient } from "./UBAClientUtilities";
-import { RelayFeeCalculatorConfigWithMap } from "../../relayFeeCalculator";
 import { UBAChainState } from "./UBAClientTypes";
 export class UBAClientWithRefresh extends BaseUBAClient {
   // @dev chainIdIndices supports indexing members of root bundle proposals submitted to the HubPool.
@@ -14,7 +13,6 @@ export class UBAClientWithRefresh extends BaseUBAClient {
     readonly tokens: string[],
     protected readonly hubPoolClient: HubPoolClient,
     public readonly spokePoolClients: { [chainId: number]: SpokePoolClient },
-    protected readonly relayerConfiguration: RelayFeeCalculatorConfigWithMap,
     readonly maxBundleStates: number,
     readonly logger?: winston.Logger
   ) {
@@ -49,7 +47,6 @@ export class UBAClientWithRefresh extends BaseUBAClient {
         this.tokens,
         this.hubPoolClient.latestBlockNumber ?? 0,
         forceClientRefresh,
-        this.relayerConfiguration,
         this.maxBundleStates
       )
     );

--- a/src/clients/mocks/MockHubPoolClient.ts
+++ b/src/clients/mocks/MockHubPoolClient.ts
@@ -39,6 +39,10 @@ export class MockHubPoolClient extends HubPoolClient {
     this.eventManager = getEventManager(chainId, this.eventSignatures, deploymentBlock);
   }
 
+  setLatestBlockNumber(blockNumber: number) {
+    this.latestBlockNumber = blockNumber;
+  }
+
   addEvent(event: Event): void {
     this.events.push(event);
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,9 +3,11 @@ export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 export const HUBPOOL_CHAIN_ID = 1;
 
-// This array contains all chains that Across supports, although some of the chains could be currently disabled.
-// The order of the chains is important to not change, as the dataworker proposes "bundle block numbers" per chain
-// in the same order as the following list. To add a new chain ID, append it to the end of the list. Never delete
-// a chain ID. The on-chain ConfigStore should store a list of enabled/disabled chain ID's that are a subset
-// of this list, so this list is simply the list of all possible Chain ID's that Across could support.
+/**
+ * This array contains all chains that Across supports, although some of the chains could be currently disabled.
+ * The order of the chains is important to not change, as the dataworker proposes "bundle block numbers" per chain
+ * in the same order as the following list. To add a new chain ID, append it to the end of the list. Never delete
+ * a chain ID. The on-chain ConfigStore should store a list of enabled/disabled chain ID's that are a subset
+ * of this list, so this list is simply the list of all possible Chain ID's that Across could support.
+**/
 export const CHAIN_ID_LIST_INDICES = [1, 10, 137, 288, 42161];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,3 +2,10 @@ export { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "@across-protocol/contracts-v2/dist
 export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 export const HUBPOOL_CHAIN_ID = 1;
+
+// This array contains all chains that Across supports, although some of the chains could be currently disabled.
+// The order of the chains is important to not change, as the dataworker proposes "bundle block numbers" per chain
+// in the same order as the following list. To add a new chain ID, append it to the end of the list. Never delete
+// a chain ID. The on-chain ConfigStore should store a list of enabled/disabled chain ID's that are a subset
+// of this list, so this list is simply the list of all possible Chain ID's that Across could support.
+export const CHAIN_ID_LIST_INDICES = [1, 10, 137, 288, 42161];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,5 +9,5 @@ export const HUBPOOL_CHAIN_ID = 1;
  * in the same order as the following list. To add a new chain ID, append it to the end of the list. Never delete
  * a chain ID. The on-chain ConfigStore should store a list of enabled/disabled chain ID's that are a subset
  * of this list, so this list is simply the list of all possible Chain ID's that Across could support.
-**/
+ **/
 export const CHAIN_ID_LIST_INDICES = [1, 10, 137, 288, 42161];

--- a/src/gasPriceOracle/adapters/arbitrum.ts
+++ b/src/gasPriceOracle/adapters/arbitrum.ts
@@ -1,4 +1,4 @@
-import { BigNumber, providers, utils as ethersUtils } from "ethers";
+import { ethers, providers, utils as ethersUtils } from "ethers";
 import { GasPriceEstimate } from "../types";
 import { eip1559 } from "./ethereum";
 
@@ -17,5 +17,5 @@ export async function eip1559_arbitrum(provider: providers.Provider, chainId: nu
   // The caller may apply scaling as they wish afterwards.
   const maxFeePerGas = _maxFeePerGas.sub(maxPriorityFeePerGas).add(1);
 
-  return { maxPriorityFeePerGas: BigNumber.from(1), maxFeePerGas };
+  return { maxPriorityFeePerGas: ethers.constants.One, maxFeePerGas };
 }

--- a/src/gasPriceOracle/adapters/ethereum.ts
+++ b/src/gasPriceOracle/adapters/ethereum.ts
@@ -1,4 +1,4 @@
-import { BigNumber, providers } from "ethers";
+import { BigNumber, providers, ethers } from "ethers";
 import { GasPriceEstimate } from "../types";
 import { gasPriceError } from "../util";
 
@@ -22,6 +22,6 @@ export async function legacy(provider: providers.Provider, chainId: number): Pro
 
   return {
     maxFeePerGas: gasPrice,
-    maxPriorityFeePerGas: BigNumber.from(0),
+    maxPriorityFeePerGas: ethers.constants.Zero,
   };
 }

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -13,7 +13,7 @@ export interface Deposit {
   destinationChainId: number;
   relayerFeePct: BigNumber;
   quoteTimestamp: number;
-  realizedLpFeePct: BigNumber; // appended after initialization (not part of Deposit event).
+  realizedLpFeePct?: BigNumber; // appended after initialization (not part of Deposit event).
   destinationToken: string; // appended after initialization (not part of Deposit event).
   message: string;
   speedUpSignature?: string | undefined; // appended after initialization, if deposit was speedup (not part of Deposit event).

--- a/src/interfaces/UBA.ts
+++ b/src/interfaces/UBA.ts
@@ -2,7 +2,7 @@ import { BigNumber } from "ethers";
 import { DepositWithBlock, FillWithBlock, RefundRequestWithBlock } from "./";
 
 export type UbaInflow = DepositWithBlock;
-export type UbaOutflow = FillWithBlock | RefundRequestWithBlock;
+export type UbaOutflow = (FillWithBlock | RefundRequestWithBlock) & { quoteBlockNumber: number };
 export type UbaFlow = UbaInflow | UbaOutflow;
 
 export const isUbaInflow = (flow: UbaFlow): flow is UbaInflow => {
@@ -13,11 +13,13 @@ export const isUbaOutflow = (flow: UbaFlow): flow is UbaOutflow => {
   return !isUbaInflow(flow) && (outflowIsFill(flow) || outflowIsRefund(flow));
 };
 
-export const outflowIsFill = (outflow: UbaOutflow): outflow is FillWithBlock => {
+export const outflowIsFill = (outflow: UbaOutflow): outflow is FillWithBlock & { quoteBlockNumber: number } => {
   return (outflow as FillWithBlock)?.updatableRelayData !== undefined;
 };
 
-export const outflowIsRefund = (outflow: UbaOutflow): outflow is RefundRequestWithBlock => {
+export const outflowIsRefund = (
+  outflow: UbaOutflow
+): outflow is RefundRequestWithBlock & { quoteBlockNumber: number } => {
   return (outflow as RefundRequestWithBlock)?.fillBlock !== undefined;
 };
 

--- a/src/pool/poolClient.ts
+++ b/src/pool/poolClient.ts
@@ -346,9 +346,9 @@ function joinUserState(
   poolState: Pool,
   tokenEventState: hubPool.TokenEventState,
   userState: Awaited<ReturnType<UserState["read"]>>,
-  transferValue: BigNumber = BigNumber.from(0),
-  cumulativeStakeBalance: BigNumber = BigNumber.from(0),
-  cumulativeStakeClaimBalance: BigNumber = BigNumber.from(0)
+  transferValue: BigNumber = ethers.constants.Zero,
+  cumulativeStakeBalance: BigNumber = ethers.constants.Zero,
+  cumulativeStakeClaimBalance: BigNumber = ethers.constants.Zero
 ): User {
   const positionValue = BigNumber.from(poolState.exchangeRateCurrent)
     .mul(userState.balanceOf.add(cumulativeStakeBalance))
@@ -521,7 +521,7 @@ export class Client {
           )
         )
       )
-    ).reduce((prev, acc) => acc.add(prev), BigNumber.from(0));
+    ).reduce((prev, acc) => acc.add(prev), ethers.constants.Zero);
 
     // Get the cumulative balance of the user from the accelerating distributor contract.
     const { cumulativeBalance } = await acceleratingDistributorContract.getUserStake(lpToken, userState.address);
@@ -565,7 +565,7 @@ export class Client {
       }
       // we make sure to filter out any transfers where to/from is the same user
       return result;
-    }, BigNumber.from(0));
+    }, ethers.constants.Zero);
   }
   private getOrCreateTransactionManager(signer: Signer, address: string) {
     if (this.transactionManagers[address]) return this.transactionManagers[address];
@@ -731,7 +731,7 @@ export class Client {
     const { address: userAddress } = userState;
     const transferValue = this.config.hasArchive
       ? await this.calculateLpTransferValue(l1TokenAddress, userState)
-      : BigNumber.from(0);
+      : ethers.constants.Zero;
     const stakeData = await this.resolveStakingData(lpToken, l1TokenAddress, userState);
     const tokenEventState = poolEventState[l1TokenAddress];
     const newUserState = this.setUserState(

--- a/src/transfers-history/client.ts
+++ b/src/transfers-history/client.ts
@@ -14,6 +14,7 @@ import {
   RequestedSpeedUpDepositEvent,
 } from "../typechain";
 import { Transfer } from "./model";
+import { ethers } from "ethers";
 
 export enum TransfersHistoryEvent {
   TransfersUpdated = "TransfersUpdated",
@@ -194,7 +195,7 @@ export class TransfersHistoryClient {
       depositTime: timestamp,
       depositTxHash: transactionHash,
       destinationChainId: destinationChainId.toNumber(),
-      filled: BigNumber.from("0"),
+      filled: ethers.constants.Zero,
       sourceChainId: originChainId.toNumber(),
       status: "pending",
       fillTxs: [],

--- a/src/utils/BundleUtils.ts
+++ b/src/utils/BundleUtils.ts
@@ -1,0 +1,136 @@
+import { AcrossConfigStoreClient, HubPoolClient, SpokePoolClient } from "../clients";
+import { CHAIN_ID_LIST_INDICES } from "../constants";
+import { ProposedRootBundle } from "../interfaces";
+
+/**
+ * Return block number for `chain` in `bundleEvaluationBlockNumbers` using the mapping
+ * in `chainIdListForBundleEvaluationBlockNumbers` to figure out which index in `bundleEvaluationBlockNumbers`
+ * the block for `chain` is
+ * @param bundleEvaluationBlockNumbers Usually, the bundle end blocks proposed in a root bundle.
+ * @param chain The chain to look up block for
+ * @param chainIdListForBundleEvaluationBlockNumbers The hardcoded sequence of chain IDs. For example:
+ * [1, 10, 137, 288, 42161] implies that if we're looking for the block for chain 137, it's at index 2 in
+ * `bundleEvaluationBlockNumbers`.
+ * @returns The block for `chain` in `bundleEvaluationBlockNumbers`.
+ */
+export function getBlockForChain(
+  bundleEvaluationBlockNumbers: number[],
+  chain: number,
+  chainIdListForBundleEvaluationBlockNumbers: number[] = CHAIN_ID_LIST_INDICES
+): number {
+  const indexForChain = chainIdListForBundleEvaluationBlockNumbers.indexOf(chain);
+  if (indexForChain === -1) {
+    throw new Error(`Could not find chain ${chain} in chain ID list ${chainIdListForBundleEvaluationBlockNumbers}`);
+  }
+  const blockForChain = bundleEvaluationBlockNumbers[indexForChain];
+  if (blockForChain === undefined) {
+    throw new Error(`Invalid block range for chain ${chain}`);
+  }
+  return blockForChain;
+}
+
+/**
+ * Similar concept as `getBlockForChain`, but returns the block range for `chain` in `blockRanges`.
+ * @param blockRanges
+ * @param chain
+ * @param chainIdListForBundleEvaluationBlockNumbers
+ * @returns
+ */
+export function getBlockRangeForChain(
+  blockRanges: number[][],
+  chain: number,
+  chainIdListForBundleEvaluationBlockNumbers: number[] = CHAIN_ID_LIST_INDICES
+): number[] {
+  const indexForChain = chainIdListForBundleEvaluationBlockNumbers.indexOf(chain);
+  if (indexForChain === -1) {
+    throw new Error(`Could not find chain ${chain} in chain ID list ${chainIdListForBundleEvaluationBlockNumbers}`);
+  }
+  const blockRangeForChain = blockRanges[indexForChain];
+  if (!blockRangeForChain || blockRangeForChain.length !== 2) {
+    throw new Error(`Invalid block range for chain ${chain}`);
+  }
+  return blockRangeForChain;
+}
+
+/**
+ * Return bundle block range for `rootBundle` whose bundle end blocks were included in the proposal.
+ * This amounts to reconstructing the bundle range start block.
+ * @param rootBundle Root bundle to return bundle block range for
+ * @returns blockRanges: number[][], [[startBlock, endBlock], [startBlock, endBlock], ...]
+ */
+export function getImpliedBundleBlockRanges(
+  hubPoolClient: HubPoolClient,
+  configStoreClient: AcrossConfigStoreClient,
+  rootBundle: ProposedRootBundle,
+  chainIdListForBundleEvaluationBlockNumbers: number[] = CHAIN_ID_LIST_INDICES
+): number[][] {
+  const prevRootBundle = hubPoolClient.getLatestFullyExecutedRootBundle(rootBundle.blockNumber);
+  // If chain is disabled for this bundle block range, end block should be same as previous bundle.
+  // Otherwise the range should be previous bundle's endBlock + 1 to current bundle's end block.
+
+  // Get enabled chains for this bundle block range.
+  // Don't let caller override the list of enabled chains when constructing an implied bundle block range,
+  // since this function is designed to reconstruct a historical bundle block range.
+  const enabledChains = configStoreClient.getEnabledChains(
+    getBlockForChain(
+      rootBundle.bundleEvaluationBlockNumbers.map((x) => x.toNumber()),
+      hubPoolClient.chainId,
+      chainIdListForBundleEvaluationBlockNumbers
+    ),
+    chainIdListForBundleEvaluationBlockNumbers
+  );
+
+  return rootBundle.bundleEvaluationBlockNumbers.map((endBlock, i) => {
+    const chainId = chainIdListForBundleEvaluationBlockNumbers[i];
+    const fromBlock = prevRootBundle?.bundleEvaluationBlockNumbers?.[i]
+      ? prevRootBundle.bundleEvaluationBlockNumbers[i].toNumber() + 1
+      : 0;
+    if (!enabledChains.includes(chainId)) {
+      return [endBlock.toNumber(), endBlock.toNumber()];
+    }
+    return [fromBlock, endBlock.toNumber()];
+  });
+}
+
+// Return true if we won't be able to construct a root bundle for the bundle block ranges ("blockRanges") because
+// the bundle wants to look up data for events that weren't in the spoke pool client's search range.
+export function blockRangesAreInvalidForSpokeClients(
+  spokePoolClients: Record<number, SpokePoolClient>,
+  blockRanges: number[][],
+  chainIdListForBundleEvaluationBlockNumbers: number[] = CHAIN_ID_LIST_INDICES
+): boolean {
+  if (blockRanges.length !== chainIdListForBundleEvaluationBlockNumbers.length) {
+    throw new Error("DataworkerUtils#blockRangesAreInvalidForSpokeClients: Invalid bundle block range length");
+  }
+  return chainIdListForBundleEvaluationBlockNumbers.some((chainId) => {
+    const blockRangeForChain = getBlockRangeForChain(
+      blockRanges,
+      Number(chainId),
+      chainIdListForBundleEvaluationBlockNumbers
+    );
+    if (isNaN(blockRangeForChain[1]) || isNaN(blockRangeForChain[0])) {
+      return true;
+    }
+    // If block range is 0 then chain is disabled, we don't need to query events for this chain.
+    if (blockRangeForChain[1] === blockRangeForChain[0]) {
+      return false;
+    }
+
+    // If spoke pool client doesn't exist for enabled chain then we clearly cannot query events for this chain.
+    if (spokePoolClients[chainId] === undefined) {
+      return true;
+    }
+
+    const clientLastBlockQueried =
+      spokePoolClients[chainId].eventSearchConfig.toBlock ?? spokePoolClients[chainId].latestBlockNumber;
+    const bundleRangeToBlock = blockRangeForChain[1];
+
+    // Note: Math.max the from block with the deployment block of the spoke pool to handle the edge case for the first
+    // bundle that set its start blocks equal 0.
+    const bundleRangeFromBlock = Math.max(spokePoolClients[chainId].deploymentBlock, blockRangeForChain[0]);
+    const earliestSpokePoolClientBlock = spokePoolClients[chainId].firstBlockToSearch;
+    if (earliestSpokePoolClientBlock === 0)
+      throw new Error(`SpokePoolClient for chain ${chainId} has firstBlockToSearch of 0 and is not updated`);
+    return bundleRangeFromBlock <= earliestSpokePoolClientBlock || bundleRangeToBlock > clientLastBlockQueried;
+  });
+}

--- a/src/utils/BundleUtils.ts
+++ b/src/utils/BundleUtils.ts
@@ -128,9 +128,7 @@ export function blockRangesAreInvalidForSpokeClients(
     // Note: Math.max the from block with the deployment block of the spoke pool to handle the edge case for the first
     // bundle that set its start blocks equal 0.
     const bundleRangeFromBlock = Math.max(spokePoolClients[chainId].deploymentBlock, blockRangeForChain[0]);
-    const earliestSpokePoolClientBlock = spokePoolClients[chainId].firstBlockToSearch;
-    if (earliestSpokePoolClientBlock === 0)
-      throw new Error(`SpokePoolClient for chain ${chainId} has firstBlockToSearch of 0 and is not updated`);
-    return bundleRangeFromBlock <= earliestSpokePoolClientBlock || bundleRangeToBlock > clientLastBlockQueried;
+    const earliestSpokePoolClientBlockSearched = spokePoolClients[chainId].eventSearchConfig.fromBlock;
+    return bundleRangeFromBlock <= earliestSpokePoolClientBlockSearched || bundleRangeToBlock > clientLastBlockQueried;
   });
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,3 +9,4 @@ export * from "./TokenUtils";
 export * from "./LogUtils";
 export * from "./FlowUtils";
 export * from "./UBAUtils";
+export * from "./BundleUtils";


### PR DESCRIPTION
This PR overall tries to make `updateUBAClients` re-use existing functions that have been battle tested in production code.

- `updateUBAClient`'s first step is to construct bundle block ranges for a specified number of the most recently validated bundles. The first fix refactors the block range construction logic into a function `getMostRecentBundles` which has unit tests accompanying it [here](https://github.com/across-protocol/relayer-v2/pull/815/files).
- `calculateUtilizationBoundaries` doesn't correctly take into account both the `refundChain` AND the `originChain` when computing utilization. The UMIP states that utilization calculation should take into account flows being added to the ETH spoke pool from a deposit and subtracted when ETH is the destination spoke pool.
- `getUBATargetSpokeBalances` is used to get spoke target balances set in the config store that we can use to compute the LP fee. The LP fee is a utilization based fee that is based on the cumulative spoke target across all chains. Therefore it is dangerous to allow the caller to specify which `chainIds` to grab spoke targets for. Instead, hardcode the list of spoke targets to ALL chains supported by Across.
    - Moreover, fixed the `getUBATargetSpokeBalances` call. Currently its fetching the wrong configuration. It should be fetching `target` values within the `uba` key, not the legacy `spokeTargetBalance`
- `computeLpFee` is supposed to be used to grab the latest LP fee. This is useful for the `Relayer` and also the Fee Quoting API. Therefore this function should be grabbing fresh HubPool balance, SpokePool balance, and spoke target information.
- Removes the  HubPool balance, SpokePool balance information from the `UBABundleState`. 
- Removes the relayer gas and capital fee information from a flow. Similar to the LP fee calculation inputs above, its not really useful to know these for each flow. The only information that is really needed to save with each flow is the running balance, incentive balance, and balancing fee at the time of the flow. These are saved so that we can easily recompute any historical flow's balancing fees, which are dependent only on the preceding flows' running balances, incentive balances, and balancing fees. The relayer gas + capital fee and the LP fees are not needed to reconstruct running balances.
    - I could see one use case where someone wants to reconstruct the LP fees and relayer gas + capital fees at some historical point in time to figure out what these values would have been at the time of some historical flow. However, this information is grabbed in O(1) time, by querying block chain state at that flow's block time. Unlike the balancing fees, these fees are not dependent on preceding historical information, and therefore derive a lot less benefit from caching the data.