### PR TITLE
improve(UBAClient): Add UBAConfig and additional comments + logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.15.9",
+  "version": "0.15.10",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/clients/UBAClient/UBAClientConfig.ts
+++ b/src/clients/UBAClient/UBAClientConfig.ts
@@ -1,14 +1,12 @@
 /**
  * Defines the configuration to customize a UBAClient instance.
  */
-class UBAClientConfig {
+export class UBAClientConfig {
   /**
    * Instantiate a new UBAClient Config object
    * @param latestMainnetBundleStartBlockToLoadFromCache If defined, the UBAClient will only load bundle data from
    * the cache from bundles whose mainnet start block is greater than or equal to this value. All older bundles
    * will be loaded from the cache and all newer bundles will be loaded fresh from new RPC data.
    */
-  constructor(public readonly latestMainnetBundleStartBlockToLoadFromCache: number | undefined) {}
+  constructor(public readonly latestMainnetBundleStartBlockToLoadFromCache?: number) {}
 }
-
-export default UBAClientConfig;

--- a/src/clients/UBAClient/UBAClientConfig.ts
+++ b/src/clients/UBAClient/UBAClientConfig.ts
@@ -1,0 +1,14 @@
+/**
+ * Defines the configuration to customize a UBAClient instance.
+ */
+class UBAClientConfig {
+  /**
+   * Instantiate a new UBAClient Config object
+   * @param latestMainnetBundleStartBlockToLoadFromCache If defined, the UBAClient will only load bundle data from
+   * the cache from bundles whose mainnet start block is greater than or equal to this value. All older bundles
+   * will be loaded from the cache and all newer bundles will be loaded fresh from new RPC data.
+   */
+  constructor(public readonly latestMainnetBundleStartBlockToLoadFromCache: number | undefined) {}
+}
+
+export default UBAClientConfig;

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -371,7 +371,25 @@ export async function getMatchedDeposit(
     return originSpokePoolClient.getDepositForFill(fill, fillFieldsToIgnore);
   }
 
-  // TODO: Add Redis to reduce some of these `findDeposit` calls
+  // TODO: Try to access caching client to reduce some of these `findDeposit` calls. To get access to the cache, we
+  // probably want to move this function into the UBAClient class.
+  // let deposit: DepositWithBlock, cachedDeposit: Deposit | undefined;
+  // const redisClient = await getRedis(originSpokePoolClient.logger);
+  // if (redisClient) {
+  //   cachedDeposit = await getDeposit(getRedisDepositKey(fill), redisClient);
+  // }
+  // if (isDefined(cachedDeposit)) {
+  //   deposit = cachedDeposit as DepositWithBlock;
+  //   // Assert that cache hasn't been corrupted.
+  //   assert(deposit.depositId === fill.depositId && deposit.originChainId === fill.originChainId);
+  // } else {
+  //   deposit = await originSpokePoolClient.findDeposit(fill.depositId, fill.destinationChainId, fill.depositor);
+
+  //   if (redisClient) {
+  //     await setDeposit(deposit, getCurrentTime(), redisClient, 24 * 60 * 60);
+  //   }
+  // }
+
   const deposit = await originSpokePoolClient.findDeposit(fill.depositId, fill.destinationChainId, fill.depositor);
 
   return validateFillForDeposit(fill, deposit, fillFieldsToIgnore) ? deposit : undefined;

--- a/src/clients/UBAClient/UBAClientWithRefresh.ts
+++ b/src/clients/UBAClient/UBAClientWithRefresh.ts
@@ -38,7 +38,7 @@ import { getDepositFee, getRefundFee } from "../../UBAFeeCalculator/UBAFeeSpokeC
 import { BigNumber, ethers } from "ethers";
 import { BaseAbstractClient } from "../BaseAbstractClient";
 import UBAConfig from "../../UBAFeeCalculator/UBAFeeConfig";
-import UBAClientConfig from "./UBAClientConfig";
+import { UBAClientConfig } from "./UBAClientConfig";
 
 /**
  * @notice This class reconstructs UBA bundle data for every bundle that has been created since the

--- a/src/clients/UBAClient/UBAClientWithRefresh.ts
+++ b/src/clients/UBAClient/UBAClientWithRefresh.ts
@@ -38,6 +38,7 @@ import { getDepositFee, getRefundFee } from "../../UBAFeeCalculator/UBAFeeSpokeC
 import { BigNumber, ethers } from "ethers";
 import { BaseAbstractClient } from "../BaseAbstractClient";
 import UBAConfig from "../../UBAFeeCalculator/UBAFeeConfig";
+import UBAClientConfig from "./UBAClientConfig";
 
 /**
  * @notice This class reconstructs UBA bundle data for every bundle that has been created since the
@@ -73,11 +74,14 @@ export class UBAClientWithRefresh extends BaseAbstractClient {
   public logger: winston.Logger;
 
   /**
+   * @notice Constructs a new UBAClientinstance.
+   * @param clientConfig Configuration to customize the UBAClient instance.
    * @param tokens Tokens to load bundle state for.
    * @param hubPoolClient
    * @param spokePoolClients
    */
   constructor(
+    readonly clientConfig: UBAClientConfig,
     readonly tokens: string[],
     protected readonly hubPoolClient: HubPoolClient,
     public readonly spokePoolClients: { [chainId: number]: SpokePoolClient },
@@ -969,6 +973,25 @@ export class UBAClientWithRefresh extends BaseAbstractClient {
     if (isDefined(this.cachingClient)) {
       for (let i = this.ubaBundleBlockRanges.length - 1; i >= 0; i--) {
         const mostRecentBundleBlockRanges = this.ubaBundleBlockRanges[i];
+
+        // Check if this bundle is older than the oldest bundle we want to load from the cache:
+        const mainnetBundleStartBlock = getBlockRangeForChain(
+          mostRecentBundleBlockRanges,
+          this.hubPoolClient.chainId,
+          this.chainIdIndices
+        )[0];
+        if (
+          isDefined(this.clientConfig.latestMainnetBundleStartBlockToLoadFromCache) &&
+          this.clientConfig.latestMainnetBundleStartBlockToLoadFromCache > mainnetBundleStartBlock
+        ) {
+          this.logger.debug({
+            at: "UBAClientWithRefresh#update",
+            message: `Skipping loading bundle data from cache for bundle with mainnet start block ${mainnetBundleStartBlock} because it's older than the oldest bundle we want to load from the cache`,
+            bundleBlockRanges: mostRecentBundleBlockRanges,
+            oldestMainnetStartBlockToLoadFromCache: this.clientConfig.latestMainnetBundleStartBlockToLoadFromCache,
+          });
+          continue;
+        }
         await forEachAsync(tokens, async (token) => {
           await forEachAsync(this.chainIdIndices, async (chainId) => {
             const redisKeyForBundle = this.getKeyForBundle(mostRecentBundleBlockRanges, token, chainId);
@@ -976,13 +999,22 @@ export class UBAClientWithRefresh extends BaseAbstractClient {
               redisKeyForBundle
             );
             if (isDefined(modifiedFlowsInBundle)) {
-              // console.log(`💿 Loaded bundle state from cache using key ${redisKeyForBundle}`);
+              this.logger.debug({
+                at: "UBAClientWithRefresh#update",
+                message: `💿 Loaded bundle state from cache using key ${redisKeyForBundle}`,
+                bundleBlockRanges: mostRecentBundleBlockRanges,
+                flowsLoaded: modifiedFlowsInBundle.length,
+              });
               this.appendValidatedFlowsToClassState(chainId, token, modifiedFlowsInBundle, mostRecentBundleBlockRanges);
 
               // Mark as loaded from cache.
               this.getBundleState(mostRecentBundleBlockRanges, token, chainId).loadedFromCache = true;
             } else {
-              // console.log(`No entry for key ${redisKeyForBundle} in redis`);
+              this.logger.debug({
+                at: "UBAClientWithRefresh#update",
+                message: `No entry for key ${redisKeyForBundle} in redis`,
+                bundleBlockRanges: mostRecentBundleBlockRanges,
+              });
             }
           });
         });

--- a/src/clients/UBAClient/index.ts
+++ b/src/clients/UBAClient/index.ts
@@ -3,3 +3,4 @@ export * from "./UBAClientUtilities";
 export * from "../../UBAFeeCalculator/UBAFeeTypes";
 export * from "./UBAClientTypes";
 export { UBAClientWithRefresh as UBAClient } from "./UBAClientWithRefresh";
+export * from "./UBAClientConfig";


### PR DESCRIPTION
- UBAConfig provides a single config to start that allows caller to customize their dependency on the cache 
- Adds a comment about moving a function into the UBAClient to get access to the cache
- Skips loading bundles from the cache if its earlier than a configured start block
Signed-off-by: nicholaspai <npai.nyc@gmail.com>
