### PR TITLE
feat: add IPFS caching client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.14.13",
+  "version": "0.14.14",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@across-protocol/across-token": "^1.0.0",
     "@across-protocol/contracts-v2": "2.4.0",
     "@eth-optimism/sdk": "^2.1.0",
+    "@pinata/sdk": "^2.1.0",
     "@uma/sdk": "^0.34.1",
     "axios": "^0.27.2",
     "decimal.js": "^10.3.1",

--- a/src/caching/IPFS/PinataIPFSClient.ts
+++ b/src/caching/IPFS/PinataIPFSClient.ts
@@ -87,6 +87,6 @@ export class PinataIPFSClient implements CachingMechanismInterface {
         function: "setWithReturnID",
       },
     });
-    return storeValueInIPFS(JSON.stringify(value, jsonReplacerWithBigNumbers), this.client);
+    return storeValueInIPFS(key, JSON.stringify(value, jsonReplacerWithBigNumbers), this.client);
   }
 }

--- a/src/caching/IPFS/PinataIPFSClient.ts
+++ b/src/caching/IPFS/PinataIPFSClient.ts
@@ -1,16 +1,16 @@
-import { buildIPFSClient, retrieveValueFromIPFS, storeValueInIPFS } from "../utils/IPFSUtils";
-import { CachingMechanismInterface } from "../interfaces";
+import { buildIPFSClient, retrieveValueFromIPFS, storeValueInIPFS } from "../../utils/IPFSUtils";
+import { CachingMechanismInterface } from "../../interfaces";
 import { Struct } from "superstruct";
 import winston from "winston";
 import PinataClient from "@pinata/sdk";
-import { jsonReviverWithBigNumbers, jsonReplacerWithBigNumbers, formattedLog } from "../utils";
+import { jsonReviverWithBigNumbers, jsonReplacerWithBigNumbers, formattedLog } from "../../utils";
 
 /**
  * A client for interacting with the IPFS. This is a wrapper around the IPFS API.
  * This client also is a part of the caching mechanism interface.
  * @see https://docs.ipfs.io/reference/http/api/
  */
-export class IPFSClient implements CachingMechanismInterface {
+export class PinataIPFSClient implements CachingMechanismInterface {
   /**
    * The IPFS client instance
    */

--- a/src/caching/IPFS/index.ts
+++ b/src/caching/IPFS/index.ts
@@ -1,0 +1,1 @@
+export * from "./PinataIPFSClient";

--- a/src/caching/IPFSClient.ts
+++ b/src/caching/IPFSClient.ts
@@ -3,7 +3,7 @@ import { CachingMechanismInterface } from "../interfaces";
 import { Struct } from "superstruct";
 import winston from "winston";
 import PinataClient from "@pinata/sdk";
-import { jsonReviverWithBigNumbers, jsonReplacerWithBigNumbers } from "../utils";
+import { jsonReviverWithBigNumbers, jsonReplacerWithBigNumbers, formattedLog } from "../utils";
 
 /**
  * A client for interacting with the IPFS. This is a wrapper around the IPFS API.
@@ -42,7 +42,15 @@ export class IPFSClient implements CachingMechanismInterface {
     if (!key) {
       return null;
     }
-    this.logger?.info(`Retrieving value from IPFS with key ${key}`);
+    formattedLog(this.logger, {
+      level: "debug",
+      message: `Retrieving value from IPFS with key ${key}`,
+      at: {
+        location: "IPFSClient",
+        function: "get",
+      },
+    });
+
     const arrivedResult = await retrieveValueFromIPFS(key, this.publicGatewayURL);
     if (!arrivedResult) {
       return null;
@@ -50,7 +58,14 @@ export class IPFSClient implements CachingMechanismInterface {
     const revivedResult = JSON.parse(arrivedResult, jsonReviverWithBigNumbers);
 
     if (_structValidator && !_structValidator.is(revivedResult)) {
-      this.logger?.warn(`Retrieved value from IPFS with key ${key} does not match the expected type`);
+      formattedLog(this.logger, {
+        level: "warn",
+        message: `Retrieved value from IPFS with key ${key} does not match the expected type`,
+        at: {
+          location: "IPFSClient",
+          function: "get",
+        },
+      });
       return null;
     }
 
@@ -76,7 +91,14 @@ export class IPFSClient implements CachingMechanismInterface {
    * @returns The CID of the value stored.
    */
   setWithReturnID<T>(key: string, value: T): Promise<string | undefined> {
-    this.logger?.info(`Setting value from IPFS with key ${key}`);
+    formattedLog(this.logger, {
+      level: "debug",
+      message: `Setting value from IPFS with key ${key}`,
+      at: {
+        location: "IPFSClient",
+        function: "setWithReturnID",
+      },
+    });
     return storeValueInIPFS(JSON.stringify(value, jsonReplacerWithBigNumbers), this.client);
   }
 }

--- a/src/caching/IPFSClient.ts
+++ b/src/caching/IPFSClient.ts
@@ -1,14 +1,9 @@
-import {
-  buildIPFSClient,
-  jsonReplacerWithBigNumbers,
-  jsonReviverWithBigNumbers,
-  retrieveValueFromIPFS,
-  storeValueInIPFS,
-} from "../utils/IPFSUtils";
+import { buildIPFSClient, retrieveValueFromIPFS, storeValueInIPFS } from "../utils/IPFSUtils";
 import { CachingMechanismInterface } from "../interfaces";
 import { Struct } from "superstruct";
 import winston from "winston";
 import PinataClient from "@pinata/sdk";
+import { jsonReviverWithBigNumbers, jsonReplacerWithBigNumbers } from "../utils";
 
 /**
  * A client for interacting with the IPFS. This is a wrapper around the IPFS API.

--- a/src/caching/IPFSClient.ts
+++ b/src/caching/IPFSClient.ts
@@ -73,24 +73,12 @@ export class IPFSClient implements CachingMechanismInterface {
   }
 
   /**
-   * Stores a value in the IPFS.
-   * @param key An optional key to store the value with. This is purely in the metadata of the CID.
-   * @param value The value to store.
-   * @returns Whether or not the value was stored.
-   * @note This method does not return the CID of the value stored. If you need the CID, use `setWithReturnID`.
-   */
-  async set<T>(_key: string, value: T): Promise<boolean> {
-    const result = await this.setWithReturnID(_key, value);
-    return result !== undefined;
-  }
-
-  /**
    * Stores a value in the IPFS and returns the CID of the value stored.
    * @param key An optional key to store the value with. This is purely in the metadata of the CID.
    * @param value The value to store.
    * @returns The CID of the value stored.
    */
-  setWithReturnID<T>(key: string, value: T): Promise<string | undefined> {
+  set<T>(key: string, value: T): Promise<string | undefined> {
     formattedLog(this.logger, {
       level: "debug",
       message: `Setting value from IPFS with key ${key}`,

--- a/src/caching/IPFSClient.ts
+++ b/src/caching/IPFSClient.ts
@@ -1,0 +1,87 @@
+import {
+  buildIPFSClient,
+  jsonReplacerWithBigNumbers,
+  jsonReviverWithBigNumbers,
+  retrieveValueFromIPFS,
+  storeValueInIPFS,
+} from "../utils/IPFSUtils";
+import { CachingMechanismInterface } from "../interfaces";
+import { Struct } from "superstruct";
+import winston from "winston";
+import PinataClient from "@pinata/sdk";
+
+/**
+ * A client for interacting with the IPFS. This is a wrapper around the IPFS API.
+ * This client also is a part of the caching mechanism interface.
+ * @see https://docs.ipfs.io/reference/http/api/
+ */
+export class IPFSClient implements CachingMechanismInterface {
+  /**
+   * The IPFS client instance
+   */
+  private client: PinataClient;
+
+  /**
+   * Public IPFS gateway URL to retrieve the content from
+   */
+  private publicGatewayURL: string;
+
+  /**
+   * An optional logger for logging messages
+   */
+  private logger?: winston.Logger;
+
+  public constructor(projectId: string, projectSecret: string, publicGatewayURL: string, logger?: winston.Logger) {
+    this.client = buildIPFSClient(projectId, projectSecret);
+    this.publicGatewayURL = publicGatewayURL;
+    this.logger = logger;
+  }
+
+  /**
+   * Calls to a public IPFS gateway to retrieve a value.
+   * @param key The key to retrieve.
+   * @param _structValidator An optional struct validator to validate the retrieved value. If the value does not match the struct, null is returned.
+   * @returns The value if it exists, otherwise null.
+   */
+  async get<ObjectType>(key?: string, _structValidator?: Struct<unknown, unknown>): Promise<ObjectType | null> {
+    if (!key) {
+      return null;
+    }
+    this.logger?.info(`Retrieving value from IPFS with key ${key}`);
+    const arrivedResult = await retrieveValueFromIPFS(key, this.publicGatewayURL);
+    if (!arrivedResult) {
+      return null;
+    }
+    const revivedResult = JSON.parse(arrivedResult, jsonReviverWithBigNumbers);
+
+    if (_structValidator && !_structValidator.is(revivedResult)) {
+      this.logger?.warn(`Retrieved value from IPFS with key ${key} does not match the expected type`);
+      return null;
+    }
+
+    return revivedResult as ObjectType;
+  }
+
+  /**
+   * Stores a value in the IPFS.
+   * @param key An optional key to store the value with. This is purely in the metadata of the CID.
+   * @param value The value to store.
+   * @returns Whether or not the value was stored.
+   * @note This method does not return the CID of the value stored. If you need the CID, use `setWithReturnID`.
+   */
+  async set<T>(_key: string, value: T): Promise<boolean> {
+    const result = await this.setWithReturnID(_key, value);
+    return result !== undefined;
+  }
+
+  /**
+   * Stores a value in the IPFS and returns the CID of the value stored.
+   * @param key An optional key to store the value with. This is purely in the metadata of the CID.
+   * @param value The value to store.
+   * @returns The CID of the value stored.
+   */
+  setWithReturnID<T>(key: string, value: T): Promise<string | undefined> {
+    this.logger?.info(`Setting value from IPFS with key ${key}`);
+    return storeValueInIPFS(JSON.stringify(value, jsonReplacerWithBigNumbers), this.client);
+  }
+}

--- a/src/caching/index.ts
+++ b/src/caching/index.ts
@@ -1,1 +1,1 @@
-export * from "./IPFSClient";
+export * from "./IPFS";

--- a/src/caching/index.ts
+++ b/src/caching/index.ts
@@ -1,0 +1,1 @@
+export * from "./IPFSClient";

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,3 +14,4 @@ export * as typeguards from "./typeguards";
 export * as ubaFeeCalculator from "./UBAFeeCalculator";
 export * as clients from "./clients";
 export * as typechain from "./typechain";
+export * as caching from "./caching";

--- a/src/interfaces/CachingMechanism.ts
+++ b/src/interfaces/CachingMechanism.ts
@@ -18,31 +18,17 @@ export interface CachingMechanismInterface {
   ): Promise<ObjectType | null>;
 
   /**
-   * Attempts to store a value in the cache.
-   * @param key The key to store.
-   * @param value The value to store.
-   * @param ttl The time to live in seconds.
-   * @param overrides Any overrides to the default caching mechanism configuration for the given caching protocol.
-   * @returns True if the value was stored, otherwise false.
-   * @throws {Error} If the value could not be stored.
-   */
-  set<ObjectType, OverrideType>(
-    key: string,
-    value: ObjectType,
-    ttl?: number,
-    overrides?: OverrideType
-  ): Promise<boolean>;
-
-  /**
-   * Identical to set, but returns the ID of the value stored. This is useful for storing values in a cache that
-   * are not known ahead of time. For example, if you want to store a value in a cache that is the result of a
+   * Attempts to set a key in the caching store. Returns the ID of the value stored. This is useful for storing values
+   * in a cache that are not known ahead of time. For example, if you want to store a value in a cache that is the result of a
    * computation, you can use this method to store the value and retrieve the ID of the value stored.
    * @param key The canonical key to store.
    * @param value The value to store.
    * @param ttl The time to live in seconds.
    * @param overrides Any overrides to the default caching mechanism configuration for the given caching protocol.
+   * @note Caching mechanisms where the `key` is directly used to store values will return `key` on success.
+   * @returns The ID of the value stored. If the value could not be stored, undefined is returned. If the caching mechanism uses the `key` as the ID, the `key` is returned.
    */
-  setWithReturnID<ObjectType, OverrideType>(
+  set<ObjectType, OverrideType>(
     key: string,
     value: ObjectType,
     ttl?: number,

--- a/src/interfaces/CachingMechanism.ts
+++ b/src/interfaces/CachingMechanism.ts
@@ -1,3 +1,5 @@
+import { Struct } from "superstruct";
+
 /**
  * The interface for a caching mechanism. This is used to store and retrieve values from a cache.
  * @interface CachingInterface
@@ -9,7 +11,11 @@ export interface CachingMechanismInterface {
    * @param key The key to retrieve.
    * @returns The value if it exists, otherwise null.
    */
-  get<T>(key: string): Promise<T | null>;
+  get<ObjectType, OverrideType>(
+    key?: string,
+    structValidator?: Struct<unknown, unknown>,
+    overrides?: OverrideType
+  ): Promise<ObjectType | null>;
 
   /**
    * Attempts to store a value in the cache.
@@ -20,5 +26,26 @@ export interface CachingMechanismInterface {
    * @returns True if the value was stored, otherwise false.
    * @throws {Error} If the value could not be stored.
    */
-  set<T>(key: string, value: T, ttl?: number, overrides?: unknown): Promise<boolean>;
+  set<ObjectType, OverrideType>(
+    key: string,
+    value: ObjectType,
+    ttl?: number,
+    overrides?: OverrideType
+  ): Promise<boolean>;
+
+  /**
+   * Identical to set, but returns the ID of the value stored. This is useful for storing values in a cache that
+   * are not known ahead of time. For example, if you want to store a value in a cache that is the result of a
+   * computation, you can use this method to store the value and retrieve the ID of the value stored.
+   * @param key The canonical key to store.
+   * @param value The value to store.
+   * @param ttl The time to live in seconds.
+   * @param overrides Any overrides to the default caching mechanism configuration for the given caching protocol.
+   */
+  setWithReturnID<ObjectType, OverrideType>(
+    key: string,
+    value: ObjectType,
+    ttl?: number,
+    overrides?: OverrideType
+  ): Promise<string | undefined>;
 }

--- a/src/utils/IPFSUtils.ts
+++ b/src/utils/IPFSUtils.ts
@@ -3,7 +3,7 @@ import axios from "axios";
 import { BigNumber } from "ethers";
 
 /**
- *  Build an IPFS client for interacting with the IPFS API
+ * Build an IPFS client for interacting with the IPFS API
  * @param APIKey The project ID
  * @param secretAPIKey The project secret
  * @returns An IPFS client for interacting with Pinata
@@ -12,6 +12,12 @@ export function buildIPFSClient(APIKey: string, secretAPIKey: string): PinataCli
   return new PinataClient(APIKey, secretAPIKey);
 }
 
+/**
+ * Retrieves a value from an IPFS gateway
+ * @param contentHash The content hash of the value to retrieve
+ * @param publicGatewayURL The URL of the public IPFS gateway to use
+ * @returns The value, or undefined if it could not be retrieved
+ */
 export async function retrieveValueFromIPFS(
   contentHash: string,
   publicGatewayURL: string
@@ -32,6 +38,12 @@ export async function retrieveValueFromIPFS(
   }
 }
 
+/**
+ * Pins a value to the IPFS network
+ * @param content The value to pin
+ * @param client The IPFS client to use
+ * @returns The content hash of the pinned value
+ */
 export async function storeValueInIPFS(content: string, client: PinataClient): Promise<string> {
   const result = await client.pinJSONToIPFS(JSON.parse(content));
   return result.IpfsHash;
@@ -44,9 +56,10 @@ export async function storeValueInIPFS(content: string, client: PinataClient): P
  * @returns The converted value
  */
 export function jsonReplacerWithBigNumbers(_key: string, value: unknown): unknown {
-  if (typeof value === "bigint") {
-    return value.toString();
-  } else if (value instanceof BigNumber) {
+  // We need to check if this is a big number, because the JSON parser
+  // is not aware of BigNumbers and will convert them to the string representation
+  // of the object itself which is not what we want.
+  if (value instanceof BigNumber) {
     return value.toString();
   }
   return value;
@@ -59,6 +72,8 @@ export function jsonReplacerWithBigNumbers(_key: string, value: unknown): unknow
  * @returns The converted value
  */
 export function jsonReviverWithBigNumbers(_key: string, value: unknown): unknown {
+  // We need to check for both strings and big numbers, because the JSON parser
+  // is not aware of BigNumbers.
   if (typeof value === "string" && /^-?\d+$/.test(value)) {
     const bigNumber = BigNumber.from(value);
     if (bigNumber.toString() === value) {

--- a/src/utils/IPFSUtils.ts
+++ b/src/utils/IPFSUtils.ts
@@ -1,6 +1,5 @@
 import PinataClient from "@pinata/sdk";
 import axios from "axios";
-import { BigNumber } from "ethers";
 
 /**
  * Build an IPFS client for interacting with the IPFS API
@@ -47,38 +46,4 @@ export async function retrieveValueFromIPFS(
 export async function storeValueInIPFS(content: string, client: PinataClient): Promise<string> {
   const result = await client.pinJSONToIPFS(JSON.parse(content));
   return result.IpfsHash;
-}
-
-/**
- * A replacer for use in `JSON.stringify` that converts big numbers to numeric strings.
- * @param _key Unused
- * @param value The value to convert
- * @returns The converted value
- */
-export function jsonReplacerWithBigNumbers(_key: string, value: unknown): unknown {
-  // We need to check if this is a big number, because the JSON parser
-  // is not aware of BigNumbers and will convert them to the string representation
-  // of the object itself which is not what we want.
-  if (value instanceof BigNumber) {
-    return value.toString();
-  }
-  return value;
-}
-
-/**
- * A reviver for use in `JSON.parse` that converts numeric strings to big numbers.
- * @param _key Unused
- * @param value The value to convert
- * @returns The converted value
- */
-export function jsonReviverWithBigNumbers(_key: string, value: unknown): unknown {
-  // We need to check for both strings and big numbers, because the JSON parser
-  // is not aware of BigNumbers.
-  if (typeof value === "string" && /^-?\d+$/.test(value)) {
-    const bigNumber = BigNumber.from(value);
-    if (bigNumber.toString() === value) {
-      return bigNumber;
-    }
-  }
-  return value;
 }

--- a/src/utils/IPFSUtils.ts
+++ b/src/utils/IPFSUtils.ts
@@ -15,26 +15,20 @@ export function buildIPFSClient(APIKey: string, secretAPIKey: string): PinataCli
  * Retrieves a value from an IPFS gateway
  * @param contentHash The content hash of the value to retrieve
  * @param publicGatewayURL The URL of the public IPFS gateway to use
- * @returns The value, or undefined if it could not be retrieved
+ * @returns The value retrieved from the IPFS gateway
+ * @throws Error if the value could not be retrieved
  */
-export async function retrieveValueFromIPFS(
-  contentHash: string,
-  publicGatewayURL: string
-): Promise<string | undefined> {
-  try {
-    const result = await axios.get(`${publicGatewayURL}/ipfs/${contentHash}`, {
-      // We need to set the Accept header to text/plain to avoid
-      // any anomalies with the response
-      headers: {
-        Accept: "text/plain",
-      },
-      // We want just the raw response, not the parsed response
-      transformResponse: (r) => r,
-    });
-    return result.data;
-  } catch (e) {
-    return undefined;
-  }
+export async function retrieveValueFromIPFS(contentHash: string, publicGatewayURL: string): Promise<string> {
+  const result = await axios.get(`${publicGatewayURL}/ipfs/${contentHash}`, {
+    // We need to set the Accept header to text/plain to avoid
+    // any anomalies with the response
+    headers: {
+      Accept: "text/plain",
+    },
+    // We want just the raw response, not the parsed response
+    transformResponse: (r) => r,
+  });
+  return result.data;
 }
 
 /**

--- a/src/utils/IPFSUtils.ts
+++ b/src/utils/IPFSUtils.ts
@@ -18,11 +18,14 @@ export async function retrieveValueFromIPFS(
 ): Promise<string | undefined> {
   try {
     const result = await axios.get(`${publicGatewayURL}/ipfs/${contentHash}`, {
+      // We need to set the Accept header to text/plain to avoid
+      // any anomalies with the response
       headers: {
         Accept: "text/plain",
       },
+      // We want just the raw response, not the parsed response
+      transformResponse: (r) => r,
     });
-    console.log(result.data);
     return result.data;
   } catch (e) {
     return undefined;

--- a/src/utils/IPFSUtils.ts
+++ b/src/utils/IPFSUtils.ts
@@ -33,11 +33,16 @@ export async function retrieveValueFromIPFS(contentHash: string, publicGatewayUR
 
 /**
  * Pins a value to the IPFS network
+ * @param key A key to use for pinning the value. This is a metadata field.
  * @param content The value to pin
  * @param client The IPFS client to use
  * @returns The content hash of the pinned value
  */
-export async function storeValueInIPFS(content: string, client: PinataClient): Promise<string> {
-  const result = await client.pinJSONToIPFS(JSON.parse(content));
+export async function storeValueInIPFS(key: string, content: string, client: PinataClient): Promise<string> {
+  const result = await client.pinJSONToIPFS(JSON.parse(content), {
+    pinataMetadata: {
+      name: key,
+    },
+  });
   return result.IpfsHash;
 }

--- a/src/utils/IPFSUtils.ts
+++ b/src/utils/IPFSUtils.ts
@@ -1,0 +1,66 @@
+import PinataClient from "@pinata/sdk";
+import axios from "axios";
+import { BigNumber } from "ethers";
+
+/**
+ *  Build an IPFS client for interacting with the IPFS API
+ * @param APIKey The project ID
+ * @param secretAPIKey The project secret
+ * @returns An IPFS client for interacting with Pinata
+ */
+export function buildIPFSClient(APIKey: string, secretAPIKey: string): PinataClient {
+  return new PinataClient(APIKey, secretAPIKey);
+}
+
+export async function retrieveValueFromIPFS(
+  contentHash: string,
+  publicGatewayURL: string
+): Promise<string | undefined> {
+  try {
+    const result = await axios.get(`${publicGatewayURL}/ipfs/${contentHash}`, {
+      headers: {
+        Accept: "text/plain",
+      },
+    });
+    console.log(result.data);
+    return result.data;
+  } catch (e) {
+    return undefined;
+  }
+}
+
+export async function storeValueInIPFS(content: string, client: PinataClient): Promise<string> {
+  const result = await client.pinJSONToIPFS(JSON.parse(content));
+  return result.IpfsHash;
+}
+
+/**
+ * A replacer for use in `JSON.stringify` that converts big numbers to numeric strings.
+ * @param _key Unused
+ * @param value The value to convert
+ * @returns The converted value
+ */
+export function jsonReplacerWithBigNumbers(_key: string, value: unknown): unknown {
+  if (typeof value === "bigint") {
+    return value.toString();
+  } else if (value instanceof BigNumber) {
+    return value.toString();
+  }
+  return value;
+}
+
+/**
+ * A reviver for use in `JSON.parse` that converts numeric strings to big numbers.
+ * @param _key Unused
+ * @param value The value to convert
+ * @returns The converted value
+ */
+export function jsonReviverWithBigNumbers(_key: string, value: unknown): unknown {
+  if (typeof value === "string" && /^-?\d+$/.test(value)) {
+    const bigNumber = BigNumber.from(value);
+    if (bigNumber.toString() === value) {
+      return bigNumber;
+    }
+  }
+  return value;
+}

--- a/src/utils/JSONUtils.ts
+++ b/src/utils/JSONUtils.ts
@@ -36,3 +36,37 @@ export function stringifyJSONWithNumericString(obj: unknown): string {
     return value;
   });
 }
+
+/**
+ * A replacer for use in `JSON.stringify` that converts big numbers to numeric strings.
+ * @param _key Unused
+ * @param value The value to convert
+ * @returns The converted value
+ */
+export function jsonReplacerWithBigNumbers(_key: string, value: unknown): unknown {
+  // We need to check if this is a big number, because the JSON parser
+  // is not aware of BigNumbers and will convert them to the string representation
+  // of the object itself which is not what we want.
+  if (value instanceof BigNumber) {
+    return value.toString();
+  }
+  return value;
+}
+
+/**
+ * A reviver for use in `JSON.parse` that converts numeric strings to big numbers.
+ * @param _key Unused
+ * @param value The value to convert
+ * @returns The converted value
+ */
+export function jsonReviverWithBigNumbers(_key: string, value: unknown): unknown {
+  // We need to check for both strings and big numbers, because the JSON parser
+  // is not aware of BigNumbers.
+  if (typeof value === "string" && /^-?\d+$/.test(value)) {
+    const bigNumber = BigNumber.from(value);
+    if (bigNumber.toString() === value) {
+      return bigNumber;
+    }
+  }
+  return value;
+}

--- a/src/utils/JSONUtils.ts
+++ b/src/utils/JSONUtils.ts
@@ -47,7 +47,7 @@ export function jsonReplacerWithBigNumbers(_key: string, value: unknown): unknow
   // We need to check if this is a big number, because the JSON parser
   // is not aware of BigNumbers and will convert them to the string representation
   // of the object itself which is not what we want.
-  if (value instanceof BigNumber) {
+  if (BigNumber.isBigNumber(value)) {
     return value.toString();
   }
   return value;

--- a/src/utils/LogUtils.ts
+++ b/src/utils/LogUtils.ts
@@ -1,1 +1,26 @@
+import { Logger } from "winston";
+
 export type DefaultLogLevels = "debug" | "info" | "warn" | "error";
+
+type LogParamType = {
+  level: DefaultLogLevels;
+  message: string;
+  at: {
+    location: string;
+    function: string;
+  };
+  data?: Record<string | number, unknown>;
+};
+
+export function formattedLog(
+  logger: Logger | undefined,
+  { level, message, at: { location, function: fnName }, data }: LogParamType
+): void {
+  if (logger) {
+    logger[level]({
+      at: `${location}#${fnName}`,
+      message,
+      ...data,
+    });
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -11,3 +11,4 @@ export * from "./FlowUtils";
 export * from "./UBAUtils";
 export * from "./BundleUtils";
 export * from "./JSONUtils";
+export * from "./IPFSUtils";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2813,6 +2813,16 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.9.2.tgz#1cb2d5e4d3360141a17dbc45094a8cad6aac16c1"
   integrity sha512-mO+y6JaqXjWeMh9glYVzVu8HYPGknAAnWyxTRhGeckOruyXQMNnlcW6w/Dx9ftLeIQk6N+ZJFuVmTwF7lEIFrg==
 
+"@pinata/sdk@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@pinata/sdk/-/sdk-2.1.0.tgz#d61aa8f21ec1206e867f4b65996db52b70316945"
+  integrity sha512-hkS0tcKtsjf9xhsEBs2Nbey5s+Db7x5rlOH9TaWHBXkJ7IwwOs2xnEDigNaxAHKjYAwcw+m2hzpO5QgOfeF7Zw==
+  dependencies:
+    axios "^0.21.1"
+    form-data "^2.3.3"
+    is-ipfs "^0.6.0"
+    path "^0.12.7"
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
@@ -6069,7 +6079,7 @@ ci-job-number@^1.2.2:
   resolved "https://registry.yarnpkg.com/ci-job-number/-/ci-job-number-1.2.2.tgz#f4e5918fcaeeda95b604f214be7d7d4a961fe0c0"
   integrity sha512-CLOGsVDrVamzv8sXJGaILUVI6dsuAkouJP/n6t+OxLPeeA4DDby7zn9SB6EUpa1H7oIKoE+rMmkW80zYsFfUjA==
 
-cids@^0.7.1:
+cids@^0.7.1, cids@~0.7.0:
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/cids/-/cids-0.7.5.tgz#60a08138a99bfb69b6be4ceb63bfef7a396b28b2"
   integrity sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==
@@ -6079,6 +6089,17 @@ cids@^0.7.1:
     multibase "~0.6.0"
     multicodec "^1.0.0"
     multihashes "~0.4.15"
+
+cids@~0.8.0:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/cids/-/cids-0.8.3.tgz#aaf48ac8ed857c3d37dad94d8db1d8c9407b92db"
+  integrity sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==
+  dependencies:
+    buffer "^5.6.0"
+    class-is "^1.1.0"
+    multibase "^1.0.0"
+    multicodec "^1.0.1"
+    multihashes "^1.0.1"
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -8854,7 +8875,7 @@ form-data-encoder@1.7.1:
   resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-1.7.1.tgz#ac80660e4f87ee0d3d3c3638b7da8278ddb8ec96"
   integrity sha512-EFRDrsMm/kyqbTQocNvRXMLjc7Es2Vk+IQFx/YW7hkUH1eBl4J1fqiP34l74Yt0pFLCNpc06fkbVk00008mzjg==
 
-form-data@^2.2.0:
+form-data@^2.2.0, form-data@^2.3.3:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
   integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
@@ -10015,6 +10036,11 @@ inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, i
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+inherits@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+  integrity sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==
+
 ini@^1.3.5, ini@~1.3.0:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
@@ -10076,6 +10102,11 @@ ip-regex@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
   integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
+
+ip-regex@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.3.0.tgz#687275ab0f57fa76978ff8f4dddc8a23d5990db5"
+  integrity sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==
 
 ipaddr.js@1.9.1:
   version "1.9.1"
@@ -10291,6 +10322,25 @@ is-interactive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
   integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
+
+is-ip@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/is-ip/-/is-ip-3.1.0.tgz#2ae5ddfafaf05cb8008a62093cf29734f657c5d8"
+  integrity sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==
+  dependencies:
+    ip-regex "^4.0.0"
+
+is-ipfs@^0.6.0:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/is-ipfs/-/is-ipfs-0.6.3.tgz#82a5350e0a42d01441c40b369f8791e91404c497"
+  integrity sha512-HyRot1dvLcxImtDqPxAaY1miO6WsiP/z7Yxpg2qpaLWv5UdhAPtLvHJ4kMLM0w8GSl8AFsVF23PHe1LzuWrUlQ==
+  dependencies:
+    bs58 "^4.0.1"
+    cids "~0.7.0"
+    mafmt "^7.0.0"
+    multiaddr "^7.2.1"
+    multibase "~0.6.0"
+    multihashes "~0.4.13"
 
 is-lower-case@^1.1.0:
   version "1.1.3"
@@ -11727,6 +11777,13 @@ ltgt@~2.2.0:
   resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.2.1.tgz#f35ca91c493f7b73da0e07495304f17b31f87ee5"
   integrity sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=
 
+mafmt@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/mafmt/-/mafmt-7.1.0.tgz#4126f6d0eded070ace7dbbb6fb04977412d380b5"
+  integrity sha512-vpeo9S+hepT3k2h5iFxzEHvvR0GPBx9uKaErmnRzYNcaKb03DgOArjEMlgG4a9LcuZZ89a3I8xbeto487n26eA==
+  dependencies:
+    multiaddr "^7.3.0"
+
 magic-string@^0.25.2, magic-string@^0.25.7:
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.9.tgz#de7f9faf91ef8a1c91d02c2e5314c8277dbcdd1c"
@@ -12181,10 +12238,30 @@ ms@2.1.3, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+multiaddr@^7.2.1, multiaddr@^7.3.0:
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/multiaddr/-/multiaddr-7.5.0.tgz#976c88e256e512263445ab03b3b68c003d5f485e"
+  integrity sha512-GvhHsIGDULh06jyb6ev+VfREH9evJCFIRnh3jUt9iEZ6XDbyoisZRFEI9bMvK/AiR6y66y6P+eoBw9mBYMhMvw==
+  dependencies:
+    buffer "^5.5.0"
+    cids "~0.8.0"
+    class-is "^1.1.0"
+    is-ip "^3.1.0"
+    multibase "^0.7.0"
+    varint "^5.0.0"
+
 multibase@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/multibase/-/multibase-0.7.0.tgz#1adfc1c50abe05eefeb5091ac0c2728d6b84581b"
   integrity sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==
+  dependencies:
+    base-x "^3.0.8"
+    buffer "^5.5.0"
+
+multibase@^1.0.0, multibase@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/multibase/-/multibase-1.0.1.tgz#4adbe1de0be8a1ab0274328b653c3f1903476724"
+  integrity sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==
   dependencies:
     base-x "^3.0.8"
     buffer "^5.5.0"
@@ -12204,7 +12281,7 @@ multicodec@^0.5.5:
   dependencies:
     varint "^5.0.0"
 
-multicodec@^1.0.0:
+multicodec@^1.0.0, multicodec@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/multicodec/-/multicodec-1.0.4.tgz#46ac064657c40380c28367c90304d8ed175a714f"
   integrity sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==
@@ -12212,13 +12289,22 @@ multicodec@^1.0.0:
     buffer "^5.6.0"
     varint "^5.0.0"
 
-multihashes@^0.4.15, multihashes@~0.4.15:
+multihashes@^0.4.15, multihashes@~0.4.13, multihashes@~0.4.15:
   version "0.4.21"
   resolved "https://registry.yarnpkg.com/multihashes/-/multihashes-0.4.21.tgz#dc02d525579f334a7909ade8a122dabb58ccfcb5"
   integrity sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==
   dependencies:
     buffer "^5.5.0"
     multibase "^0.7.0"
+    varint "^5.0.0"
+
+multihashes@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/multihashes/-/multihashes-1.0.1.tgz#a89415d68283cf6287c6e219e304e75ce7fb73fe"
+  integrity sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==
+  dependencies:
+    buffer "^5.6.0"
+    multibase "^1.0.1"
     varint "^5.0.0"
 
 murmur-128@^0.2.1:
@@ -13036,6 +13122,14 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+path@^0.12.7:
+  version "0.12.7"
+  resolved "https://registry.yarnpkg.com/path/-/path-0.12.7.tgz#d4dc2a506c4ce2197eb481ebfcd5b36c0140b10f"
+  integrity sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==
+  dependencies:
+    process "^0.11.1"
+    util "^0.10.3"
+
 pathval@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
@@ -13209,7 +13303,7 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-process@^0.11.10:
+process@^0.11.1, process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
@@ -15904,6 +15998,13 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+
+util@^0.10.3:
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
+  integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
+  dependencies:
+    inherits "2.0.3"
 
 util@^0.12.0:
   version "0.12.4"


### PR DESCRIPTION
This PR adds an IPFS client to the SDK. Additionally, this client complies with the `CachingMechanism` interface so that we can use it in arbitrary locations throughout the SDK where caching is concerned.