### PR TITLE
feat: match events with correct UBA config based on bundle start block not quote block

### DIFF
--- a/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
+++ b/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
@@ -15,7 +15,6 @@ import {
   max,
   sortEventsAscending,
   findLast,
-  isUBA,
 } from "../../utils";
 import { Contract, BigNumber, Event } from "ethers";
 import winston from "winston";
@@ -234,32 +233,6 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
     const version = this.getConfigStoreVersionForTimestamp(timestamp);
     return this.isValidConfigStoreVersion(version);
   }
-
-  /**
-   * Return first block number where UBA was activated by setting "Version" GlobalConfig in ConfigStore
-   * @returns
-   */
-  getUbaActivationBlock(): number {
-    const config = this.cumulativeConfigStoreVersionUpdates.find((config) => {
-      isUBA(Number(config.value));
-    });
-    if (config) {
-      return config.blockNumber;
-    } else {
-      return Number.MAX_SAFE_INTEGER;
-    }
-  }
-
-  public isUbaBlock(block: number): boolean {
-    const versionAppliedToDeposit = this.getConfigStoreVersionForBlock(block);
-    return isUBA(versionAppliedToDeposit);
-  }
-
-  public canSupportUbaBlock(block: number): boolean {
-    const versionAppliedToDeposit = this.getConfigStoreVersionForBlock(block);
-    return this.isValidConfigStoreVersion(versionAppliedToDeposit);
-  }
-
   isValidConfigStoreVersion(version: number): boolean {
     return this.configStoreVersion >= version;
   }

--- a/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
+++ b/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
@@ -15,6 +15,7 @@ import {
   max,
   sortEventsAscending,
   findLast,
+  isUBA,
 } from "../../utils";
 import { Contract, BigNumber, Event } from "ethers";
 import winston from "winston";
@@ -232,6 +233,31 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
   hasValidConfigStoreVersionForTimestamp(timestamp: number = Number.MAX_SAFE_INTEGER): boolean {
     const version = this.getConfigStoreVersionForTimestamp(timestamp);
     return this.isValidConfigStoreVersion(version);
+  }
+
+  /**
+   * Return first block number where UBA was activated by setting "Version" GlobalConfig in ConfigStore
+   * @returns
+   */
+  getUbaActivationBlock(): number {
+    const config = this.cumulativeConfigStoreVersionUpdates.find((config) => {
+      isUBA(Number(config.value));
+    });
+    if (config) {
+      return config.blockNumber;
+    } else {
+      return Number.MAX_SAFE_INTEGER;
+    }
+  }
+
+  public isUbaBlock(block: number): boolean {
+    const versionAppliedToDeposit = this.getConfigStoreVersionForBlock(block);
+    return isUBA(versionAppliedToDeposit);
+  }
+
+  public canSupportUbaBlock(block: number): boolean {
+    const versionAppliedToDeposit = this.getConfigStoreVersionForBlock(block);
+    return this.isValidConfigStoreVersion(versionAppliedToDeposit);
   }
 
   isValidConfigStoreVersion(version: number): boolean {

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -20,7 +20,15 @@ import {
   paginatedEventQuery,
   toBN,
 } from "../utils";
-import { Deposit, L1Token, CancelledRootBundle, DisputedRootBundle, LpToken, TokenRunningBalance } from "../interfaces";
+import {
+  Deposit,
+  L1Token,
+  CancelledRootBundle,
+  DisputedRootBundle,
+  LpToken,
+  TokenRunningBalance,
+  DepositWithBlock,
+} from "../interfaces";
 import { ExecutedRootBundle, PendingRootBundle, ProposedRootBundle } from "../interfaces";
 import { CrossChainContractsSet, DestinationTokenWithBlock, SetPoolRebalanceRoot } from "../interfaces";
 import * as lpFeeCalculator from "../lpFeeCalculator";
@@ -253,13 +261,10 @@ export class HubPoolClient extends BaseAbstractClient {
   }
 
   async computeRealizedLpFeePct(
-    deposit: {
-      quoteTimestamp: number;
-      amount: BigNumber;
-      destinationChainId: number;
-      originChainId: number;
-      blockNumber: number;
-    },
+    deposit: Pick<
+      DepositWithBlock,
+      "quoteTimestamp" | "amount" | "destinationChainId" | "originChainId" | "blockNumber"
+    >,
     l1Token: string
   ): Promise<{ realizedLpFeePct: BigNumber | undefined; quoteBlock: number }> {
     const quoteBlock = await this.getBlockNumber(deposit.quoteTimestamp);
@@ -754,7 +759,7 @@ export class HubPoolClient extends BaseAbstractClient {
       const nTokens = l1Tokens.length;
 
       // Safeguard
-      if (![nTokens, nTokens*2].includes(runningBalances.length)) {
+      if (![nTokens, nTokens * 2].includes(runningBalances.length)) {
         throw new Error(
           `Invalid runningBalances length: ${runningBalances.length}. Expected ${nTokens} or ${nTokens * 2} for chain ${
             this.chainId

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -733,24 +733,6 @@ export class HubPoolClient extends BaseAbstractClient {
         continue;
       }
 
-      // The applicable version is determined by the block number of the corresponding proposal.
-      let proposalBlockNumber = event.blockNumber;
-      for (let idx = this.proposedRootBundles.length - 1; idx >= 0; --idx) {
-        const rootBundleProposal = this.proposedRootBundles[idx];
-        if (event.blockNumber > rootBundleProposal.blockNumber) {
-          proposalBlockNumber = rootBundleProposal.blockNumber;
-          break;
-        }
-      }
-      if (proposalBlockNumber === event.blockNumber) {
-        this.logger.warn({
-          at: "HubPoolClient#update",
-          message: `Unable to find RootBundleProposal before blockNumber ${event.blockNumber}`,
-          executedRootBundle: event.transactionHash,
-        });
-        continue;
-      }
-
       // Set running balances and incentive balances for this bundle.
       // Pre-UBA: runningBalances length is 1:1 with l1Tokens length. Pad incentiveBalances with zeroes.
       // Post-UBA: runningBalances array is a concatenation of pre-UBA runningBalances and incentiveBalances.

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -25,8 +25,8 @@ import { ExecutedRootBundle, PendingRootBundle, ProposedRootBundle } from "../in
 import { CrossChainContractsSet, DestinationTokenWithBlock, SetPoolRebalanceRoot } from "../interfaces";
 import * as lpFeeCalculator from "../lpFeeCalculator";
 import { AcrossConfigStoreClient as ConfigStoreClient } from "./";
+import { isUbaBlock } from "./UBAClient/UBAClientUtilities";
 import { BaseAbstractClient } from "./BaseAbstractClient";
-import { CHAIN_ID_LIST_INDICES } from "../constants";
 
 type _HubPoolUpdate = {
   success: true;
@@ -274,7 +274,7 @@ export class HubPoolClient extends BaseAbstractClient {
       deposit.originChainId,
       this.latestBlockNumber
     );
-    if (this.configStoreClient.isUbaBlock(bundleStartBlockContainingDeposit)) {
+    if (isUbaBlock(bundleStartBlockContainingDeposit, this.configStoreClient)) {
       // If UBA deposit then we can't compute the realizedLpFeePct until after we've updated the UBA Client.
       return {
         realizedLpFeePct: undefined,
@@ -409,21 +409,6 @@ export class HubPoolClient extends BaseAbstractClient {
       endingBlockNumber = bundleEvalBlockNumber;
     }
     return endingBlockNumber;
-  }
-
-  /**
-   * Returns bundle range start blocks for first bundle that UBA was activated
-   * @param chainIds Chains to return start blocks for.
-   * */
-  getUbaActivationBundleStartBlocks(chainIds: number[] = CHAIN_ID_LIST_INDICES): number[] {
-    if (!isDefined(this.latestBlockNumber)) {
-      throw new Error("getUbaActivationBundleStartBlocks: latestBlockNumber is not set");
-    }
-    const ubaActivationHubPoolBlock = this.configStoreClient.getUbaActivationBlock();
-    const bundleStartBlocks = chainIds.map((chainId) => {
-      return this.getBundleStartBlockContainingBlock(ubaActivationHubPoolBlock, chainId);
-    });
-    return bundleStartBlocks;
   }
 
   // TODO: This might not be necessary since the cumulative root bundle count doesn't grow fast enough, but consider

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -754,7 +754,7 @@ export class HubPoolClient extends BaseAbstractClient {
       const nTokens = l1Tokens.length;
 
       // Safeguard
-      if (runningBalances.length !== nTokens || runningBalances.length !== nTokens * 2) {
+      if (![nTokens, nTokens*2].includes(runningBalances.length)) {
         throw new Error(
           `Invalid runningBalances length: ${runningBalances.length}. Expected ${nTokens} or ${nTokens * 2} for chain ${
             this.chainId

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -341,7 +341,7 @@ export class HubPoolClient extends BaseAbstractClient {
     // If there is no latest executed bundle, then return the spoke's activation block. This means that there is no
     // bundle before `hubPoolLatestBlock` containing the event block so the next bundle will start at
     // the activation block and contain the event.
-    if (!latestExecutedBundle) {
+    if (!isDefined(latestExecutedBundle)) {
       return this.getSpokeActivationBlockForChain(eventChain);
     }
 
@@ -414,14 +414,14 @@ export class HubPoolClient extends BaseAbstractClient {
 
   /**
    * Returns bundle range start blocks for first bundle that UBA was activated
+   * @param chainIds Chains to return start blocks for.
    * */
   getUbaActivationBundleStartBlocks(chainIds: number[] = CHAIN_ID_LIST_INDICES): number[] {
-    if (!this.latestBlockNumber) {
+    if (!isDefined(this.latestBlockNumber)) {
       throw new Error("getUbaActivationBundleStartBlocks: latestBlockNumber is not set");
     }
     const ubaActivationHubPoolBlock = this.configStoreClient.getUbaActivationBlock();
     const bundleStartBlocks = chainIds.map((chainId) => {
-      // Otherwise, return the start block of the bundle containing the end block.
       return this.getBundleStartBlockContainingBlock(ubaActivationHubPoolBlock, chainId);
     });
     return bundleStartBlocks;
@@ -776,8 +776,8 @@ export class HubPoolClient extends BaseAbstractClient {
       if (isUBA(version)) {
         // runningBalances array is a concatenation of pre-UBA runningBalances and incentiveBalances.
         executedRootBundle.runningBalances = runningBalances.slice(0, nTokens);
-        // If bundle hasn't added incentive balance values, then assume they are 0.
-        // TODO: They really should be equal to the last validated incentive balance value.
+        // If bundle hasn't added incentive balance values, then assume they are 0. This is in place
+        // to make sure that the incentiveBalances isn't undefined.
         executedRootBundle.incentiveBalances =
           runningBalances.length > nTokens
             ? runningBalances.slice(nTokens)

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -832,6 +832,7 @@ export class SpokePoolClient extends BaseAbstractClient {
       destinationChainId: Number(depositEvent.args.destinationChainId),
       originToken: depositEvent.args.originToken,
       quoteTimestamp: depositEvent.args.quoteTimestamp,
+      blockNumber: depositEvent.blockNumber,
     };
 
     const l1Token = this.hubPoolClient.getL1TokenForDeposit(deposit);

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -548,10 +548,11 @@ export function getUbaActivationBundleStartBlocks(hubPoolClient: HubPoolClient, 
  * @returns
  */
 export function getUbaActivationBlock(configStoreClient: AcrossConfigStoreClient): number {
-  return configStoreClient.cumulativeConfigStoreVersionUpdates.find((config) => {
-    isUBA(Number(config.value));
-  })?.blockNumber ?? Number.MAX_SAFE_INTEGER;
-
+  return (
+    configStoreClient.cumulativeConfigStoreVersionUpdates.find((config) => {
+      isUBA(Number(config.value));
+    })?.blockNumber ?? Number.MAX_SAFE_INTEGER
+  );
 }
 
 export function isUbaBlock(block: number, configStoreClient: AcrossConfigStoreClient): boolean {

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -354,8 +354,6 @@ export async function getModifiedFlow(
     })
   );
 
-  // What if there are 0 bundle ranges?
-
   // Instantiate new spoke pool clients that will look back at older data:
   const newSpokePoolClients = Object.fromEntries(
     await mapAsync(Object.keys(spokePoolClients), async (_chainId) => {

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -548,14 +548,10 @@ export function getUbaActivationBundleStartBlocks(hubPoolClient: HubPoolClient, 
  * @returns
  */
 export function getUbaActivationBlock(configStoreClient: AcrossConfigStoreClient): number {
-  const config = configStoreClient.cumulativeConfigStoreVersionUpdates.find((config) => {
+  return configStoreClient.cumulativeConfigStoreVersionUpdates.find((config) => {
     isUBA(Number(config.value));
-  });
-  if (config) {
-    return config.blockNumber;
-  } else {
-    return Number.MAX_SAFE_INTEGER;
-  }
+  })?.blockNumber ?? Number.MAX_SAFE_INTEGER;
+
 }
 
 export function isUbaBlock(block: number, configStoreClient: AcrossConfigStoreClient): boolean {

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -7,7 +7,6 @@ import {
   filterAsync,
   getTokenSymbolForFlow,
   isDefined,
-  isUBA,
   mapAsync,
   queryHistoricalDepositForFill,
   resolveCorrespondingDepositForFill,


### PR DESCRIPTION
In the UBA model, events should be matched to UBA config based on the bundle start block containing the event, rather than the event.quoteBlock