### PR TITLE
feat: ✨ add global chain index scraping from configstore 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
+++ b/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
@@ -454,7 +454,7 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
         // indices are [1, 10, 137, 288, 42161] (outlined in UMIP-157)
         const previousUpdate = this.chainIdIndicesUpdates.at(-1)?.value ?? [1, 10, 137, 288, 42161];
         // We should now check that previousUpdate is a subset of chainIndices.
-        if (!previousUpdate.every((chainId) => chainIndices.includes(chainId))) {
+        if (!previousUpdate.every((chainId, idx) => chainIndices[idx] === chainId)) {
           this.logger.warn({
             at: "ConfigStoreClient#update",
             message: `The array ${rawChainIndices} is invalid. It must be a superset of the previous array ${previousUpdate}`,

--- a/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
+++ b/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
@@ -614,7 +614,7 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
     return {
       eventSearchConfig: this.eventSearchConfig,
       configStoreVersion: this.configStoreVersion,
-      enabledChainIds: this.chainIdIndicesUpdates,
+      chainIdIndicesUpdates: this.chainIdIndicesUpdates,
       cumulativeRateModelUpdates: this.cumulativeRateModelUpdates,
       ubaConfigUpdates: JSON.parse(
         stringifyJSONWithNumericString(this.ubaConfigUpdates)

--- a/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
+++ b/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
@@ -434,18 +434,6 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
         // Let's parse this via JSON.parse. Since we've passed the regex check, we can
         // be sure that this is a valid array of positive integers.
         const chainIndices = JSON.parse(rawChainIndices) as number[];
-        // We need to now check that all the indices exist and do not contain duplicates.
-        // This is essentially a set of indices that exist in the array length. For example,
-        // for a length of 5, the valid indices must contain [0, 1, 2, 3, 4].
-        // Let's check for this condition and for duplicates. If we find this to be invalid,
-        // we'll skip this update.
-        if (
-          chainIndices.length !== new Set(chainIndices).size ||
-          chainIndices.some((index) => index < 0 || index >= chainIndices.length)
-        ) {
-          this.logger.warn({ at: "ConfigStore", message: `The array ${chainIndices} is invalid.` });
-          continue;
-        }
         // If all else passes, we can add this update.
         this.chainIdIndicesUpdates.push({ ...args, value: chainIndices });
       } else if (args.key === utf8ToHex(GLOBAL_CONFIG_STORE_KEYS.MAX_POOL_REBALANCE_LEAF_SIZE)) {

--- a/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
+++ b/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
@@ -124,6 +124,17 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
     return across.rateModel.parseAndReturnRateModelFromString(config.routeRateModel[route]);
   }
 
+  /**
+   * Resolves the chain ids that were available to the protocol at a given block range.
+   * @param blockNumber Block number to search for. Defaults to latest block.
+   * @returns List of chain IDs that were available to the protocol at the given block number.
+   * @note This dynamic functionality has been added after the launch of Across.
+   * @note This function will return a default list of chain IDs if the block requested
+   *       existed before the initial inclusion of this dynamic key/value entry. In the
+   *       case that a block number is requested that is before the initial inclusion of
+   *       this key/value entry, the function will return the default list of chain IDs as
+   *       outlined per the UMIP (https://github.com/UMAprotocol/UMIPs/pull/590).
+   */
   getChainIdIndicesForBlock(blockNumber: number = Number.MAX_SAFE_INTEGER): number[] {
     const config = (sortEventsDescending(this.chainIdIndicesUpdates) as GlobalConfigUpdate<number[]>[]).find(
       (config) => config.blockNumber <= blockNumber

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -348,7 +348,7 @@ export class HubPoolClient extends BaseAbstractClient {
     chain: number,
     chainIdListOverride?: number[]
   ): number | undefined {
-    const chainIdList = chainIdListOverride ?? this.configStoreClient.enabledChainIds;
+    const chainIdList = chainIdListOverride ?? this.configStoreClient.getEnabledChains(block);
     let endingBlockNumber: number | undefined;
     // Search proposed root bundles in reverse chronological order.
     for (let i = this.proposedRootBundles.length - 1; i >= 0; i--) {

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -348,7 +348,7 @@ export class HubPoolClient extends BaseAbstractClient {
     chain: number,
     chainIdListOverride?: number[]
   ): number | undefined {
-    const chainIdList = chainIdListOverride ?? this.configStoreClient.getEnabledChains(block);
+    const chainIdList = chainIdListOverride ?? this.configStoreClient.getEnabledChains();
     let endingBlockNumber: number | undefined;
     // Search proposed root bundles in reverse chronological order.
     for (let i = this.proposedRootBundles.length - 1; i >= 0; i--) {

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -188,7 +188,7 @@ export function getMostRecentBundleBlockRanges(
     const hubPoolStartBlock = getBlockRangeForChain(
       rootBundleBlockRanges,
       hubPoolClient.chainId,
-      hubPoolClient.configStoreClient.getEnabledChains(latestExecutedRootBundle.blockNumber)
+      hubPoolClient.configStoreClient.getEnabledChains()
     )[0];
     if (hubPoolStartBlock < ubaActivationHubStartBlock) {
       break;

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -150,7 +150,6 @@ export function getUBAFeeConfig(
  * windows, so that the caller can call this function to cover all UBA events.
  * @param chainId
  * @param maxBundleStates If this is larger than available validated bundles in the HubPoolClient, will throw an error.
- * @param hubPoolBlock Only returns the most recent validated bundles proposed before this block.
  * @param hubPoolClient The hub pool client to use for fetching the bundle ranges.
  * @param spokePoolClients The spoke pool clients to use for fetching the bundle ranges.
  * @returns The most recent `maxBundleStates` bundle ranges for a given chain, in chronological ascending order.

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -167,11 +167,7 @@ export function getMostRecentBundleBlockRanges(
 
   // Reconstruct bundle ranges based on published end blocks.
   const ubaActivationStartBlocks = getUbaActivationBundleStartBlocks(hubPoolClient);
-  const ubaActivationHubStartBlock = getBlockForChain(
-    ubaActivationStartBlocks,
-    hubPoolClient.chainId,
-    hubPoolClient.configStoreClient.enabledChainIds
-  );
+  const ubaActivationHubStartBlock = ubaActivationStartBlocks[0];
 
   // Bundle states are examined in chronological descending order.
   const bundleData: { start: number; end: number }[] = [];
@@ -192,7 +188,7 @@ export function getMostRecentBundleBlockRanges(
     const hubPoolStartBlock = getBlockRangeForChain(
       rootBundleBlockRanges,
       hubPoolClient.chainId,
-      hubPoolClient.configStoreClient.enabledChainIds
+      hubPoolClient.configStoreClient.getEnabledChains(latestExecutedRootBundle.blockNumber)
     )[0];
     if (hubPoolStartBlock < ubaActivationHubStartBlock) {
       break;
@@ -202,7 +198,7 @@ export function getMostRecentBundleBlockRanges(
     const blockRangeForChain = getBlockRangeForChain(
       rootBundleBlockRanges,
       chainId,
-      hubPoolClient.configStoreClient.enabledChainIds
+      hubPoolClient.configStoreClient.getEnabledChains(latestExecutedRootBundle.blockNumber)
     );
     bundleData.unshift({
       start: blockRangeForChain[0],
@@ -221,7 +217,9 @@ export function getMostRecentBundleBlockRanges(
     const ubaActivationBundleStartBlockForChain = getBlockForChain(
       ubaActivationBundleStartBlocks,
       chainId,
-      hubPoolClient.configStoreClient.enabledChainIds
+      // We want to pull the most recent enabled chains because we should assume that the
+      // protocol defaults as per the UMIP (https://github.com/UMAprotocol/UMIPs/pull/590) will be triggered.
+      hubPoolClient.configStoreClient.getEnabledChains()
     );
     bundleData.unshift({
       // Tell caller to load data for events beginning at the start of the UBA version added to the ConfigStore
@@ -255,7 +253,7 @@ export function getOpeningRunningBalanceForEvent(
   l1Token: string,
   hubPoolLatestBlock: number
 ): TokenRunningBalance {
-  const enabledChains = hubPoolClient.configStoreClient.enabledChainIds;
+  const enabledChains = hubPoolClient.configStoreClient.getEnabledChains(hubPoolLatestBlock);
 
   // First find the latest executed bundle as of `hubPoolLatestBlock`.
   const latestExecutedBundle = hubPoolClient.getNthFullyExecutedRootBundle(-1, hubPoolLatestBlock);
@@ -379,12 +377,11 @@ export async function getMatchedDeposit(
 export function isUBAActivatedAtBlock(hubPoolClient: HubPoolClient, block: number, chain: number): boolean {
   try {
     const ubaActivationBlocks = getUbaActivationBundleStartBlocks(hubPoolClient);
-    const ubaActivationStartBlockForChain = getBlockForChain(
-      ubaActivationBlocks,
-      chain,
-      hubPoolClient.configStoreClient.enabledChainIds
-    );
-    return block >= ubaActivationStartBlockForChain;
+    const enabledChainsIndices = hubPoolClient.configStoreClient.getEnabledChains(ubaActivationBlocks[0]);
+    // Find the first activation block where the index matches the chain
+    const activationBlock =
+      ubaActivationBlocks.find((_, idx) => enabledChainsIndices[idx] === chain) ?? Number.MAX_SAFE_INTEGER;
+    return block >= activationBlock;
   } catch (err) {
     // UBA not activated yet or hub pool client not updated
     return false;
@@ -416,7 +413,7 @@ export function getUbaActivationBundleStartBlocks(hubPoolClient: HubPoolClient):
       return bundleStartBlocks;
     } else {
       // No validated bundles after UBA activation block, UBA should be activated on next bundle start blocks.
-      const chainIdIndices = hubPoolClient.configStoreClient.enabledChainIds;
+      const chainIdIndices = hubPoolClient.configStoreClient.getEnabledChains(ubaActivationBlock);
       const nextBundleStartBlocks = chainIdIndices.map((chainId) =>
         hubPoolClient.getNextBundleStartBlockNumber(chainIdIndices, latestHubPoolBlock, chainId)
       );

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -253,7 +253,7 @@ export function getOpeningRunningBalanceForEvent(
   l1Token: string,
   hubPoolLatestBlock: number
 ): TokenRunningBalance {
-  const enabledChains = hubPoolClient.configStoreClient.getEnabledChains(hubPoolLatestBlock);
+  const enabledChains = hubPoolClient.configStoreClient.getEnabledChains();
 
   // First find the latest executed bundle as of `hubPoolLatestBlock`.
   const latestExecutedBundle = hubPoolClient.getNthFullyExecutedRootBundle(-1, hubPoolLatestBlock);

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -413,7 +413,7 @@ export function getUbaActivationBundleStartBlocks(hubPoolClient: HubPoolClient):
       return bundleStartBlocks;
     } else {
       // No validated bundles after UBA activation block, UBA should be activated on next bundle start blocks.
-      const chainIdIndices = hubPoolClient.configStoreClient.getEnabledChains(ubaActivationBlock);
+      const chainIdIndices = hubPoolClient.configStoreClient.getEnabledChains();
       const nextBundleStartBlocks = chainIdIndices.map((chainId) =>
         hubPoolClient.getNextBundleStartBlockNumber(chainIdIndices, latestHubPoolBlock, chainId)
       );

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -377,7 +377,7 @@ export async function getMatchedDeposit(
 export function isUBAActivatedAtBlock(hubPoolClient: HubPoolClient, block: number, chain: number): boolean {
   try {
     const ubaActivationBlocks = getUbaActivationBundleStartBlocks(hubPoolClient);
-    const enabledChainsIndices = hubPoolClient.configStoreClient.getEnabledChains(ubaActivationBlocks[0]);
+    const enabledChainsIndices = hubPoolClient.configStoreClient.getEnabledChains();
     // Find the first activation block where the index matches the chain
     const activationBlock =
       ubaActivationBlocks.find((_, idx) => enabledChainsIndices[idx] === chain) ?? Number.MAX_SAFE_INTEGER;

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -377,11 +377,12 @@ export async function getMatchedDeposit(
 export function isUBAActivatedAtBlock(hubPoolClient: HubPoolClient, block: number, chain: number): boolean {
   try {
     const ubaActivationBlocks = getUbaActivationBundleStartBlocks(hubPoolClient);
-    const enabledChainsIndices = hubPoolClient.configStoreClient.getEnabledChains();
-    // Find the first activation block where the index matches the chain
-    const activationBlock =
-      ubaActivationBlocks.find((_, idx) => enabledChainsIndices[idx] === chain) ?? Number.MAX_SAFE_INTEGER;
-    return block >= activationBlock;
+    const ubaActivationStartBlockForChain = getBlockForChain(
+      ubaActivationBlocks,
+      chain,
+      hubPoolClient.configStoreClient.getEnabledChains()
+    );
+    return block >= ubaActivationStartBlockForChain;
   } catch (err) {
     // UBA not activated yet or hub pool client not updated
     return false;

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -377,12 +377,11 @@ export async function getMatchedDeposit(
 export function isUBAActivatedAtBlock(hubPoolClient: HubPoolClient, block: number, chain: number): boolean {
   try {
     const ubaActivationBlocks = getUbaActivationBundleStartBlocks(hubPoolClient);
-    const ubaActivationStartBlockForChain = getBlockForChain(
-      ubaActivationBlocks,
-      chain,
-      hubPoolClient.configStoreClient.getEnabledChains()
-    );
-    return block >= ubaActivationStartBlockForChain;
+    const enabledChainsIndices = hubPoolClient.configStoreClient.getEnabledChains();
+    // Find the first activation block where the index matches the chain
+    const activationBlock =
+      ubaActivationBlocks.find((_, idx) => enabledChainsIndices[idx] === chain) ?? Number.MAX_SAFE_INTEGER;
+    return block >= activationBlock;
   } catch (err) {
     // UBA not activated yet or hub pool client not updated
     return false;

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -198,7 +198,7 @@ export function getMostRecentBundleBlockRanges(
     const blockRangeForChain = getBlockRangeForChain(
       rootBundleBlockRanges,
       chainId,
-      hubPoolClient.configStoreClient.getEnabledChains(latestExecutedRootBundle.blockNumber)
+      hubPoolClient.configStoreClient.getEnabledChains()
     );
     bundleData.unshift({
       start: blockRangeForChain[0],

--- a/src/clients/UBAClient/UBAClientWithRefresh.ts
+++ b/src/clients/UBAClient/UBAClientWithRefresh.ts
@@ -85,7 +85,7 @@ export class UBAClientWithRefresh extends BaseAbstractClient {
   ) {
     super();
     this.logger = this.hubPoolClient.logger;
-    this.chainIdIndices = this.hubPoolClient.configStoreClient.enabledChainIds;
+    this.chainIdIndices = this.hubPoolClient.configStoreClient.getEnabledChains();
     assert(this.chainIdIndices.length > 0, "No chainIds provided");
     assert(Object.values(spokePoolClients).length > 0, "No SpokePools provided");
   }
@@ -835,7 +835,7 @@ export class UBAClientWithRefresh extends BaseAbstractClient {
           message: `Block ranges for chain ${chainId} do not cover from UBA activation bundle start block to latest spoke pool client block searched`,
           startBlockForChain: _blockRangesForChain[0][0],
           ubaActivationBundleStartBlockForChain,
-          endBlockForChain: _blockRangesForChain.at(-1)![1],
+          endBlockForChain: _blockRangesForChain.at(-1)?.[1],
           latestSpokePoolClientBlockSearched: this.spokePoolClients[chainId]?.latestBlockSearched,
         });
         throw new Error(
@@ -924,7 +924,7 @@ export class UBAClientWithRefresh extends BaseAbstractClient {
           const startBlock = getBlockForChain(
             startBlocks,
             chainId,
-            this.hubPoolClient.configStoreClient.enabledChainIds
+            this.hubPoolClient.configStoreClient.getEnabledChains(mainnetStartBlock)
           );
           const openingBalances = getOpeningRunningBalanceForEvent(
             this.hubPoolClient,

--- a/src/clients/UBAClient/UBAClientWithRefresh.ts
+++ b/src/clients/UBAClient/UBAClientWithRefresh.ts
@@ -924,7 +924,7 @@ export class UBAClientWithRefresh extends BaseAbstractClient {
           const startBlock = getBlockForChain(
             startBlocks,
             chainId,
-            this.hubPoolClient.configStoreClient.getEnabledChains(mainnetStartBlock)
+          this.chainIdIndices
           );
           const openingBalances = getOpeningRunningBalanceForEvent(
             this.hubPoolClient,

--- a/src/clients/mocks/MockConfigStoreClient.ts
+++ b/src/clients/mocks/MockConfigStoreClient.ts
@@ -2,7 +2,12 @@ import assert from "assert";
 import winston from "winston";
 import { Contract, Event, ethers } from "ethers";
 import { EventSearchConfig, MakeOptional, utf8ToHex } from "../../utils";
-import { AcrossConfigStoreClient, ConfigStoreUpdate, DEFAULT_CONFIG_STORE_VERSION } from "../AcrossConfigStoreClient";
+import {
+  AcrossConfigStoreClient,
+  ConfigStoreUpdate,
+  DEFAULT_CONFIG_STORE_VERSION,
+  GLOBAL_CONFIG_STORE_KEYS,
+} from "../AcrossConfigStoreClient";
 import { EventManager, getEventManager } from "./MockEvents";
 
 export class MockConfigStoreClient extends AcrossConfigStoreClient {
@@ -24,10 +29,14 @@ export class MockConfigStoreClient extends AcrossConfigStoreClient {
     eventSearchConfig: MakeOptional<EventSearchConfig, "toBlock"> = { fromBlock: 0, maxBlockLookBack: 0 },
     configStoreVersion: number,
     chainId = 1,
-    mockUpdate = false
+    mockUpdate = false,
+    enabledChainIdsOverride?: number[]
   ) {
     super(logger, configStore, eventSearchConfig, configStoreVersion);
     this.eventManager = mockUpdate ? getEventManager(chainId, this.eventSignatures) : null;
+    if (enabledChainIdsOverride) {
+      this.updateGlobalConfig(GLOBAL_CONFIG_STORE_KEYS.CHAIN_ID_INDICES, JSON.stringify(enabledChainIdsOverride), 0);
+    }
   }
 
   setUBAActivationBlock(blockNumber: number | undefined): void {

--- a/src/clients/mocks/MockConfigStoreClient.ts
+++ b/src/clients/mocks/MockConfigStoreClient.ts
@@ -23,11 +23,10 @@ export class MockConfigStoreClient extends AcrossConfigStoreClient {
     configStore: Contract,
     eventSearchConfig: MakeOptional<EventSearchConfig, "toBlock"> = { fromBlock: 0, maxBlockLookBack: 0 },
     configStoreVersion: number,
-    enabledChainIds: number[],
     chainId = 1,
     mockUpdate = false
   ) {
-    super(logger, configStore, eventSearchConfig, configStoreVersion, enabledChainIds);
+    super(logger, configStore, eventSearchConfig, configStoreVersion);
     this.eventManager = mockUpdate ? getEventManager(chainId, this.eventSignatures) : null;
   }
 

--- a/src/interfaces/ConfigStore.ts
+++ b/src/interfaces/ConfigStore.ts
@@ -62,11 +62,11 @@ export interface TokenConfig extends SortableEvent {
   value: string;
 }
 
-export interface GlobalConfigUpdate extends SortableEvent {
-  value: number;
+export interface GlobalConfigUpdate<ValueStore = number> extends SortableEvent {
+  value: ValueStore;
 }
 
-export interface ConfigStoreVersionUpdate extends GlobalConfigUpdate {
+export interface ConfigStoreVersionUpdate<ValueStore = number> extends GlobalConfigUpdate<ValueStore> {
   timestamp: number;
 }
 

--- a/src/utils/BundleUtils.ts
+++ b/src/utils/BundleUtils.ts
@@ -75,7 +75,7 @@ export function getImpliedBundleBlockRanges(
     const fromBlock = prevRootBundle?.bundleEvaluationBlockNumbers?.[i]
       ? prevRootBundle.bundleEvaluationBlockNumbers[i].toNumber() + 1
       : 0;
-    const chainId = configStoreClient.getEnabledChains(fromBlock)[i];
+    const chainId = enabledChains[i];
     if (!enabledChains.includes(chainId)) {
       return [endBlock.toNumber(), endBlock.toNumber()];
     }

--- a/src/utils/BundleUtils.ts
+++ b/src/utils/BundleUtils.ts
@@ -69,13 +69,13 @@ export function getImpliedBundleBlockRanges(
   // Get enabled chains for this bundle block range.
   // Don't let caller override the list of enabled chains when constructing an implied bundle block range,
   // since this function is designed to reconstruct a historical bundle block range.
-  const enabledChains = configStoreClient.getEnabledChains(rootBundle.blockNumber, configStoreClient.enabledChainIds);
+  const enabledChains = configStoreClient.getEnabledChains(rootBundle.blockNumber);
 
   return rootBundle.bundleEvaluationBlockNumbers.map((endBlock, i) => {
-    const chainId = configStoreClient.enabledChainIds[i];
     const fromBlock = prevRootBundle?.bundleEvaluationBlockNumbers?.[i]
       ? prevRootBundle.bundleEvaluationBlockNumbers[i].toNumber() + 1
       : 0;
+    const chainId = configStoreClient.getEnabledChains(fromBlock)[i];
     if (!enabledChains.includes(chainId)) {
       return [endBlock.toNumber(), endBlock.toNumber()];
     }


### PR DESCRIPTION
Adds indices scraping to the across config store. This change is aimed at providing a dynamic approach to determining the across chain indices across block ranges.

<details><summary>Details</summary>
<p>

[feat: ✨ add global chain index scraping from configstore](https://github.com/across-protocol/sdk-v2/commit/6cbe2c82ddc3448a8844fd77cc3e0521795d4204) 

This change adds global config store updates for the chain ID list. If the user requests chain indices prior to the relayer's knowledge then it will return the hardcoded value per the UMIP


[feat: ✨ add generic to global config updates](https://github.com/across-protocol/sdk-v2/commit/e5d67a929732891a67c41fb42bc563484515982e) 

This change adds generic value types for global config updates. Currently, value updates were only able to be numeric types. However, now there is an optional type to include open ended values. These values default to the `number` type for events where the generic is not included.
</p>
</details> 