### PR TITLE
fix: Pass in chainIdIndices instead of enabledChainIds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -347,7 +347,7 @@ export class HubPoolClient extends BaseAbstractClient {
     chain: number,
     chainIdListOverride?: number[]
   ): number | undefined {
-    const chainIdList = chainIdListOverride ?? this.configStoreClient.getEnabledChains(latestMainnetBlock);
+    const chainIdList = chainIdListOverride ?? this.configStoreClient.getChainIdIndicesForBlock(latestMainnetBlock);
     let endingBlockNumber: number | undefined;
     // Search proposed root bundles in reverse chronological order.
     for (let i = this.proposedRootBundles.length - 1; i >= 0; i--) {

--- a/src/clients/UBAClient/UBAClientWithRefresh.ts
+++ b/src/clients/UBAClient/UBAClientWithRefresh.ts
@@ -38,7 +38,6 @@ import { getDepositFee, getRefundFee } from "../../UBAFeeCalculator/UBAFeeSpokeC
 import { BigNumber, ethers } from "ethers";
 import { BaseAbstractClient } from "../BaseAbstractClient";
 import UBAConfig from "../../UBAFeeCalculator/UBAFeeConfig";
-import _ from "lodash";
 
 /**
  * @notice This class reconstructs UBA bundle data for every bundle that has been created since the

--- a/src/utils/BundleUtils.ts
+++ b/src/utils/BundleUtils.ts
@@ -66,17 +66,20 @@ export function getImpliedBundleBlockRanges(
   // If chain is disabled for this bundle block range, end block should be same as previous bundle.
   // Otherwise the range should be previous bundle's endBlock + 1 to current bundle's end block.
 
-  // Get enabled chains for this bundle block range.
-  // Don't let caller override the list of enabled chains when constructing an implied bundle block range,
-  // since this function is designed to reconstruct a historical bundle block range.
-  const enabledChains = configStoreClient.getEnabledChains(rootBundle.blockNumber);
+  // Get enabled chains at the mainnet start block of the current root bundle.
+  // We'll check each chain represented in the bundleEvaluationBlockNumbers to see if it's enabled and
+  // use that to determine the implied block range.
+  const mainnetStartBlock = prevRootBundle?.bundleEvaluationBlockNumbers[0].toNumber() ?? 0;
+  const enabledChainsAtMainnetStartBlock = configStoreClient.getEnabledChains(mainnetStartBlock);
 
+  // Load all chain indices in order to map bundle evaluation block numbers to enabled chains list.
+  const chainIdIndices = configStoreClient.getChainIdIndicesForBlock(rootBundle.blockNumber);
   return rootBundle.bundleEvaluationBlockNumbers.map((endBlock, i) => {
     const fromBlock = prevRootBundle?.bundleEvaluationBlockNumbers?.[i]
       ? prevRootBundle.bundleEvaluationBlockNumbers[i].toNumber() + 1
       : 0;
-    const chainId = enabledChains[i];
-    if (!enabledChains.includes(chainId)) {
+    const chainId = chainIdIndices[i];
+    if (!enabledChainsAtMainnetStartBlock.includes(chainId)) {
       return [endBlock.toNumber(), endBlock.toNumber()];
     }
     return [fromBlock, endBlock.toNumber()];


### PR DESCRIPTION
There is a very important difference between calling `getEnabledChains` and `getChainIdIndices` on the `ConfigStoreClient`. The latter is used to index block numbers to chains while the former is used much more seldomly to limit which chains we care about for whatever operation.

This PR fixes critical bugs in the various clients that create block ranges. I discovered this bug while integration testing the dataworker and UBA client
