### PR TITLE
chore(gasPriceOracle): Basic support for Base

### DIFF
--- a/src/gasPriceOracle/oracle.e2e.ts
+++ b/src/gasPriceOracle/oracle.e2e.ts
@@ -48,6 +48,7 @@ const networks: { [chainId: number]: string } = {
   137: "https://polygon.llamarpc.com",
   288: "https://mainnet.boba.network",
   324: "https://mainnet.era.zksync.io",
+  8453: "https://mainnet.base.org",
   42161: "https://rpc.ankr.com/arbitrum",
 };
 
@@ -55,7 +56,7 @@ const stdGasPrice = ethersUtils.parseUnits("10", 9);
 const stdMaxPriorityFeePerGas = ethersUtils.parseUnits("1.5", 9); // EIP-1559 chains only
 const stdLastBaseFeePerGas = stdGasPrice.sub(stdMaxPriorityFeePerGas);
 const stdMaxFeePerGas = stdGasPrice;
-const eip1559Chains = [1, 10, 137, 42161];
+const eip1559Chains = [1, 10, 137, 8453, 42161];
 const legacyChains = [288, 324];
 
 let providerInstances: { [chainId: number]: MockedProvider } = {};

--- a/src/gasPriceOracle/oracle.ts
+++ b/src/gasPriceOracle/oracle.ts
@@ -25,6 +25,7 @@ export async function getGasPriceEstimate(
     137: polygonGasStation,
     288: legacy,
     324: legacy,
+    8453: eip1559,
     42161: eip1559_arbitrum,
   };
 


### PR DESCRIPTION
One thing to note: as with Optimism, the priority fee should probably be
scaled down aggressively by the caller since ethers hardcodes it to 1.5
Gwei.