### PR TITLE
improve(gasPriceOracle): Initial zkSync support

### DIFF
--- a/src/gasPriceOracle/oracle.e2e.ts
+++ b/src/gasPriceOracle/oracle.e2e.ts
@@ -47,6 +47,7 @@ const networks: { [chainId: number]: string } = {
   10: "https://mainnet.optimism.io",
   137: "https://polygon.llamarpc.com",
   288: "https://mainnet.boba.network",
+  324: "https://mainnet.era.zksync.io",
   42161: "https://rpc.ankr.com/arbitrum",
 };
 
@@ -55,7 +56,7 @@ const stdMaxPriorityFeePerGas = ethersUtils.parseUnits("1.5", 9); // EIP-1559 ch
 const stdLastBaseFeePerGas = stdGasPrice.sub(stdMaxPriorityFeePerGas);
 const stdMaxFeePerGas = stdGasPrice;
 const eip1559Chains = [1, 10, 137, 42161];
-const legacyChains = [288];
+const legacyChains = [288, 324];
 
 let providerInstances: { [chainId: number]: MockedProvider } = {};
 

--- a/src/gasPriceOracle/oracle.ts
+++ b/src/gasPriceOracle/oracle.ts
@@ -24,6 +24,7 @@ export async function getGasPriceEstimate(
     10: eip1559,
     137: polygonGasStation,
     288: legacy,
+    324: legacy,
     42161: eip1559_arbitrum,
   };
 


### PR DESCRIPTION
This change explicitly signals that zkSync gas price estimates should be based on the legacy method, rather than eip1559.

The zkSync docs indicate that type 2 (EIP1559) transactions are supported, but clarify that the maxFee* parameters are ignored:
  https://era.zksync.io/docs/reference/concepts/transactions.html#eip-1559-0x2

The zkSync-specific provider references the ethers getGasPrice() method, rather than the more post-1559 getFeeData() method that supports the priority fee:
  https://era.zksync.io/docs/api/js/providers.html#getgasprice

L2s like zkSync and Optimism are additionally indicating more dynamic pricing based on the corresponding L1 cost of the transaction, and this requires fee estimation based on the actual transaction request. Ultimately we may need to support a strategy like this in order to get accurate gas price estimates.