### PR TITLE
fix(UBA): :bug: assert that config store is updated

### DIFF
--- a/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
+++ b/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
@@ -91,7 +91,7 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
     readonly eventSearchConfig: MakeOptional<EventSearchConfig, "toBlock"> = { fromBlock: 0, maxBlockLookBack: 0 },
     readonly configStoreVersion: number
   ) {
-    super();
+    super("ConfigStore");
     this.firstBlockToSearch = eventSearchConfig.fromBlock;
     this.rateModelDictionary = new across.rateModel.RateModelDictionary();
   }

--- a/src/clients/BaseAbstractClient.ts
+++ b/src/clients/BaseAbstractClient.ts
@@ -1,11 +1,25 @@
+import { assertClientsAreUpdated } from "../utils";
+
 /**
  * Base class for all clients to extend.
  */
 export abstract class BaseAbstractClient {
   protected _isUpdated: boolean;
 
-  constructor() {
+  /**
+   * @param clientName The name of the client.
+   * @param clientsRequiredToBeUpdated The clients that are required to be updated before this client can be updated.
+   * @throws Error if the required clients are not updated.
+   */
+  constructor(
+    readonly clientName?: string,
+    clientsRequiredToBeUpdated: (BaseAbstractClient | undefined | null)[] = []
+  ) {
     this._isUpdated = false;
+    // Assert that the required clients are updated
+    // Note: this function doesn't actually update the clients, it just asserts that they are updated
+    //       as we are in the constructor and are not allowed to call async functions
+    assertClientsAreUpdated(...clientsRequiredToBeUpdated);
   }
 
   /**

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -94,7 +94,7 @@ export class HubPoolClient extends BaseAbstractClient {
       ignoredHubProposedBundles: [],
     }
   ) {
-    super();
+    super("HubPoolClient", [configStoreClient]);
     this.latestBlockNumber = deploymentBlock === 0 ? deploymentBlock : deploymentBlock - 1;
     this.firstBlockToSearch = eventSearchConfig.fromBlock;
 

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -104,7 +104,7 @@ export class SpokePoolClient extends BaseAbstractClient {
     public deploymentBlock: number,
     readonly eventSearchConfig: MakeOptional<EventSearchConfig, "toBlock"> = { fromBlock: 0, maxBlockLookBack: 0 }
   ) {
-    super();
+    super("SpokePoolClient", [hubPoolClient, hubPoolClient?.configStoreClient]);
     this.firstBlockToSearch = eventSearchConfig.fromBlock;
     this.latestBlockSearched = eventSearchConfig.fromBlock;
     this.queryableEventNames = Object.keys(this._queryableEventNames());

--- a/src/clients/UBAClient/UBAClientWithRefresh.ts
+++ b/src/clients/UBAClient/UBAClientWithRefresh.ts
@@ -86,10 +86,12 @@ export class UBAClientWithRefresh extends BaseAbstractClient {
     public readonly spokePoolClients: { [chainId: number]: SpokePoolClient },
     protected readonly cachingClient?: CachingMechanismInterface
   ) {
-    super();
+    super("UBAClientWithRefresh", [
+      hubPoolClient,
+      ...Object.values(spokePoolClients),
+      hubPoolClient?.configStoreClient,
+    ]);
     this.logger = this.hubPoolClient.logger;
-    // In order to load the enabled chains, we need to make sure that the config store client is updated.
-    assert(this.hubPoolClient.configStoreClient.isUpdated, "ConfigStoreClient must be updated");
     this.enabledChainIds = this.hubPoolClient.configStoreClient.getEnabledChains();
     assert(this.enabledChainIds.length > 0, "No chainIds provided");
     this.enabledChainIds.forEach((chainId) => {

--- a/src/clients/UBAClient/UBAClientWithRefresh.ts
+++ b/src/clients/UBAClient/UBAClientWithRefresh.ts
@@ -88,6 +88,8 @@ export class UBAClientWithRefresh extends BaseAbstractClient {
   ) {
     super();
     this.logger = this.hubPoolClient.logger;
+    // In order to load the enabled chains, we need to make sure that the config store client is updated.
+    assert(this.hubPoolClient.configStoreClient.isUpdated, "ConfigStoreClient must be updated");
     this.enabledChainIds = this.hubPoolClient.configStoreClient.getEnabledChains();
     assert(this.enabledChainIds.length > 0, "No chainIds provided");
     this.enabledChainIds.forEach((chainId) => {

--- a/src/utils/ClientUtils.ts
+++ b/src/utils/ClientUtils.ts
@@ -1,0 +1,11 @@
+import { BaseAbstractClient } from "../clients/BaseAbstractClient";
+import assert from "assert";
+
+/**
+ * Asserts that the clients are updated
+ * @param clients The clients to check
+ * @throws AssertionError if the clients are not updated
+ */
+export function assertClientsAreUpdated(...clients: BaseAbstractClient[]): void {
+  clients.forEach((client) => assert(client.isUpdated, "Client is not updated"));
+}

--- a/src/utils/ClientUtils.ts
+++ b/src/utils/ClientUtils.ts
@@ -6,6 +6,6 @@ import assert from "assert";
  * @param clients The clients to check
  * @throws AssertionError if the clients are not updated
  */
-export function assertClientsAreUpdated(...clients: BaseAbstractClient[]): void {
-  clients.forEach((client) => assert(client.isUpdated, "Client is not updated"));
+export function assertClientsAreUpdated(...clients: (BaseAbstractClient | undefined | null)[]): void {
+  clients.forEach((client) => !!client && assert(client.isUpdated, `${client.clientName ?? "Client"} is not updated`));
 }

--- a/src/utils/ClientUtils.ts
+++ b/src/utils/ClientUtils.ts
@@ -1,5 +1,6 @@
 import { BaseAbstractClient } from "../clients/BaseAbstractClient";
 import assert from "assert";
+import { isDefined } from "./TypeGuards";
 
 /**
  * Asserts that the clients are updated
@@ -7,5 +8,7 @@ import assert from "assert";
  * @throws AssertionError if the clients are not updated
  */
 export function assertClientsAreUpdated(...clients: (BaseAbstractClient | undefined | null)[]): void {
-  clients.forEach((client) => !!client && assert(client.isUpdated, `${client.clientName ?? "Client"} is not updated`));
+  clients.forEach(
+    (client) => isDefined(client) && assert(client.isUpdated, `${client.clientName ?? "Client"} is not updated`)
+  );
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -13,3 +13,4 @@ export * from "./BundleUtils";
 export * from "./JSONUtils";
 export * from "./IPFSUtils";
 export * from "./NumberUtils";
+export * from "./ClientUtils";


### PR DESCRIPTION
In order to find the list of enabled chains from the config store, we need to ensure that the config store has been updated. This is something that should be provided prior to the config store being passed into the constructor of the UBAClient.

Breaking Changes: Any code with the assumption that an unupdated config store can be passed into the UBAClientWithRefresh