### PR TITLE
feat(clients): add `toJSON` and `updateFromJSON` methods

### DIFF
--- a/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
+++ b/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
@@ -502,44 +502,61 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
       return;
     }
 
-    this.cumulativeRateModelUpdates = configStoreClientState.cumulativeRateModelUpdates || [];
-    this.ubaConfigUpdates = (configStoreClientState.ubaConfigUpdates || []).map((update) => {
-      return {
-        ...update,
-        config: parseUBAConfigFromOnChain(update.config),
-      };
-    });
-    this.cumulativeRouteRateModelUpdates = configStoreClientState.cumulativeRouteRateModelUpdates || [];
-    this.cumulativeTokenTransferUpdates = (configStoreClientState.cumulativeTokenTransferUpdates || []).map(
-      (update) => {
-        return {
-          ...update,
-          transferThreshold: BigNumber.from(update.transferThreshold),
-        };
-      }
-    );
-    this.cumulativeMaxRefundCountUpdates = configStoreClientState.cumulativeMaxRefundCountUpdates || [];
-    this.cumulativeMaxL1TokenCountUpdates = configStoreClientState.cumulativeMaxL1TokenCountUpdates || [];
-    this.cumulativeSpokeTargetBalanceUpdates = (configStoreClientState.cumulativeSpokeTargetBalanceUpdates || []).map(
-      (update) => {
-        return {
-          ...update,
-          spokeTargetBalances: Object.entries(update.spokeTargetBalances || {}).reduce(
-            (acc, [chainId, { target, threshold }]) => ({
-              ...acc,
-              [chainId]: { target: BigNumber.from(target), threshold: BigNumber.from(threshold) },
-            }),
-            {}
-          ),
-        };
-      }
-    );
-    this.cumulativeConfigStoreVersionUpdates = configStoreClientState.cumulativeConfigStoreVersionUpdates || [];
-    this.cumulativeDisabledChainUpdates = configStoreClientState.cumulativeDisabledChainUpdates || [];
-    this.firstBlockToSearch = configStoreClientState.firstBlockToSearch || 0;
-    this.hasLatestConfigStoreVersion = configStoreClientState.hasLatestConfigStoreVersion || false;
-    this.latestBlockNumber = configStoreClientState.latestBlockNumber || 0;
-    this.rateModelDictionary.updateWithEvents(configStoreClientState.cumulativeRateModelUpdates || []);
+    const {
+      cumulativeRateModelUpdates = this.cumulativeRateModelUpdates,
+      cumulativeRouteRateModelUpdates = this.cumulativeRouteRateModelUpdates,
+      cumulativeMaxRefundCountUpdates = this.cumulativeMaxRefundCountUpdates,
+      cumulativeMaxL1TokenCountUpdates = this.cumulativeMaxL1TokenCountUpdates,
+      cumulativeConfigStoreVersionUpdates = this.cumulativeConfigStoreVersionUpdates,
+      cumulativeDisabledChainUpdates = this.cumulativeDisabledChainUpdates,
+      firstBlockToSearch = this.firstBlockToSearch,
+      hasLatestConfigStoreVersion = this.hasLatestConfigStoreVersion,
+      latestBlockNumber = this.latestBlockNumber,
+      ubaConfigUpdates,
+      cumulativeTokenTransferUpdates,
+      cumulativeSpokeTargetBalanceUpdates,
+    } = configStoreClientState;
+
+    this.cumulativeRateModelUpdates = cumulativeRateModelUpdates;
+    this.ubaConfigUpdates = ubaConfigUpdates
+      ? ubaConfigUpdates.map((update) => {
+          return {
+            ...update,
+            config: parseUBAConfigFromOnChain(update.config),
+          };
+        })
+      : this.ubaConfigUpdates;
+    this.cumulativeRouteRateModelUpdates = cumulativeRouteRateModelUpdates;
+    this.cumulativeTokenTransferUpdates = cumulativeTokenTransferUpdates
+      ? cumulativeTokenTransferUpdates.map((update) => {
+          return {
+            ...update,
+            transferThreshold: BigNumber.from(update.transferThreshold),
+          };
+        })
+      : this.cumulativeTokenTransferUpdates;
+    this.cumulativeMaxRefundCountUpdates = cumulativeMaxRefundCountUpdates;
+    this.cumulativeMaxL1TokenCountUpdates = cumulativeMaxL1TokenCountUpdates;
+    this.cumulativeSpokeTargetBalanceUpdates = cumulativeSpokeTargetBalanceUpdates
+      ? cumulativeSpokeTargetBalanceUpdates.map((update) => {
+          return {
+            ...update,
+            spokeTargetBalances: Object.entries(update.spokeTargetBalances || {}).reduce(
+              (acc, [chainId, { target, threshold }]) => ({
+                ...acc,
+                [chainId]: { target: BigNumber.from(target), threshold: BigNumber.from(threshold) },
+              }),
+              {}
+            ),
+          };
+        })
+      : [];
+    this.cumulativeConfigStoreVersionUpdates = cumulativeConfigStoreVersionUpdates;
+    this.cumulativeDisabledChainUpdates = cumulativeDisabledChainUpdates;
+    this.firstBlockToSearch = firstBlockToSearch;
+    this.hasLatestConfigStoreVersion = hasLatestConfigStoreVersion;
+    this.latestBlockNumber = latestBlockNumber;
+    this.rateModelDictionary.updateWithEvents(cumulativeRateModelUpdates);
     this.isUpdated = true;
   }
 

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -840,28 +840,48 @@ export class HubPoolClient extends BaseAbstractClient {
       throw new Error("ConfigStoreClient not updated");
     }
 
-    this.l1TokensToDestinationTokens = hubPoolClientState.l1TokensToDestinationTokens || {};
-    this.l1Tokens = hubPoolClientState.l1Tokens || [];
-    this.lpTokens = hubPoolClientState.lpTokens || {};
-    this.proposedRootBundles = (hubPoolClientState.proposedRootBundles || []).map((bundle) => ({
-      ...bundle,
-      bundleEvaluationBlockNumbers: bundle.bundleEvaluationBlockNumbers.map((block) => BigNumber.from(block)),
-    }));
-    this.canceledRootBundles = hubPoolClientState.canceledRootBundles || [];
-    this.disputedRootBundles = hubPoolClientState.disputedRootBundles || [];
-    this.executedRootBundles = (hubPoolClientState.executedRootBundles || []).map((bundle) => ({
-      ...bundle,
-      bundleLpFees: bundle.bundleLpFees.map((fee) => BigNumber.from(fee)),
-      netSendAmounts: bundle.netSendAmounts.map((amount) => BigNumber.from(amount)),
-      runningBalances: bundle.runningBalances.map((balance) => BigNumber.from(balance)),
-      incentiveBalances: bundle.incentiveBalances.map((balance) => BigNumber.from(balance)),
-    }));
-    this.pendingRootBundle = hubPoolClientState.pendingRootBundle;
-    this.crossChainContracts = hubPoolClientState.crossChainContracts || {};
-    this.l1TokensToDestinationTokensWithBlock = hubPoolClientState.l1TokensToDestinationTokensWithBlock || {};
-    this.firstBlockToSearch = hubPoolClientState.firstBlockToSearch || 0;
-    this.latestBlockNumber = hubPoolClientState.latestBlockNumber || 0;
-    this.currentTime = hubPoolClientState.currentTime || 0;
+    const {
+      l1TokensToDestinationTokens = this.l1TokensToDestinationTokens,
+      l1Tokens = this.l1Tokens,
+      lpTokens = this.lpTokens,
+      canceledRootBundles = this.canceledRootBundles,
+      disputedRootBundles = this.disputedRootBundles,
+      pendingRootBundle = this.pendingRootBundle,
+      crossChainContracts = this.crossChainContracts,
+      l1TokensToDestinationTokensWithBlock = this.l1TokensToDestinationTokensWithBlock,
+      firstBlockToSearch = this.firstBlockToSearch,
+      latestBlockNumber = this.latestBlockNumber,
+      currentTime = this.currentTime,
+      proposedRootBundles,
+      executedRootBundles,
+    } = hubPoolClientState;
+
+    this.l1TokensToDestinationTokens = l1TokensToDestinationTokens;
+    this.l1Tokens = l1Tokens;
+    this.lpTokens = lpTokens;
+    this.proposedRootBundles = proposedRootBundles
+      ? proposedRootBundles.map((bundle) => ({
+          ...bundle,
+          bundleEvaluationBlockNumbers: bundle.bundleEvaluationBlockNumbers.map((block) => BigNumber.from(block)),
+        }))
+      : this.proposedRootBundles;
+    this.canceledRootBundles = canceledRootBundles;
+    this.disputedRootBundles = disputedRootBundles;
+    this.executedRootBundles = executedRootBundles
+      ? executedRootBundles.map((bundle) => ({
+          ...bundle,
+          bundleLpFees: bundle.bundleLpFees.map((fee) => BigNumber.from(fee)),
+          netSendAmounts: bundle.netSendAmounts.map((amount) => BigNumber.from(amount)),
+          runningBalances: bundle.runningBalances.map((balance) => BigNumber.from(balance)),
+          incentiveBalances: bundle.incentiveBalances.map((balance) => BigNumber.from(balance)),
+        }))
+      : this.executedRootBundles;
+    this.pendingRootBundle = pendingRootBundle;
+    this.crossChainContracts = crossChainContracts;
+    this.l1TokensToDestinationTokensWithBlock = l1TokensToDestinationTokensWithBlock;
+    this.firstBlockToSearch = firstBlockToSearch;
+    this.latestBlockNumber = latestBlockNumber;
+    this.currentTime = currentTime;
     this.isUpdated = true;
   }
 

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -962,9 +962,21 @@ export class SpokePoolClient extends BaseAbstractClient {
     return deposit;
   }
 
-  public updateFromJSON(spokePoolClientState: ReturnType<SpokePoolClient["toJSON"]>) {
-    this.currentTime = spokePoolClientState.currentTime;
-    this.depositHashes = Object.entries(spokePoolClientState.depositHashes).reduce(
+  public updateFromJSON(spokePoolClientState: Partial<ReturnType<SpokePoolClient["toJSON"]>>) {
+    const keysToUpdate = Object.keys(spokePoolClientState);
+
+    this.logger.debug({
+      at: "SpokePoolClient",
+      message: "Updating SpokePool client from JSON",
+      keys: keysToUpdate,
+    });
+
+    if (keysToUpdate.length === 0) {
+      return;
+    }
+
+    this.currentTime = spokePoolClientState.currentTime || this.currentTime;
+    this.depositHashes = Object.entries(spokePoolClientState.depositHashes || {}).reduce(
       (acc, [hash, deposit]) => ({
         ...acc,
         [hash]: {
@@ -977,7 +989,7 @@ export class SpokePoolClient extends BaseAbstractClient {
       }),
       {} as Record<string, DepositWithBlock>
     );
-    this.depositHashesToFills = Object.entries(spokePoolClientState.depositHashesToFills).reduce(
+    this.depositHashesToFills = Object.entries(spokePoolClientState.depositHashesToFills || {}).reduce(
       (acc, [hash, fills]) => ({
         ...acc,
         [hash]: fills.map((fill) => ({
@@ -996,7 +1008,7 @@ export class SpokePoolClient extends BaseAbstractClient {
       }),
       {} as Record<string, FillWithBlock[]>
     );
-    this.speedUps = Object.entries(spokePoolClientState.speedUps).reduce((acc, [depositor, speedUpsMap]) => {
+    this.speedUps = Object.entries(spokePoolClientState.speedUps || {}).reduce((acc, [depositor, speedUpsMap]) => {
       const speedUps = Object.entries(speedUpsMap).reduce(
         (acc, [depositId, speedUps]) => ({
           ...acc,
@@ -1009,30 +1021,30 @@ export class SpokePoolClient extends BaseAbstractClient {
       );
       return { ...acc, [depositor]: speedUps };
     }, {});
-    this.depositRoutes = spokePoolClientState.depositRoutes;
-    this.tokensBridged = spokePoolClientState.tokensBridged.map((tokenBridged) => ({
+    this.depositRoutes = spokePoolClientState.depositRoutes || {};
+    this.tokensBridged = (spokePoolClientState.tokensBridged || []).map((tokenBridged) => ({
       ...tokenBridged,
       amountToReturn: BigNumber.from(tokenBridged.amountToReturn),
     }));
-    (this.rootBundleRelays = spokePoolClientState.rootBundleRelays),
-      (this.relayerRefundExecutions = spokePoolClientState.relayerRefundExecutions.map((refundExecution) => ({
-        ...refundExecution,
-        amountToReturn: BigNumber.from(refundExecution.amountToReturn),
-        refundAmounts: refundExecution.refundAmounts.map((refundAmount) => BigNumber.from(refundAmount)),
-      })));
-    this.earlyDeposits = spokePoolClientState.earlyDeposits.map((deposit) => ({
+    this.rootBundleRelays = spokePoolClientState.rootBundleRelays || [];
+    this.relayerRefundExecutions = (spokePoolClientState.relayerRefundExecutions || []).map((refundExecution) => ({
+      ...refundExecution,
+      amountToReturn: BigNumber.from(refundExecution.amountToReturn),
+      refundAmounts: refundExecution.refundAmounts.map((refundAmount) => BigNumber.from(refundAmount)),
+    }));
+    this.earlyDeposits = (spokePoolClientState.earlyDeposits || []).map((deposit) => ({
       ...deposit,
       amount: BigNumber.from(deposit.amount),
       originChainId: BigNumber.from(deposit.originChainId),
       destinationChainId: BigNumber.from(deposit.destinationChainId),
       relayerFeePct: BigNumber.from(deposit.relayerFeePct),
     }));
-    this.queryableEventNames = spokePoolClientState.queryableEventNames;
-    this.earliestDepositIdQueried = spokePoolClientState.earliestDepositIdQueried;
-    this.latestDepositIdQueried = spokePoolClientState.latestDepositIdQueried;
-    this.firstBlockToSearch = spokePoolClientState.firstBlockToSearch;
-    this.latestBlockSearched = spokePoolClientState.latestBlockSearched;
-    this.fills = Object.entries(spokePoolClientState.fills).reduce(
+    this.queryableEventNames = spokePoolClientState.queryableEventNames || this.queryableEventNames;
+    this.earliestDepositIdQueried = spokePoolClientState.earliestDepositIdQueried || this.earliestDepositIdQueried;
+    this.latestDepositIdQueried = spokePoolClientState.latestDepositIdQueried || this.latestDepositIdQueried;
+    this.firstBlockToSearch = spokePoolClientState.firstBlockToSearch || this.firstBlockToSearch;
+    this.latestBlockSearched = spokePoolClientState.latestBlockSearched || this.latestBlockSearched;
+    this.fills = Object.entries(spokePoolClientState.fills || []).reduce(
       (acc, [chainId, fills]) => ({
         ...acc,
         [chainId]: fills.map((fill) => ({
@@ -1051,7 +1063,7 @@ export class SpokePoolClient extends BaseAbstractClient {
       }),
       {}
     );
-    this.refundRequests = spokePoolClientState.refundRequests.map((refundRequest) => ({
+    this.refundRequests = (spokePoolClientState.refundRequests || []).map((refundRequest) => ({
       ...refundRequest,
       amount: BigNumber.from(refundRequest.amount),
       realizedLpFeePct: BigNumber.from(refundRequest.realizedLpFeePct),

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -1,5 +1,13 @@
 import { groupBy } from "lodash";
-import { assign, EventSearchConfig, DefaultLogLevels, MakeOptional, AnyObject, MAX_BIG_INT } from "../utils";
+import {
+  assign,
+  EventSearchConfig,
+  DefaultLogLevels,
+  MakeOptional,
+  AnyObject,
+  MAX_BIG_INT,
+  stringifyJSONWithNumericString,
+} from "../utils";
 import { toBN } from "../utils/common";
 import { validateFillForDeposit, filledSameDeposit } from "../utils/FlowUtils";
 import {
@@ -24,6 +32,13 @@ import {
   SpeedUp,
   TokensBridged,
   FundsDepositedEvent,
+  DepositWithBlockStringified,
+  FillWithBlockStringified,
+  SpeedUpStringified,
+  TokensBridgedStringified,
+  RelayerRefundExecutionWithBlockStringified,
+  FundsDepositedEventStringified,
+  RefundRequestWithBlockStringified,
 } from "../interfaces";
 import { HubPoolClient } from "./HubPoolClient";
 import { ZERO_ADDRESS } from "../constants";
@@ -945,5 +960,147 @@ export class SpokePoolClient extends BaseAbstractClient {
     });
 
     return deposit;
+  }
+
+  public updateFromJSON(spokePoolClientState: ReturnType<SpokePoolClient["toJSON"]>) {
+    this.currentTime = spokePoolClientState.currentTime;
+    this.depositHashes = Object.entries(spokePoolClientState.depositHashes).reduce(
+      (acc, [hash, deposit]) => ({
+        ...acc,
+        [hash]: {
+          ...deposit,
+          amount: BigNumber.from(deposit.amount),
+          relayerFeePct: BigNumber.from(deposit.relayerFeePct),
+          realizedLpFeePct: deposit.relayerFeePct ? BigNumber.from(deposit.realizedLpFeePct) : undefined,
+          newRelayerFeePct: deposit.newRelayerFeePct ? BigNumber.from(deposit.newRelayerFeePct) : undefined,
+        },
+      }),
+      {} as Record<string, DepositWithBlock>
+    );
+    this.depositHashesToFills = Object.entries(spokePoolClientState.depositHashesToFills).reduce(
+      (acc, [hash, fills]) => ({
+        ...acc,
+        [hash]: fills.map((fill) => ({
+          ...fill,
+          amount: BigNumber.from(fill.amount),
+          totalFilledAmount: BigNumber.from(fill.totalFilledAmount),
+          fillAmount: BigNumber.from(fill.fillAmount),
+          relayerFeePct: BigNumber.from(fill.relayerFeePct),
+          realizedLpFeePct: BigNumber.from(fill.realizedLpFeePct),
+          updatableRelayData: {
+            ...fill.updatableRelayData,
+            relayerFeePct: BigNumber.from(fill.updatableRelayData.relayerFeePct),
+            payoutAdjustmentPct: BigNumber.from(fill.updatableRelayData.payoutAdjustmentPct),
+          },
+        })),
+      }),
+      {} as Record<string, FillWithBlock[]>
+    );
+    this.speedUps = Object.entries(spokePoolClientState.speedUps).reduce((acc, [depositor, speedUpsMap]) => {
+      const speedUps = Object.entries(speedUpsMap).reduce(
+        (acc, [depositId, speedUps]) => ({
+          ...acc,
+          [depositId]: speedUps.map((speedUp) => ({
+            ...speedUp,
+            newRelayerFeePct: BigNumber.from(speedUp.newRelayerFeePct),
+          })),
+        }),
+        {} as Record<string, SpeedUp[]>
+      );
+      return { ...acc, [depositor]: speedUps };
+    }, {});
+    this.depositRoutes = spokePoolClientState.depositRoutes;
+    this.tokensBridged = spokePoolClientState.tokensBridged.map((tokenBridged) => ({
+      ...tokenBridged,
+      amountToReturn: BigNumber.from(tokenBridged.amountToReturn),
+    }));
+    (this.rootBundleRelays = spokePoolClientState.rootBundleRelays),
+      (this.relayerRefundExecutions = spokePoolClientState.relayerRefundExecutions.map((refundExecution) => ({
+        ...refundExecution,
+        amountToReturn: BigNumber.from(refundExecution.amountToReturn),
+        refundAmounts: refundExecution.refundAmounts.map((refundAmount) => BigNumber.from(refundAmount)),
+      })));
+    this.earlyDeposits = spokePoolClientState.earlyDeposits.map((deposit) => ({
+      ...deposit,
+      amount: BigNumber.from(deposit.amount),
+      originChainId: BigNumber.from(deposit.originChainId),
+      destinationChainId: BigNumber.from(deposit.destinationChainId),
+      relayerFeePct: BigNumber.from(deposit.relayerFeePct),
+    }));
+    this.queryableEventNames = spokePoolClientState.queryableEventNames;
+    this.earliestDepositIdQueried = spokePoolClientState.earliestDepositIdQueried;
+    this.latestDepositIdQueried = spokePoolClientState.latestDepositIdQueried;
+    this.firstBlockToSearch = spokePoolClientState.firstBlockToSearch;
+    this.latestBlockSearched = spokePoolClientState.latestBlockSearched;
+    this.fills = Object.entries(spokePoolClientState.fills).reduce(
+      (acc, [chainId, fills]) => ({
+        ...acc,
+        [chainId]: fills.map((fill) => ({
+          ...fill,
+          amount: BigNumber.from(fill.amount),
+          totalFilledAmount: BigNumber.from(fill.totalFilledAmount),
+          fillAmount: BigNumber.from(fill.fillAmount),
+          relayerFeePct: BigNumber.from(fill.relayerFeePct),
+          realizedLpFeePct: BigNumber.from(fill.realizedLpFeePct),
+          updatableRelayData: {
+            ...fill.updatableRelayData,
+            relayerFeePct: BigNumber.from(fill.updatableRelayData.relayerFeePct),
+            payoutAdjustmentPct: BigNumber.from(fill.updatableRelayData.payoutAdjustmentPct),
+          },
+        })),
+      }),
+      {}
+    );
+    this.refundRequests = spokePoolClientState.refundRequests.map((refundRequest) => ({
+      ...refundRequest,
+      amount: BigNumber.from(refundRequest.amount),
+      realizedLpFeePct: BigNumber.from(refundRequest.realizedLpFeePct),
+      previousIdenticalRequests: BigNumber.from(refundRequest.previousIdenticalRequests),
+      fillBlock: BigNumber.from(refundRequest.fillBlock),
+    }));
+    this.isUpdated = true;
+  }
+
+  public toJSON() {
+    return {
+      chainId: this.chainId,
+      deploymentBlock: this.deploymentBlock,
+      eventSearchConfig: this.eventSearchConfig,
+
+      currentTime: this.currentTime,
+      depositHashes: JSON.parse(stringifyJSONWithNumericString(this.depositHashes)) as Record<
+        string,
+        DepositWithBlockStringified
+      >,
+      depositHashesToFills: JSON.parse(stringifyJSONWithNumericString(this.depositHashesToFills)) as Record<
+        string,
+        FillWithBlockStringified[]
+      >,
+      speedUps: JSON.parse(stringifyJSONWithNumericString(this.speedUps)) as {
+        [depositorAddress: string]: {
+          [depositId: number]: SpeedUpStringified[];
+        };
+      },
+      depositRoutes: this.depositRoutes,
+      tokensBridged: JSON.parse(stringifyJSONWithNumericString(this.tokensBridged)) as TokensBridgedStringified[],
+      rootBundleRelays: this.rootBundleRelays,
+      relayerRefundExecutions: JSON.parse(
+        stringifyJSONWithNumericString(this.relayerRefundExecutions)
+      ) as RelayerRefundExecutionWithBlockStringified[],
+      earlyDeposits: JSON.parse(stringifyJSONWithNumericString(this.earlyDeposits)) as FundsDepositedEventStringified[],
+      queryableEventNames: this.queryableEventNames,
+
+      earliestDepositIdQueried: this.earliestDepositIdQueried,
+      earliestDepositIdForSpokePool: this.firstDepositIdForSpokePool,
+      latestDepositIdQueried: this.latestDepositIdQueried,
+      latestDepositIdForSpokePool: this.lastDepositIdForSpokePool,
+      firstBlockToSearch: this.firstBlockToSearch,
+      latestBlockSearched: this.latestBlockSearched,
+      isUpdated: this.isUpdated,
+      fills: JSON.parse(stringifyJSONWithNumericString(this.fills)) as Record<string, FillWithBlockStringified[]>,
+      refundRequests: JSON.parse(
+        stringifyJSONWithNumericString(this.refundRequests)
+      ) as RefundRequestWithBlockStringified[],
+    };
   }
 }

--- a/src/interfaces/ConfigStore.ts
+++ b/src/interfaces/ConfigStore.ts
@@ -22,14 +22,30 @@ export interface L1TokenTransferThreshold extends SortableEvent {
   l1Token: string;
 }
 
+export type L1TokenTransferThresholdStringified = Omit<L1TokenTransferThreshold, "transferThreshold"> & {
+  transferThreshold: string;
+};
+
 export interface SpokePoolTargetBalance {
   target: BigNumber;
   threshold: BigNumber;
 }
 
+export type SpokePoolTargetBalanceStringified = Omit<SpokePoolTargetBalance, "threshold" | "target"> & {
+  target: string;
+  threshold: string;
+};
+
 export interface SpokeTargetBalanceUpdate extends SortableEvent {
   spokeTargetBalances?: {
     [chainId: number]: SpokePoolTargetBalance;
+  };
+  l1Token: string;
+}
+
+export interface SpokeTargetBalanceUpdateStringified extends SortableEvent {
+  spokeTargetBalances?: {
+    [chainId: number]: SpokePoolTargetBalanceStringified;
   };
   l1Token: string;
 }
@@ -155,5 +171,13 @@ export type UBAParsedConfigType = UBAAgnosticConfigType<BigNumber>;
  */
 export type UBAConfigUpdates = SortableEvent & {
   config: UBAParsedConfigType;
+  l1Token: string;
+};
+
+/**
+ * A type for stringified UBAConfig Update events.
+ */
+export type UBASerializedConfigUpdates = SortableEvent & {
+  config: UBAOnChainConfigType;
   l1Token: string;
 };

--- a/src/interfaces/HubPool.ts
+++ b/src/interfaces/HubPool.ts
@@ -30,6 +30,10 @@ export interface ProposedRootBundle extends SortableEvent {
   proposer: string;
 }
 
+export type ProposedRootBundleStringified = Omit<ProposedRootBundle, "bundleEvaluationBlockNumbers"> & {
+  bundleEvaluationBlockNumbers: string[];
+};
+
 export interface CancelledRootBundle extends SortableEvent {
   disputer: string;
   requestTime: number;
@@ -50,6 +54,16 @@ export interface ExecutedRootBundle extends SortableEvent {
   l1Tokens: string[];
   proof: string[];
 }
+
+export type ExecutedRootBundleStringified = Omit<
+  ExecutedRootBundle,
+  "bundleLpFees" | "netSendAmounts" | "runningBalances" | "incentiveBalances"
+> & {
+  bundleLpFees: string[];
+  netSendAmounts: string[];
+  runningBalances: string[];
+  incentiveBalances: string[];
+};
 
 export type TokenRunningBalance = {
   runningBalance: BigNumber;

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -1,5 +1,6 @@
 import { BigNumber } from "ethers";
 import { SortableEvent } from "./Common";
+import { FundsDepositedEvent } from "../typechain";
 
 export type { FundsDepositedEvent } from "../typechain";
 
@@ -26,6 +27,16 @@ export interface DepositWithBlock extends Deposit, SortableEvent {
   quoteBlockNumber: number;
 }
 
+export type DepositWithBlockStringified = Omit<
+  DepositWithBlock,
+  "amount" | "relayerFeePct" | "realizedLpFeePct" | "newRelayerFeePct"
+> & {
+  amount: string;
+  relayerFeePct: string;
+  realizedLpFeePct?: string;
+  newRelayerFeePct?: string;
+};
+
 export interface RelayExecutionInfo {
   recipient: string;
   message: string;
@@ -33,6 +44,13 @@ export interface RelayExecutionInfo {
   isSlowRelay: boolean;
   payoutAdjustmentPct: BigNumber;
 }
+export type RelayerRefundExecutionInfoStringified = Omit<
+  RelayExecutionInfo,
+  "relayerFeePct" | "payoutAdjustmentPct"
+> & {
+  relayerFeePct: string;
+  payoutAdjustmentPct: string;
+};
 export interface Fill {
   amount: BigNumber;
   totalFilledAmount: BigNumber;
@@ -53,6 +71,18 @@ export interface Fill {
 
 export interface FillWithBlock extends Fill, SortableEvent {}
 
+export type FillWithBlockStringified = Omit<
+  FillWithBlock,
+  "amount" | "relayerFeePct" | "totalFilledAmount" | "fillAmount" | "realizedLpFeePct" | "updatableRelayData"
+> & {
+  amount: string;
+  totalFilledAmount: string;
+  fillAmount: string;
+  relayerFeePct: string;
+  realizedLpFeePct: string;
+  updatableRelayData: RelayerRefundExecutionInfoStringified;
+};
+
 export interface SpeedUp {
   depositor: string;
   depositorSignature: string;
@@ -62,6 +92,10 @@ export interface SpeedUp {
   updatedRecipient: string;
   updatedMessage: string;
 }
+
+export type SpeedUpStringified = Omit<SpeedUp, "newRelayerFeePct"> & {
+  newRelayerFeePct: string;
+};
 
 export interface SlowFill {
   relayHash: string;
@@ -99,6 +133,16 @@ export interface RefundRequest {
 
 export interface RefundRequestWithBlock extends RefundRequest, SortableEvent {}
 
+export type RefundRequestWithBlockStringified = Omit<
+  RefundRequestWithBlock,
+  "amount" | "realizedLpFeePct" | "previousIdenticalRequests" | "fillBlock" | "previousIdenticalRequests"
+> & {
+  amount: string;
+  realizedLpFeePct: string;
+  previousIdenticalRequests: string;
+  fillBlock: string;
+};
+
 export interface RootBundleRelay {
   rootBundleId: number;
   relayerRefundRoot: string;
@@ -119,6 +163,14 @@ export interface RelayerRefundExecution {
 }
 
 export interface RelayerRefundExecutionWithBlock extends RelayerRefundExecution, SortableEvent {}
+
+export type RelayerRefundExecutionWithBlockStringified = Omit<
+  RelayerRefundExecutionWithBlock,
+  "amountToReturn" | "refundAmounts"
+> & {
+  amountToReturn: string;
+  refundAmounts: string[];
+};
 
 // Used in pool by spokePool to execute a slow relay.
 export interface RelayData {
@@ -172,3 +224,17 @@ export interface TokensBridged extends SortableEvent {
   l2TokenAddress: string;
   caller: string;
 }
+
+export type TokensBridgedStringified = Omit<TokensBridged, "amountToReturn"> & {
+  amountToReturn: string;
+};
+
+export type FundsDepositedEventStringified = Omit<
+  FundsDepositedEvent,
+  "amount" | "originChainId" | "destinationChainId" | "relayerFeePct"
+> & {
+  amount: string;
+  originChainId: string;
+  destinationChainId: string;
+  relayerFeePct: string;
+};


### PR DESCRIPTION
In an effort to make the states of `ConfigStoreClient`, `HubPoolClient` and `SpokePoolClient` serializable, i.e. cachable, I added custom `toJSON` methods. The `updateFromJSON` method allows updating the client state from the output of `toJSON`.

I added these because the performances of the `uba-client-state` job and serverless handler of `/suggested-fees` can be increased significantly by utilizing the above methods and caching.

For example, in the `/suggested-fees` handler, we can use cached `HubPoolClient` and `ConfigStoreClient` states in addition to the already cached `UBAClientState`. This way we don't need to call the `update()` methods to save time.