### PR TITLE
fix: uba client fixes for quote engine

### DIFF
--- a/src/UBAFeeCalculator/UBAFeeConfig.ts
+++ b/src/UBAFeeCalculator/UBAFeeConfig.ts
@@ -1,6 +1,7 @@
 import { BigNumber, ethers } from "ethers";
 import { ThresholdBoundType, FlowTupleParameters } from "./UBAFeeTypes";
 import { CHAIN_ID_LIST_INDICES } from "../constants";
+import { stringifyJSONWithNumericString } from "../utils/JSONUtils";
 
 type ChainId = number;
 type RouteCombination = string;
@@ -156,6 +157,17 @@ class UBAConfig {
    */
   public getUbaRewardMultiplier(chainId: string): BigNumber {
     return this.ubaRewardMultiplier?.[chainId] ?? ethers.constants.One; // Default to 1 if not set
+  }
+
+  public toJSON() {
+    return {
+      baselineFee: JSON.parse(stringifyJSONWithNumericString(this.baselineFee)),
+      balancingFee: JSON.parse(stringifyJSONWithNumericString(this.balancingFee)),
+      balanceTriggerThreshold: JSON.parse(stringifyJSONWithNumericString(this.balanceTriggerThreshold)),
+      lpGammaFunction: JSON.parse(stringifyJSONWithNumericString(this.lpGammaFunction)),
+      incentivePoolAdjustment: JSON.parse(stringifyJSONWithNumericString(this.incentivePoolAdjustment)),
+      ubaRewardMultiplier: JSON.parse(stringifyJSONWithNumericString(this.ubaRewardMultiplier)),
+    };
   }
 }
 

--- a/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
+++ b/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
@@ -316,7 +316,10 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
             this.logger.warn({
               at: "ConfigStore::update",
               message: `Failed to parse UBA config for ${l1Token}`,
-              error: e,
+              error: {
+                message: (e as Error)?.message,
+                stack: (e as Error)?.stack,
+              },
             });
           }
         }

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -161,12 +161,12 @@ export function getUBAFeeConfig(
       override: {
         [chainTokenCombination]: {
           lowerBound: {
-            target: threshold.target_lower,
-            threshold: threshold.threshold_lower,
+            target: threshold?.target_lower,
+            threshold: threshold?.threshold_lower,
           },
           upperBound: {
-            target: threshold.target_upper,
-            threshold: threshold.threshold_upper,
+            target: threshold?.target_upper,
+            threshold: threshold?.threshold_upper,
           },
         },
       },

--- a/src/clients/UBAClient/UBAClientWithRefresh.ts
+++ b/src/clients/UBAClient/UBAClientWithRefresh.ts
@@ -59,7 +59,4 @@ export class UBAClientWithRefresh extends BaseUBAClient {
       this.isUpdated
     );
   }
-  public set isUpdated(value: boolean) {
-    this._isUpdated = value;
-  }
 }

--- a/src/clients/UBAClient/UBAClientWithRefresh.ts
+++ b/src/clients/UBAClient/UBAClientWithRefresh.ts
@@ -32,7 +32,7 @@ export class UBAClientWithRefresh extends BaseUBAClient {
     }
     // Update the clients if the necessary clients have not been updated at least once.
     // Also update if forceClientRefresh is true.
-    if (forceClientRefresh || !this.areClientsUpdated) {
+    if (forceClientRefresh || !this.isUpdated) {
       // Update the Across config store
       await this.hubPoolClient.configStoreClient.update();
       // Update the HubPool
@@ -51,12 +51,15 @@ export class UBAClientWithRefresh extends BaseUBAClient {
       )
     );
   }
-  public get areClientsUpdated(): boolean {
+  public get isUpdated(): boolean {
     return (
       this.hubPoolClient.configStoreClient.isUpdated &&
       this.hubPoolClient.isUpdated &&
       Object.values(this.spokePoolClients).every((spokePoolClient) => spokePoolClient.isUpdated) &&
       this.isUpdated
     );
+  }
+  public set isUpdated(value: boolean) {
+    this._isUpdated = value;
   }
 }

--- a/src/clients/UBAClient/UBAClientWithRefresh.ts
+++ b/src/clients/UBAClient/UBAClientWithRefresh.ts
@@ -28,10 +28,11 @@ export class UBAClientWithRefresh extends BaseUBAClient {
   public async update(state: { [chainId: number]: UBAChainState }, forceClientRefresh?: boolean): Promise<void> {
     if (state) {
       await super.update(state);
+      return;
     }
     // Update the clients if the necessary clients have not been updated at least once.
     // Also update if forceClientRefresh is true.
-    if (forceClientRefresh || !this.isUpdated) {
+    if (forceClientRefresh || !this.areClientsUpdated) {
       // Update the Across config store
       await this.hubPoolClient.configStoreClient.update();
       // Update the HubPool
@@ -39,7 +40,7 @@ export class UBAClientWithRefresh extends BaseUBAClient {
       // Update the SpokePools
       await Promise.all(Object.values(this.spokePoolClients).map(async (spokePoolClient) => spokePoolClient.update()));
     }
-    this.update(
+    return this.update(
       await updateUBAClient(
         this.hubPoolClient,
         this.spokePoolClients,
@@ -50,7 +51,7 @@ export class UBAClientWithRefresh extends BaseUBAClient {
       )
     );
   }
-  public get isUpdated(): boolean {
+  public get areClientsUpdated(): boolean {
     return (
       this.hubPoolClient.configStoreClient.isUpdated &&
       this.hubPoolClient.isUpdated &&

--- a/src/utils/JSONUtils.ts
+++ b/src/utils/JSONUtils.ts
@@ -30,8 +30,8 @@ export function parseJSONWithNumericString(jsonString: string): unknown | undefi
  */
 export function stringifyJSONWithNumericString(obj: unknown): string {
   return JSON.stringify(obj, (_key, value) => {
-    if (BigNumber.isBigNumber(value)) {
-      return value.toString();
+    if (typeof value === "object" && value !== null && value.type === "BigNumber") {
+      return BigNumber.from(value).toString();
     }
     return value;
   });


### PR DESCRIPTION
Some things I had to add and fix in order to get it working in the Vercel API handler:
- handle `undefined` of var `threshold` 
- utility function to deserialize the uba client state
   - because we return the state as JSON when consuming it in the `/suggested-fees` handler, we need to parse it (especially `BigNumber` instances and `UBAFeeConfig` instance)
- some fixes in the `UBAClientWithRefresh.update` method (not 100% if I am correct here though)