### PR TITLE
feat: Relocate computeSystemFee and refactor getModifiedFlows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -297,9 +297,11 @@ export class SpokePoolClient extends BaseAbstractClient {
    * @param fill The fill to find a corresponding deposit for.
    * @returns The corresponding deposit if found, undefined otherwise.
    */
-  public getDepositForFill(fill: Fill): DepositWithBlock | undefined {
+  public getDepositForFill(fill: Fill, fillFieldsToIgnore: string[] = []): DepositWithBlock | undefined {
     const depositWithMatchingDepositId = this.depositHashes[this.getDepositHash(fill)];
-    return validateFillForDeposit(fill, depositWithMatchingDepositId) ? depositWithMatchingDepositId : undefined;
+    return validateFillForDeposit(fill, depositWithMatchingDepositId, fillFieldsToIgnore)
+      ? depositWithMatchingDepositId
+      : undefined;
   }
 
   /**

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -1,18 +1,14 @@
 import { groupBy } from "lodash";
+import { assign, EventSearchConfig, DefaultLogLevels, MakeOptional, AnyObject, MAX_BIG_INT } from "../utils";
+import { toBN } from "../utils/common";
+import { validateFillForDeposit, filledSameDeposit } from "../utils/FlowUtils";
 import {
   spreadEvent,
-  assign,
-  EventSearchConfig,
-  sortEventsAscendingInPlace,
-  DefaultLogLevels,
-  MakeOptional,
+  paginatedEventQuery,
+  spreadEventWithBlockNumber,
   sortEventsAscending,
-  filledSameDeposit,
-  validateFillForDeposit,
-  AnyObject,
-  MAX_BIG_INT,
-} from "../utils";
-import { toBN, paginatedEventQuery, spreadEventWithBlockNumber } from "../utils";
+  sortEventsAscendingInPlace,
+} from "../utils/EventUtils";
 import winston from "winston";
 
 import { Contract, BigNumber, Event, EventFilter, ethers } from "ethers";
@@ -29,7 +25,7 @@ import {
   TokensBridged,
   FundsDepositedEvent,
 } from "../interfaces";
-import { HubPoolClient } from ".";
+import { HubPoolClient } from "./HubPoolClient";
 import { ZERO_ADDRESS } from "../constants";
 import { getNetworkName } from "../utils/NetworkUtils";
 import { BaseAbstractClient } from "./BaseAbstractClient";

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -862,7 +862,6 @@ export async function refundRequestIsValid(
       );
   });
   if (!isDefined(fill)) {
-    // If fill block is
     if (fillBlock.lt(destSpoke.eventSearchConfig.fromBlock)) {
       // TODO: We need to do a look back for a fill if we can't find it. We can't assume it doesn't exist, similar to
       // why we try to do a longer lookback below for a deposit. The problem with looking up the fill is that there is no

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -544,6 +544,10 @@ export async function updateUBAClient(
         throw new Error(`Spoke pool client ${chainId} has not searched all blocks in bundle range`);
       }
 
+      // TODO: We are stuck here. Given a list of bundle block ranges and functions like getFlows(chainId, tokenSymbol)
+      // that return all flows for a bundle range for a chain and token, how do you validate the set of flows
+      // and charge balancing fees to all of them?
+
       // For each bundle, load common data that we'll use for all tokens in bundle, and then load flow data
       // for each token. This is a triple loop that we run in parallel at each level:
       // 1. Loop through all bundles

--- a/src/clients/UBAClient/UBAClientWithRefresh.ts
+++ b/src/clients/UBAClient/UBAClientWithRefresh.ts
@@ -1,6 +1,8 @@
 import assert from "assert";
 import winston from "winston";
-import { HubPoolClient, SpokePoolClient, UBAActionType } from "..";
+import { SpokePoolClient } from "../SpokePoolClient";
+import { HubPoolClient } from "../HubPoolClient";
+import { UBAActionType } from "../../UBAFeeCalculator/UBAFeeTypes";
 import { BaseUBAClient } from "./UBAClientBase";
 import { computeLpFeeStateful, getUBAFeeConfig, updateUBAClient } from "./UBAClientUtilities";
 import { SystemFeeResult, UBAChainState } from "./UBAClientTypes";

--- a/src/interfaces/UBA.ts
+++ b/src/interfaces/UBA.ts
@@ -2,7 +2,7 @@ import { BigNumber } from "ethers";
 import { DepositWithBlock, FillWithBlock, RefundRequestWithBlock } from "./";
 
 export type UbaInflow = DepositWithBlock;
-export type UbaOutflow = (FillWithBlock | RefundRequestWithBlock) & { quoteBlockNumber: number };
+export type UbaOutflow = (FillWithBlock | RefundRequestWithBlock) & { matchedDeposit: DepositWithBlock };
 export type UbaFlow = UbaInflow | UbaOutflow;
 
 export const isUbaInflow = (flow: UbaFlow): flow is UbaInflow => {
@@ -13,13 +13,13 @@ export const isUbaOutflow = (flow: UbaFlow): flow is UbaOutflow => {
   return !isUbaInflow(flow) && (outflowIsFill(flow) || outflowIsRefund(flow));
 };
 
-export const outflowIsFill = (outflow: UbaOutflow): outflow is FillWithBlock & { quoteBlockNumber: number } => {
+export const outflowIsFill = (outflow: UbaOutflow): outflow is FillWithBlock & { matchedDeposit: DepositWithBlock } => {
   return (outflow as FillWithBlock)?.updatableRelayData !== undefined;
 };
 
 export const outflowIsRefund = (
   outflow: UbaOutflow
-): outflow is RefundRequestWithBlock & { quoteBlockNumber: number } => {
+): outflow is RefundRequestWithBlock & { matchedDeposit: DepositWithBlock } => {
   return (outflow as RefundRequestWithBlock)?.fillBlock !== undefined;
 };
 

--- a/src/utils/FlowUtils.ts
+++ b/src/utils/FlowUtils.ts
@@ -1,7 +1,6 @@
-import { HubPoolClient, getModifiedFlow } from "../clients";
+import { HubPoolClient } from "../clients/HubPoolClient";
 import {
   Deposit,
-  DepositWithBlock,
   Fill,
   FillWithBlock,
   RefundRequestWithBlock,
@@ -10,7 +9,6 @@ import {
   isUbaInflow,
   outflowIsFill,
 } from "../interfaces";
-import { SpokePoolClients } from "./TypeUtils";
 
 export const FILL_DEPOSIT_COMPARISON_KEYS = [
   "amount",
@@ -88,84 +86,4 @@ export function validateFillForDeposit(fill: Fill, deposit?: Deposit): boolean {
   return FILL_DEPOSIT_COMPARISON_KEYS.every((key) => {
     return fill[key] !== undefined && fill[key].toString() === deposit[key]?.toString();
   });
-}
-
-/**
- * Resolves the corresponding deposit for a fill. Unlike in the Pre UBA clients, this function does NOT
- * fall back to querying fresh RPC events to try to find a fill. Instead, if the deposit can't be found
- * then this code will just crash, protecting the caller's funds. This is because if we were to find an old
- * deposit, we'd need to recompute its expected realizedLpFeePct, which would be based on the deposit balancing
- * fee and therefore requires more information from the flows preceding it. This is a future TODO.
- * @param fill The fill to resolve the corresponding deposit for
- * @param spokePoolClients The spoke clients to query for the deposit
- * @returns The corresponding deposit for the fill, or undefined if the deposit was not found
- */
-export async function resolveCorrespondingDepositForFill(
-  fill: FillWithBlock,
-  spokePoolClients: SpokePoolClients,
-  hubPoolClient: HubPoolClient
-): Promise<DepositWithBlock | undefined> {
-  // Matched deposit for fill was not found in spoke client. This situation should be rare so let's
-  // send some extra RPC requests to blocks older than the spoke client's initial event search config
-  // to find the deposit if it exists.
-  return queryHistoricalDepositForFill(hubPoolClient, spokePoolClients, fill);
-}
-
-// of a deposit older or younger than its fixed lookback.
-export async function queryHistoricalDepositForFill(
-  hubPoolClient: HubPoolClient,
-  spokePoolClients: SpokePoolClients,
-  fill: Fill
-): Promise<DepositWithBlock | undefined> {
-  const originSpokePoolClient = spokePoolClients[fill.originChainId];
-
-  // We need to update client so we know the first and last deposit ID's queried for this spoke pool client, as well
-  // as the global first and last deposit ID's for this spoke pool.
-  if (!originSpokePoolClient.isUpdated) {
-    throw new Error("SpokePoolClient must be updated before querying historical deposits");
-  }
-
-  // If someone fills with a clearly bogus deposit ID then we can quickly mark it as invalid
-  if (
-    fill.depositId < originSpokePoolClient.firstDepositIdForSpokePool ||
-    fill.depositId > originSpokePoolClient.lastDepositIdForSpokePool
-  ) {
-    return undefined;
-  }
-
-  if (
-    fill.depositId >= originSpokePoolClient.earliestDepositIdQueried &&
-    fill.depositId <= originSpokePoolClient.latestDepositIdQueried
-  ) {
-    return originSpokePoolClient.getDepositForFill(fill);
-  }
-
-  // At this stage, deposit is not in spoke pool client's search range. Perform an expensive, additional data query
-  // to try to validate this deposit.
-  const timerStart = Date.now();
-  hubPoolClient.logger.debug({
-    at: "queryHistoricalDepositForFill",
-    message: "Loading historical bundle to try to find matching deposit for fill",
-    fill,
-  });
-  const deposit: DepositWithBlock = await originSpokePoolClient.findDeposit(
-    fill.depositId,
-    fill.destinationChainId,
-    fill.depositor
-  );
-  hubPoolClient.logger.debug({
-    at: "queryHistoricalDepositForFill",
-    message: "Found matching deposit candidate for fill, fetching bundle data to set fees",
-    timeElapsed: Date.now() - timerStart,
-    deposit,
-  });
-  const depositFees = await getModifiedFlow(deposit.originChainId, deposit, hubPoolClient, spokePoolClients);
-  hubPoolClient.logger.debug({
-    at: "queryHistoricalDepositForFill",
-    message: "Recomputed deposit realizedLpFee",
-    timeElapsed: Date.now() - timerStart,
-    depositFees,
-  });
-  deposit.realizedLpFeePct = depositFees.systemFee.systemFee;
-  return validateFillForDeposit(fill, deposit) ? deposit : undefined;
 }

--- a/src/utils/FlowUtils.ts
+++ b/src/utils/FlowUtils.ts
@@ -71,19 +71,18 @@ export function filledSameDeposit(fillA: Fill, fillB: Fill): boolean {
 
 // Ensure that each deposit element is included with the same value in the fill. This includes all elements defined
 // by the depositor as well as the realizedLpFeePct and the destinationToken, which are pulled from other clients.
-export function validateFillForDeposit(fill: Fill, deposit?: Deposit): boolean {
+export function validateFillForDeposit(fill: Fill, deposit?: Deposit, fillFieldsToIgnore: string[] = []): boolean {
   if (deposit === undefined) {
     return false;
-  }
-
-  if (deposit.realizedLpFeePct === undefined) {
-    throw new Error("realizedLpFeePct should never be undefined pre UBA");
   }
 
   // Note: this short circuits when a key is found where the comparison doesn't match.
   // TODO: if we turn on "strict" in the tsconfig, the elements of FILL_DEPOSIT_COMPARISON_KEYS will be automatically
   // validated against the fields in Fill and Deposit, generating an error if there is a discrepency.
   return FILL_DEPOSIT_COMPARISON_KEYS.every((key) => {
+    if (fillFieldsToIgnore.includes(key)) {
+      return true;
+    }
     return fill[key] !== undefined && fill[key].toString() === deposit[key]?.toString();
   });
 }


### PR DESCRIPTION
- `computeLpFee` shouldn't try to retrieve a bundle config from state since its expected to be used by the relayer. If the relayer is trying to set the LP fee for a very recent deposit, then it should not be using the config included at the time of the last validated bundle, instead it should be using the latest config in the `ConfigStore` contract
- `getModifiedFlows` is refactored and now is used in `resolveHistoricalDepositForFill` to reduce the DOS vector
- The only remaining DOS vector is looking up an old fill for a refund. I've left a TODO

Fixes #ACX1321