### PR TITLE
improve: Append block timestamp to SpokePool events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.14.12",
+  "version": "0.14.13",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -727,11 +727,11 @@ export class SpokePoolClient extends BaseAbstractClient {
         });
       }
       await forEachAsync(fillEvents, async (event) => {
-        const fillData = spreadEventWithBlockNumber(event);
-        const fill = {
-          ...fillData,
-          blockTimestamp: (await this.spokePool.provider.getBlock(fillData.blockNumber)).timestamp,
-        } as FillWithBlock;
+        const rawFill = spreadEventWithBlockNumber(event) as FillWithBlock;
+        const fill: FillWithBlock = {
+          ...rawFill,
+          blockTimestamp: (await this.spokePool.provider.getBlock(rawFill.blockNumber)).timestamp,
+        };
         assign(this.fills, [fill.originChainId], [fill]);
         assign(this.depositHashesToFills, [this.getDepositHash(fill)], [fill]);
       });
@@ -749,14 +749,14 @@ export class SpokePoolClient extends BaseAbstractClient {
         });
       }
       await forEachAsync(refundRequests, async (event) => {
-        const refundRequestData = spreadEventWithBlockNumber(event);
-        const refundRequest = {
-          ...refundRequestData,
+        const rawRefundRequest = spreadEventWithBlockNumber(event) as RefundRequestWithBlock;
+        const refundRequest: RefundRequestWithBlock = {
+          ...rawRefundRequest,
           // repaymentChainId is not part of the on-chain event, so add it here.
           repaymentChainId: this.chainId,
-          blockTimestamp: (await this.spokePool.provider.getBlock(refundRequestData.blockNumber)).timestamp,
+          blockTimestamp: (await this.spokePool.provider.getBlock(rawRefundRequest.blockNumber)).timestamp,
         };
-        this.refundRequests.push(refundRequest as RefundRequestWithBlock);
+        this.refundRequests.push(refundRequest);
       });
     }
 

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -787,8 +787,7 @@ export class SpokePoolClient extends BaseAbstractClient {
         const rawRefundRequest = spreadEventWithBlockNumber(event) as RefundRequestWithBlock;
         const refundRequest: RefundRequestWithBlock = {
           ...rawRefundRequest,
-          // repaymentChainId is not part of the on-chain event, so add it here.
-          repaymentChainId: this.chainId,
+          repaymentChainId: this.chainId, // repaymentChainId is not part of the on-chain event, so add it here.
           blockTimestamp: blocks[event.blockNumber].timestamp,
         };
         this.refundRequests.push(refundRequest);

--- a/src/clients/UBAClient/UBAClientWithRefresh.ts
+++ b/src/clients/UBAClient/UBAClientWithRefresh.ts
@@ -98,6 +98,7 @@ export class UBAClientWithRefresh extends BaseUBAClient {
       // Unused params:
       recipient: "",
       depositId: 0,
+      blockTimestamp: 0,
       relayerFeePct: ethers.constants.Zero,
       quoteTimestamp: 0,
       destinationToken: "",

--- a/src/clients/mocks/MockEvents.ts
+++ b/src/clients/mocks/MockEvents.ts
@@ -76,6 +76,7 @@ export class EventManager {
     const blockHash = id(`Across-v2-blockHash-${parentHash}-${random(1, 100_000)}`);
 
     // getBlock() may later be used to retrieve (for example) the block timestamp.
+    // @todo: If multiple events coincide on the same block number, this callback should return the same Block object.
     const getBlock = async (): Promise<Block> => {
       return {
         hash: blockHash,

--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -1,12 +1,14 @@
 import assert from "assert";
-import { Contract, Event } from "ethers";
+import { Contract, Event, providers } from "ethers";
 import { random } from "lodash";
 import winston from "winston";
 import { ZERO_ADDRESS } from "../../constants";
 import { DepositWithBlock, FillWithBlock, RefundRequestWithBlock } from "../../interfaces";
-import { toBN, toBNWei, randomAddress } from "../../utils";
+import { toBN, toBNWei, forEachAsync, randomAddress } from "../../utils";
 import { SpokePoolClient, SpokePoolUpdate } from "../SpokePoolClient";
 import { EventManager, getEventManager } from "./MockEvents";
+
+type Block = providers.Block;
 
 // This class replaces internal SpokePoolClient functionality, enabling the
 // user to bypass on-chain queries and inject ethers Event objects directly.
@@ -59,13 +61,16 @@ export class MockSpokePoolClient extends SpokePoolClient {
     const latestBlockNumber = this.eventManager.blockNumber;
     const currentTime = Math.floor(Date.now() / 1000);
 
+    const blocks: { [blockNumber: number]: Block } = {};
+
     // Ensure an array for every requested event exists, in the requested order.
     // All requested event types must be populated in the array (even if empty).
     const events: Event[][] = eventsToQuery.map(() => []);
-    this.events.flat().forEach((event) => {
+    await forEachAsync(this.events.flat(), async (event) => {
       const idx = eventsToQuery.indexOf(event.event as string);
       if (idx !== -1) {
         events[idx].push(event);
+        blocks[event.blockNumber] = await event.getBlock();
       }
     });
     this.events = [];
@@ -84,6 +89,7 @@ export class MockSpokePoolClient extends SpokePoolClient {
       latestDepositId,
       currentTime,
       events,
+      blocks,
       searchEndBlock: this.eventSearchConfig.toBlock || latestBlockNumber,
     };
   }

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -23,6 +23,7 @@ export interface Deposit {
 }
 
 export interface DepositWithBlock extends Deposit, SortableEvent {
+  blockTimestamp: number;
   quoteBlockNumber: number;
 }
 
@@ -51,7 +52,9 @@ export interface Fill {
   updatableRelayData: RelayExecutionInfo;
 }
 
-export interface FillWithBlock extends Fill, SortableEvent {}
+export interface FillWithBlock extends Fill, SortableEvent {
+  blockTimestamp: number;
+}
 
 export interface SpeedUp {
   depositor: string;
@@ -97,7 +100,9 @@ export interface RefundRequest {
   previousIdenticalRequests: BigNumber;
 }
 
-export interface RefundRequestWithBlock extends RefundRequest, SortableEvent {}
+export interface RefundRequestWithBlock extends RefundRequest, SortableEvent {
+  blockTimestamp: number;
+}
 
 export interface RootBundleRelay {
   rootBundleId: number;

--- a/src/interfaces/UBA.test.ts
+++ b/src/interfaces/UBA.test.ts
@@ -1,5 +1,5 @@
 import { random } from "lodash";
-import { toBN, toBNWei } from "../utils";
+import { getCurrentTime, toBN, toBNWei } from "../utils";
 import {
   DepositWithBlock,
   FillWithBlock,
@@ -12,12 +12,15 @@ import {
   outflowIsRefund,
 } from "./";
 
+const now = getCurrentTime();
+
 const common = {
   depositId: random(1, 1000, false),
   amount: toBNWei(0.01),
   originChainId: 1,
   destinationChainId: 10,
   blockNumber: 1,
+  blockTimestamp: now,
   transactionIndex: 0,
   logIndex: 0,
   transactionHash: "",
@@ -28,7 +31,7 @@ const sampleDeposit = {
   recipient: "",
   originToken: "",
   relayerFeePct: toBNWei(0.0001),
-  quoteTimestamp: Math.floor(Date.now() / 1000),
+  quoteTimestamp: now,
   realizedLpFeePct: toBNWei(0.00001),
   destinationToken: "",
   quoteBlockNumber: 1,


### PR DESCRIPTION
Add the block timestamp to FundsDeposited, FilledRelay and RefundRequested events. This allows upper layers to perform additional checks based on cross-chain timestamps.

This change is plucked from @nicholaspai's existing draft PR here: https://github.com/across-protocol/sdk-v2/pull/332/files#diff-8aaa64629d1940a0ea618d935e9d93044f09df5bd32d7352ee02c415a763d250

This change is also implicitly dependent on the following change in relayer-v2, because without it the relayer will experience a potentially significant performance decrease (and a potentially large increase in RPC usage): https://github.com/across-protocol/relayer-v2/pull/835

ACX-1328