### PR TITLE
fix(queries): browser compatibility + use chain id enum

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.15.13",
+  "version": "0.15.14",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/relayFeeCalculator/chain-queries/arbitrum.ts
+++ b/src/relayFeeCalculator/chain-queries/arbitrum.ts
@@ -1,19 +1,41 @@
-import { getDeployedAddress } from "@across-protocol/contracts-v2";
+import { getDeployedAddress } from "../../utils/DeploymentUtils";
 import { DEFAULT_LOGGER, Logger } from "../relayFeeCalculator";
 import { providers } from "ethers";
-import { TOKEN_SYMBOLS_MAP } from "../../constants";
+import { TOKEN_SYMBOLS_MAP, CHAIN_IDs } from "../../constants";
 import { DEFAULT_SIMULATED_RELAYER_ADDRESS } from "./baseQuery";
 import QueryBase from "./baseQuery";
-
-const chainId = 42161;
 
 export class ArbitrumQueries extends QueryBase {
   constructor(
     provider: providers.Provider,
     symbolMapping = TOKEN_SYMBOLS_MAP,
-    spokePoolAddress = getDeployedAddress("SpokePool", chainId),
-    usdcAddress = TOKEN_SYMBOLS_MAP.USDC.addresses[chainId],
+    spokePoolAddress = getDeployedAddress("SpokePool", CHAIN_IDs.ARBITRUM),
+    usdcAddress = TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.ARBITRUM],
     simulatedRelayerAddress = DEFAULT_SIMULATED_RELAYER_ADDRESS,
+    coingeckoProApiKey?: string,
+    logger: Logger = DEFAULT_LOGGER,
+    gasMarkup = 0
+  ) {
+    super(
+      provider,
+      symbolMapping,
+      spokePoolAddress,
+      usdcAddress,
+      simulatedRelayerAddress,
+      gasMarkup,
+      logger,
+      coingeckoProApiKey
+    );
+  }
+}
+
+export class ArbitrumGoerliQueries extends QueryBase {
+  constructor(
+    provider: providers.Provider,
+    symbolMapping = TOKEN_SYMBOLS_MAP,
+    spokePoolAddress = getDeployedAddress("SpokePool", CHAIN_IDs.ARBITRUM_GOERLI),
+    usdcAddress = TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.ARBITRUM_GOERLI],
+    simulatedRelayerAddress = "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D",
     coingeckoProApiKey?: string,
     logger: Logger = DEFAULT_LOGGER,
     gasMarkup = 0

--- a/src/relayFeeCalculator/chain-queries/ethereum.ts
+++ b/src/relayFeeCalculator/chain-queries/ethereum.ts
@@ -1,19 +1,16 @@
-import { getDeployedAddress } from "@across-protocol/contracts-v2";
+import { getDeployedAddress } from "../../utils/DeploymentUtils";
 import { DEFAULT_LOGGER, Logger } from "../relayFeeCalculator";
 import { providers } from "ethers";
-import { TOKEN_SYMBOLS_MAP } from "../../constants";
+import { TOKEN_SYMBOLS_MAP, CHAIN_IDs } from "../../constants";
 import { DEFAULT_SIMULATED_RELAYER_ADDRESS } from "./baseQuery";
 import QueryBase from "./baseQuery";
-
-const chainId = 1;
-const testChainId = 5;
 
 export class EthereumQueries extends QueryBase {
   constructor(
     provider: providers.Provider,
     symbolMapping = TOKEN_SYMBOLS_MAP,
-    spokePoolAddress = getDeployedAddress("SpokePool", chainId),
-    usdcAddress = TOKEN_SYMBOLS_MAP.USDC.addresses[chainId],
+    spokePoolAddress = getDeployedAddress("SpokePool", CHAIN_IDs.MAINNET),
+    usdcAddress = TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.MAINNET],
     simulatedRelayerAddress = DEFAULT_SIMULATED_RELAYER_ADDRESS,
     coingeckoProApiKey?: string,
     logger: Logger = DEFAULT_LOGGER,
@@ -39,8 +36,8 @@ export class EthereumGoerliQueries extends QueryBase {
   constructor(
     provider: providers.Provider,
     symbolMapping = TOKEN_SYMBOLS_MAP,
-    spokePoolAddress = getDeployedAddress("SpokePool", testChainId),
-    usdcAddress = TOKEN_SYMBOLS_MAP.USDC.addresses[testChainId],
+    spokePoolAddress = getDeployedAddress("SpokePool", CHAIN_IDs.GOERLI),
+    usdcAddress = TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.GOERLI],
     simulatedRelayerAddress = "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D",
     coingeckoProApiKey?: string,
     logger: Logger = DEFAULT_LOGGER,

--- a/src/relayFeeCalculator/chain-queries/optimism.ts
+++ b/src/relayFeeCalculator/chain-queries/optimism.ts
@@ -1,19 +1,17 @@
-import { getDeployedAddress } from "@across-protocol/contracts-v2";
+import { getDeployedAddress } from "../../utils/DeploymentUtils";
 import { DEFAULT_LOGGER, Logger } from "../relayFeeCalculator";
 import { providers } from "ethers";
-import { TOKEN_SYMBOLS_MAP } from "../../constants";
+import { TOKEN_SYMBOLS_MAP, CHAIN_IDs } from "../../constants";
 import { asL2Provider } from "@eth-optimism/sdk/dist/l2-provider";
 import { DEFAULT_SIMULATED_RELAYER_ADDRESS } from "./baseQuery";
 import QueryBase from "./baseQuery";
-
-const chainId = 10;
 
 export class OptimismQueries extends QueryBase {
   constructor(
     provider: providers.Provider,
     symbolMapping = TOKEN_SYMBOLS_MAP,
-    spokePoolAddress = getDeployedAddress("SpokePool", chainId),
-    usdcAddress = TOKEN_SYMBOLS_MAP.USDC.addresses[chainId],
+    spokePoolAddress = getDeployedAddress("SpokePool", CHAIN_IDs.OPTIMISM),
+    usdcAddress = TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.OPTIMISM],
     simulatedRelayerAddress = DEFAULT_SIMULATED_RELAYER_ADDRESS,
     coingeckoProApiKey?: string,
     logger: Logger = DEFAULT_LOGGER,

--- a/src/relayFeeCalculator/chain-queries/polygon.ts
+++ b/src/relayFeeCalculator/chain-queries/polygon.ts
@@ -1,4 +1,4 @@
-import { getDeployedAddress } from "@across-protocol/contracts-v2";
+import { getDeployedAddress } from "../../utils/DeploymentUtils";
 import { DEFAULT_LOGGER, Logger } from "../relayFeeCalculator";
 import { providers } from "ethers";
 import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "../../constants";
@@ -6,14 +6,12 @@ import { Coingecko } from "../../coingecko/Coingecko";
 import { DEFAULT_SIMULATED_RELAYER_ADDRESS } from "./baseQuery";
 import QueryBase from "./baseQuery";
 
-const chainId = 137;
-
 export class PolygonQueries extends QueryBase {
   constructor(
     provider: providers.Provider,
     symbolMapping = TOKEN_SYMBOLS_MAP,
-    spokePoolAddress = getDeployedAddress("SpokePool", chainId),
-    usdcAddress = TOKEN_SYMBOLS_MAP.USDC.addresses[chainId],
+    spokePoolAddress = getDeployedAddress("SpokePool", CHAIN_IDs.POLYGON),
+    usdcAddress = TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.POLYGON],
     simulatedRelayerAddress = DEFAULT_SIMULATED_RELAYER_ADDRESS,
     coingeckoProApiKey?: string,
     logger: Logger = DEFAULT_LOGGER,

--- a/src/relayFeeCalculator/chain-queries/zksync.ts
+++ b/src/relayFeeCalculator/chain-queries/zksync.ts
@@ -1,19 +1,16 @@
-// import { getDeployedAddress } from "@across-protocol/contracts-v2";
+// import { getDeployedAddress } from "../../utils/DeploymentUtils";
 import { DEFAULT_LOGGER, Logger } from "../relayFeeCalculator";
 import { providers } from "ethers";
-import { TOKEN_SYMBOLS_MAP } from "../../constants";
+import { TOKEN_SYMBOLS_MAP, CHAIN_IDs } from "../../constants";
 import { DEFAULT_SIMULATED_RELAYER_ADDRESS } from "./baseQuery";
 import QueryBase from "./baseQuery";
-
-const chainId = 324;
-const testChainId = 280;
 
 export class ZkSyncQueries extends QueryBase {
   constructor(
     provider: providers.Provider,
     symbolMapping = TOKEN_SYMBOLS_MAP,
     spokePoolAddress = "0xE0B015E54d54fc84a6cB9B666099c46adE9335FF", // @todo upgrade contracts-v2
-    usdcAddress = TOKEN_SYMBOLS_MAP.USDC.addresses[chainId],
+    usdcAddress = TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.ZK_SYNC],
     simulatedRelayerAddress = DEFAULT_SIMULATED_RELAYER_ADDRESS,
     coingeckoProApiKey?: string,
     logger: Logger = DEFAULT_LOGGER,
@@ -40,7 +37,7 @@ export class zkSyncGoerliQueries extends QueryBase {
     provider: providers.Provider,
     symbolMapping = TOKEN_SYMBOLS_MAP,
     spokePoolAddress = "0x863859ef502F0Ee9676626ED5B418037252eFeb2", // @todo upgrade contracts-v2
-    usdcAddress = TOKEN_SYMBOLS_MAP.USDC.addresses[testChainId],
+    usdcAddress = TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.ZK_SYNC_GOERLI],
     simulatedRelayerAddress = "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D",
     coingeckoProApiKey?: string,
     logger: Logger = DEFAULT_LOGGER,

--- a/src/utils/DeploymentUtils.ts
+++ b/src/utils/DeploymentUtils.ts
@@ -1,0 +1,5 @@
+export {
+  getContractInfoFromAddress,
+  getDeployedAddress,
+  getDeployedBlockNumber,
+} from "@across-protocol/contracts-v2/dist/src/DeploymentUtils";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -13,3 +13,4 @@ export * from "./BundleUtils";
 export * from "./JSONUtils";
 export * from "./IPFSUtils";
 export * from "./NumberUtils";
+export * from "./DeploymentUtils";


### PR DESCRIPTION
The import path
```js
import { getDeployedAddress } from "@across-protocol/contracts-v2";
```
broke the FE because the package is not tree shakable and contains dependencies that are not compatible with a browser env. We fix this by importing the `getDeployedAddress` directly from the source file.

