### PR TITLE
improve(ConfigStoreClient): Remove noisy log

### DIFF
--- a/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
+++ b/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
@@ -330,11 +330,6 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
             const ubaConfig = parseUBAConfigFromOnChain(parsedValue.uba);
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const { value: _value, key: _key, ...passedArgs } = args;
-            this.logger.debug({
-              at: "ConfigStore::update",
-              message: `Parsed UBA config for ${l1Token}`,
-              ubaConfig,
-            });
             this.ubaConfigUpdates.push({ ...passedArgs, config: ubaConfig, l1Token });
           } catch (e) {
             this.logger.warn({


### PR DESCRIPTION
The UBA config is large and logging this parsed config for every token is very noisy