### PR TITLE
improve(ConfigStoreClient): Add Chain ID awareness

### DIFF
--- a/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
+++ b/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
@@ -133,7 +133,7 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
    * @param ConfigStore chain ID.
    * @dev If the resolved chain ID is part of the default set, assume the protocol defaults.
    *      Otherwise, assume this is a test deployment with a lone chain ID.
-   * @dev The protocol defaults are [1, 10, 137, 288, 42161](outlined in UMIP-157).
+   * @dev The protocol defaults are [1, 10, 137, 288, 42161] (outlined in UMIP-157).
    * @dev chainId is marked optional to appease tsc. It must always be passed in.
    */
   protected implicitChainIdIndices(chainId?: number): number[] {

--- a/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
+++ b/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
@@ -137,10 +137,8 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
    * @dev chainId is marked optional to appease tsc. It must always be passed in.
    */
   protected implicitChainIdIndices(chainId?: number): number[] {
-    assert(isDefined(chainId), `ConfigStoreClient used before update`);
-    return PROTOCOL_DEFAULT_CHAIN_ID_INDICES[0] === chainId
-      ? PROTOCOL_DEFAULT_CHAIN_ID_INDICES
-      : [chainId];
+    assert(isDefined(chainId), "ConfigStoreClient used before update");
+    return PROTOCOL_DEFAULT_CHAIN_ID_INDICES[0] === chainId ? PROTOCOL_DEFAULT_CHAIN_ID_INDICES : [chainId];
   }
 
   /**
@@ -332,7 +330,7 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
     if (!result.success) {
       return;
     }
-    const { chainId} = result;
+    const { chainId } = result;
     const { updatedTokenConfigEvents, updatedGlobalConfigEvents, globalConfigUpdateTimes } = result.events;
     assert(
       updatedGlobalConfigEvents.length === globalConfigUpdateTimes.length,

--- a/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
+++ b/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
@@ -130,7 +130,7 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
 
   /**
    * Resolve the implied set of chain ID indices based on the chain ID of the ConfigStore.
-   * @param ConfigStore chain ID.
+   * @param chainId Chain ID of the ConfigStore.
    * @dev If the resolved chain ID is part of the default set, assume the protocol defaults.
    *      Otherwise, assume this is a test deployment with a lone chain ID.
    * @dev The protocol defaults are [1, 10, 137, 288, 42161] (outlined in UMIP-157).

--- a/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
+++ b/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
@@ -284,9 +284,21 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
     return this.configStoreVersion >= version;
   }
 
+  /**
+   * Resolve the chain ID for the ConfigStore Provider instance.
+   * @dev When the provider is a StatisJsonRpcProvider instance, the getNetwork() is non-blocking.
+   * @returns Chain ID for the ConfigStore deployment.
+   */
+  protected async resolveChainId(): Promise<number> {
+    return this.chainId ?? (await this.configStore.provider.getNetwork()).chainId;
+  }
+
   async _update(): Promise<ConfigStoreUpdate> {
-    const chainId = this.chainId ?? (await this.configStore.provider.getNetwork()).chainId;
-    const latestBlockNumber = await this.configStore.provider.getBlockNumber();
+    const [chainId, latestBlockNumber] = await Promise.all([
+      this.resolveChainId(),
+      this.configStore.provider.getBlockNumber(),
+    ]);
+
     const searchConfig = {
       fromBlock: this.firstBlockToSearch,
       toBlock: this.eventSearchConfig.toBlock || latestBlockNumber,

--- a/src/clients/mocks/MockConfigStoreClient.ts
+++ b/src/clients/mocks/MockConfigStoreClient.ts
@@ -34,6 +34,7 @@ export class MockConfigStoreClient extends AcrossConfigStoreClient {
     availableChainIdsOverride?: number[]
   ) {
     super(logger, configStore, eventSearchConfig, configStoreVersion);
+    this.chainId = chainId;
     this.eventManager = mockUpdate ? getEventManager(chainId, this.eventSignatures) : null;
     if (isDefined(this.eventManager) && this.eventManager) {
       this.updateGlobalConfig(
@@ -104,6 +105,7 @@ export class MockConfigStoreClient extends AcrossConfigStoreClient {
 
     return {
       success: true,
+      chainId: this.chainId as number,
       latestBlockNumber,
       searchEndBlock: this.eventSearchConfig.toBlock || latestBlockNumber,
       events: {

--- a/src/clients/mocks/MockConfigStoreClient.ts
+++ b/src/clients/mocks/MockConfigStoreClient.ts
@@ -63,7 +63,9 @@ export class MockConfigStoreClient extends AcrossConfigStoreClient {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   getConfigStoreVersionForBlock(_blockNumber: number): number {
-    return this.configStoreVersion;
+    return this.configStoreVersion === DEFAULT_CONFIG_STORE_VERSION
+      ? super.getConfigStoreVersionForBlock(_blockNumber)
+      : this.configStoreVersion;
   }
 
   setConfigStoreVersion(version: number): void {


### PR DESCRIPTION
This makes the ConfigStoreClient more compatible with testnet deployments, and helps to ignore obviously incorrect GlobalConfig updates impacting the chain ID indices array.