### PR TITLE
fix: correct etherscan link & refactoring

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.15.18",
+  "version": "0.15.20",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -23,9 +23,9 @@
     "prepare": "tsdx build && husky install",
     "size": "size-limit",
     "analyze": "size-limit --why",
-    "bump-version:major": "yarn version --major --no-git-tag-version --no-commit-hooks",
-    "bump-version:minor": "yarn version --minor --no-git-tag-version --no-commit-hooks",
-    "bump-version:patch": "yarn version --patch --no-git-tag-version --no-commit-hooks"
+    "bump-version:major": "yarn version --major --no-git-tag-version --no-commit-hooks && git commit -m 'chore: bump version' ./package.json",
+    "bump-version:minor": "yarn version --minor --no-git-tag-version --no-commit-hooks && git commit -m 'chore: bump version' ./package.json",
+    "bump-version:patch": "yarn version --patch --no-git-tag-version --no-commit-hooks && git commit -m 'chore: bump version' ./package.json"
   },
   "lint-staged": {
     "*.ts": "yarn lint"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.15.20",
+  "version": "0.15.19",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -9,8 +9,8 @@ import {
   AnyObject,
   MAX_BIG_INT,
   stringifyJSONWithNumericString,
+  toBN,
 } from "../utils";
-import { toBN } from "../utils/common";
 import { validateFillForDeposit, filledSameDeposit } from "../utils/FlowUtils";
 import {
   spreadEvent,

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -5,7 +5,6 @@ import UBAFeeConfig from "../../UBAFeeCalculator/UBAFeeConfig";
 import { mapAsync } from "../../utils/ArrayUtils";
 import { SpokePoolClients } from "../../utils/TypeUtils";
 import { isDefined } from "../../utils/TypeGuards";
-import { toBN } from "../../utils/common";
 import { validateFillForDeposit } from "../../utils/FlowUtils";
 import { ModifiedUBAFlow, RequestValidReturnType, SpokePoolFillFilter, UBAClientState } from "./UBAClientTypes";
 import {
@@ -22,6 +21,7 @@ import {
 } from "../../interfaces";
 import { getBlockForChain, getBlockRangeForChain, getImpliedBundleBlockRanges } from "../../utils/BundleUtils";
 import { stringifyJSONWithNumericString } from "../../utils/JSONUtils";
+import { toBN } from "../../utils";
 
 /**
  * Omit the default key from a dictionary

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,18 +19,18 @@ export const PROTOCOL_DEFAULT_CHAIN_ID_INDICES = [1, 10, 137, 288, 42161];
 export const PUBLIC_NETWORKS: { [chainId: number]: { name: string; etherscan: string } } = {
   1: {
     name: "mainnet",
-    etherscan: "https://etherscan.io/",
+    etherscan: "https://etherscan.io",
   },
-  5: { name: "goerli", etherscan: "https://goerli.etherscan.io/" },
-  10: { name: "optimism", etherscan: "https://optimistic.etherscan.io/" },
+  5: { name: "goerli", etherscan: "https://goerli.etherscan.i/" },
+  10: { name: "optimism", etherscan: "https://optimistic.etherscan.io" },
   137: {
     name: "polygon-matic",
-    etherscan: "https://polygonscan.com/",
+    etherscan: "https://polygonscan.com",
   },
-  324: { name: "zksync", etherscan: "https://explorer.zksync.io/" },
+  324: { name: "zksync", etherscan: "https://explorer.zksync.io" },
   8453: { name: "base", etherscan: "https://basescan.org" },
-  42161: { name: "arbitrum", etherscan: "https://arbiscan.io/" },
-  43114: { name: "avalanche", etherscan: "https://snowtrace.io/" },
-  84531: { name: "base-goerli", etherscan: "https://basescan.org/" },
-  421613: { name: "arbitrum-goerli", etherscan: "https://goerli.arbiscan.io/" },
+  42161: { name: "arbitrum", etherscan: "https://arbiscan.io" },
+  43114: { name: "avalanche", etherscan: "https://snowtrace.io" },
+  84531: { name: "base-goerli", etherscan: "https://basescan.org" },
+  421613: { name: "arbitrum-goerli", etherscan: "https://goerli.arbiscan.io" },
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,7 +21,7 @@ export const PUBLIC_NETWORKS: { [chainId: number]: { name: string; etherscan: st
     name: "mainnet",
     etherscan: "https://etherscan.io",
   },
-  5: { name: "goerli", etherscan: "https://goerli.etherscan.i/" },
+  5: { name: "goerli", etherscan: "https://goerli.etherscan.io" },
   10: { name: "optimism", etherscan: "https://optimistic.etherscan.io" },
   137: {
     name: "polygon-matic",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,6 +31,6 @@ export const PUBLIC_NETWORKS: { [chainId: number]: { name: string; etherscan: st
   8453: { name: "base", etherscan: "https://mainnet.basescan.org" },
   42161: { name: "arbitrum", etherscan: "https://arbiscan.io/" },
   43114: { name: "avalanche", etherscan: "https://snowtrace.io/" },
-  84531: { name: "base-goerli", etherscan: "https://basescan.org" },
+  84531: { name: "base-goerli", etherscan: "https://basescan.org/" },
   421613: { name: "arbitrum-goerli", etherscan: "https://goerli.arbiscan.io/" },
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -34,3 +34,5 @@ export const PUBLIC_NETWORKS: { [chainId: number]: { name: string; etherscan: st
   84531: { name: "base-goerli", etherscan: "https://basescan.org" },
   421613: { name: "arbitrum-goerli", etherscan: "https://goerli.arbiscan.io" },
 };
+
+export const DEFAULT_BLOCKCHAIN_EXPLORER_DOMAIN = "https://etherscan.io";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,7 +28,7 @@ export const PUBLIC_NETWORKS: { [chainId: number]: { name: string; etherscan: st
     etherscan: "https://polygonscan.com/",
   },
   324: { name: "zksync", etherscan: "https://explorer.zksync.io/" },
-  8453: { name: "base", etherscan: "https://mainnet.basescan.org" },
+  8453: { name: "base", etherscan: "https://basescan.org" },
   42161: { name: "arbitrum", etherscan: "https://arbiscan.io/" },
   43114: { name: "avalanche", etherscan: "https://snowtrace.io/" },
   84531: { name: "base-goerli", etherscan: "https://basescan.org/" },

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -207,7 +207,7 @@ export class RelayFeeCalculator {
     ]);
     const decimals = this.queries.getTokenDecimals(tokenSymbol);
     const gasFeesInToken = nativeToToken(gasCosts, tokenPrice, decimals, this.nativeTokenDecimals);
-    return percent(gasFeesInToken, amountToRelay);
+    return percent(gasFeesInToken, amountToRelay.toString());
   }
 
   // Note: these variables are unused now, but may be needed in future versions of this function that are more complex.

--- a/src/utils/BlockExplorerUtils.ts
+++ b/src/utils/BlockExplorerUtils.ts
@@ -1,0 +1,54 @@
+import { PUBLIC_NETWORKS, DEFAULT_BLOCKCHAIN_EXPLORER_DOMAIN } from "../constants";
+import { createShortHexString } from "./FormattingUtils";
+
+/**
+ * Creates an etherscan link for a transaction or address on a given network.
+ * @param txHashOrAddress The transaction hash or address to link to.
+ * @param chainId The chainId to link to.
+ * @returns The etherscan link. This link will be formatted in markdown.
+ */
+export function etherscanLink(txHashOrAddress: string, chainId: number | string): string {
+  return _createEtherscanLinkMarkdown(txHashOrAddress, Number(chainId)) ?? "<>";
+}
+
+/**
+ * Resolves a domain to an etherscan link for a given network.
+ * @param networkId The network to link to.
+ * @returns The etherscan link. If the networkId is not supported, the default etherscan mainnet link will be returned.
+ */
+export function createEtherscanLinkFromTx(networkId: number): string {
+  return PUBLIC_NETWORKS[networkId]?.etherscan ?? DEFAULT_BLOCKCHAIN_EXPLORER_DOMAIN;
+}
+
+/**
+ * Generates a valid etherscan link for a given transaction hash or address.
+ * @param hex The transaction hash or address to link to.
+ * @param chainId The chainId to link to.
+ * @returns A formatted markdown etherscan link to the given transaction hash or address on the given chainId.
+ */
+function _createEtherscanLinkMarkdown(hex: string, chainId = 1): string | null {
+  if (hex.substring(0, 2) != "0x") {
+    return null;
+  }
+  const shortURLString = createShortHexString(hex);
+  // Transaction hash
+  if (hex.length == 66) {
+    return `<${createEtherscanLinkFromTx(chainId)}tx/${hex}|${shortURLString}>`;
+  }
+  // Account
+  else if (hex.length == 42) {
+    return `<${createEtherscanLinkFromTx(chainId)}address/${hex}|${shortURLString}>`;
+  }
+  return null;
+}
+
+/**
+ * Generates a list of etherscan links for a given list of transaction hashes or addresses.
+ * @param txHashesOrAddresses The list of transaction hashes or addresses to link to.
+ * @param chainId The chainId to link to.
+ * @returns A list of formatted markdown etherscan links to the given transaction hashes or addresses on the given chainId.
+ * @see etherscanLink
+ */
+export function etherscanLinks(txHashesOrAddresses: string[], chainId: number | string): string {
+  return txHashesOrAddresses.map((hash) => `${etherscanLink(hash, chainId)}\n`).join("");
+}

--- a/src/utils/BlockExplorerUtils.ts
+++ b/src/utils/BlockExplorerUtils.ts
@@ -33,11 +33,11 @@ function _createEtherscanLinkMarkdown(hex: string, chainId = 1): string | null {
   const shortURLString = createShortHexString(hex);
   // Transaction hash
   if (hex.length == 66) {
-    return `<${createEtherscanLinkFromTx(chainId)}tx/${hex}|${shortURLString}>`;
+    return `<${createEtherscanLinkFromTx(chainId)}/tx/${hex}|${shortURLString}>`;
   }
   // Account
   else if (hex.length == 42) {
-    return `<${createEtherscanLinkFromTx(chainId)}address/${hex}|${shortURLString}>`;
+    return `<${createEtherscanLinkFromTx(chainId)}/address/${hex}|${shortURLString}>`;
   }
   return null;
 }

--- a/src/utils/FormattingUtils.ts
+++ b/src/utils/FormattingUtils.ts
@@ -1,6 +1,5 @@
 import { ethers, BigNumber } from "ethers";
 import { createFormatFunction } from "@uma/common";
-import { DEFAULT_BLOCKCHAIN_EXPLORER_DOMAIN, PUBLIC_NETWORKS } from "../constants";
 
 export { createFormatFunction };
 
@@ -45,25 +44,6 @@ export const formatFeePct = (relayerFeePct: BigNumber): string => {
 };
 
 /**
- * Creates an etherscan link for a transaction or address on a given network.
- * @param txHashOrAddress The transaction hash or address to link to.
- * @param chainId The chainId to link to.
- * @returns The etherscan link. This link will be formatted in markdown.
- */
-export function etherscanLink(txHashOrAddress: string, chainId: number | string): string {
-  return _createEtherscanLinkMarkdown(txHashOrAddress, Number(chainId)) ?? "<>";
-}
-
-/**
- * Resolves a domain to an etherscan link for a given network.
- * @param networkId The network to link to.
- * @returns The etherscan link. If the networkId is not supported, the default etherscan mainnet link will be returned.
- */
-export function createEtherscanLinkFromTx(networkId: number): string {
-  return PUBLIC_NETWORKS[networkId]?.etherscan ?? DEFAULT_BLOCKCHAIN_EXPLORER_DOMAIN;
-}
-
-/**
  * Shortens a lengthy hexadecimal string to a shorter version with an ellipsis in the middle.
  * @param hex A hexadecimal string to be shortened.
  * @returns The shortened hexadecimal string.
@@ -71,39 +51,6 @@ export function createEtherscanLinkFromTx(networkId: number): string {
  */
 export function createShortHexString(hex: string): string {
   return hex.substring(0, 5) + "..." + hex.substring(hex.length - 6, hex.length);
-}
-
-/**
- * Generates a valid etherscan link for a given transaction hash or address.
- * @param hex The transaction hash or address to link to.
- * @param chainId The chainId to link to.
- * @returns A formatted markdown etherscan link to the given transaction hash or address on the given chainId.
- */
-function _createEtherscanLinkMarkdown(hex: string, chainId = 1): string | null {
-  if (hex.substring(0, 2) != "0x") {
-    return null;
-  }
-  const shortURLString = createShortHexString(hex);
-  // Transaction hash
-  if (hex.length == 66) {
-    return `<${createEtherscanLinkFromTx(chainId)}tx/${hex}|${shortURLString}>`;
-  }
-  // Account
-  else if (hex.length == 42) {
-    return `<${createEtherscanLinkFromTx(chainId)}address/${hex}|${shortURLString}>`;
-  }
-  return null;
-}
-
-/**
- * Generates a list of etherscan links for a given list of transaction hashes or addresses.
- * @param txHashesOrAddresses The list of transaction hashes or addresses to link to.
- * @param chainId The chainId to link to.
- * @returns A list of formatted markdown etherscan links to the given transaction hashes or addresses on the given chainId.
- * @see etherscanLink
- */
-export function etherscanLinks(txHashesOrAddresses: string[], chainId: number | string): string {
-  return txHashesOrAddresses.map((hash) => `${etherscanLink(hash, chainId)}\n`).join("");
 }
 
 /**

--- a/src/utils/FormattingUtils.ts
+++ b/src/utils/FormattingUtils.ts
@@ -1,0 +1,165 @@
+import { ethers, BigNumber } from "ethers";
+import { createFormatFunction } from "@uma/common";
+import { DEFAULT_BLOCKCHAIN_EXPLORER_DOMAIN, PUBLIC_NETWORKS } from "../constants";
+
+export { createFormatFunction };
+
+export type BigNumberish = ethers.BigNumberish;
+export type BN = ethers.BigNumber;
+
+/**
+ * Parse a stringified number into a BigNumber.
+ * @param num The number to parse.
+ * @returns The parsed BigNumber.
+ */
+export function toWei(num: BigNumberish): BN {
+  return ethers.utils.parseEther(num.toString());
+}
+
+/**
+ * Parse a stringified number into a BigNumber with 9 decimal places.
+ * @param num The number to parse.
+ * @returns The parsed BigNumber.
+ */
+export function toGWei(num: BigNumberish): BN {
+  return ethers.utils.parseUnits(num.toString(), 9);
+}
+
+/**
+ * Converts a stringified number into a BigNumber. If the string version of the num contains a `.` then it is a number which needs to be parsed to a string int.
+ * @param num The number to parse.
+ * @returns The parsed BigNumber.
+ * @note This is a temporary function until we can backport support for decimal points to @across-protocol/sdk-v2.
+ */
+export const toBN = (num: BigNumberish): BN => {
+  // If the string version of the num contains a `.` then it is a number which needs to be parsed to a string int.
+  if (num.toString().includes(".")) {
+    return BigNumber.from(parseInt(num.toString()));
+  }
+  return BigNumber.from(num.toString());
+};
+
+export const formatFeePct = (relayerFeePct: BigNumber): string => {
+  // 1e18 = 100% so 1e16 = 1%.
+  return createFormatFunction(2, 4, false, 16)(toBN(relayerFeePct).toString());
+};
+
+/**
+ * Creates an etherscan link for a transaction or address on a given network.
+ * @param txHashOrAddress The transaction hash or address to link to.
+ * @param chainId The chainId to link to.
+ * @returns The etherscan link. This link will be formatted in markdown.
+ */
+export function etherscanLink(txHashOrAddress: string, chainId: number | string): string {
+  return _createEtherscanLinkMarkdown(txHashOrAddress, Number(chainId)) ?? "<>";
+}
+
+/**
+ * Resolves a domain to an etherscan link for a given network.
+ * @param networkId The network to link to.
+ * @returns The etherscan link. If the networkId is not supported, the default etherscan mainnet link will be returned.
+ */
+export function createEtherscanLinkFromTx(networkId: number): string {
+  return PUBLIC_NETWORKS[networkId]?.etherscan ?? DEFAULT_BLOCKCHAIN_EXPLORER_DOMAIN;
+}
+
+/**
+ * Shortens a lengthy hexadecimal string to a shorter version with an ellipsis in the middle.
+ * @param hex A hexadecimal string to be shortened.
+ * @returns The shortened hexadecimal string.
+ * @example shortenHexString("0x772871a444c6e4e9903d8533a5a13101b74037158123e6709470f0afbf6e7d94") -> "0x7787...7d94"
+ */
+export function createShortHexString(hex: string): string {
+  return hex.substring(0, 5) + "..." + hex.substring(hex.length - 6, hex.length);
+}
+
+/**
+ * Generates a valid etherscan link for a given transaction hash or address.
+ * @param hex The transaction hash or address to link to.
+ * @param chainId The chainId to link to.
+ * @returns A formatted markdown etherscan link to the given transaction hash or address on the given chainId.
+ */
+function _createEtherscanLinkMarkdown(hex: string, chainId = 1): string | null {
+  if (hex.substring(0, 2) != "0x") {
+    return null;
+  }
+  const shortURLString = createShortHexString(hex);
+  // Transaction hash
+  if (hex.length == 66) {
+    return `<${createEtherscanLinkFromTx(chainId)}tx/${hex}|${shortURLString}>`;
+  }
+  // Account
+  else if (hex.length == 42) {
+    return `<${createEtherscanLinkFromTx(chainId)}address/${hex}|${shortURLString}>`;
+  }
+  return null;
+}
+
+/**
+ * Generates a list of etherscan links for a given list of transaction hashes or addresses.
+ * @param txHashesOrAddresses The list of transaction hashes or addresses to link to.
+ * @param chainId The chainId to link to.
+ * @returns A list of formatted markdown etherscan links to the given transaction hashes or addresses on the given chainId.
+ * @see etherscanLink
+ */
+export function etherscanLinks(txHashesOrAddresses: string[], chainId: number | string): string {
+  return txHashesOrAddresses.map((hash) => `${etherscanLink(hash, chainId)}\n`).join("");
+}
+
+/**
+ * Converts a utf8 string to a hex string.
+ * @param input The utf8 string to convert.
+ * @returns The hex string.
+ */
+export function utf8ToHex(input: string): string {
+  return ethers.utils.formatBytes32String(input);
+}
+
+/**
+ * Converts a hexadecimal string to a utf8 string.
+ * @param input The hexadecimal string to convert.
+ * @returns The utf8 string.
+ */
+export function hexToUtf8(input: string): string {
+  return ethers.utils.toUtf8String(input);
+}
+
+/**
+ * Converts a BigNumber to a 32-byte hexadecimal string.
+ *
+ * @param input - The BigNumber to convert.
+ * @returns The 32-byte hexadecimal string representation of the input.
+ */
+export function bnToHex(input: BigNumber): string {
+  return ethers.utils.hexZeroPad(ethers.utils.hexlify(toBN(input)), 32);
+}
+
+/**
+ * Converts a value from wei to a decimal value with the specified number of decimal places.
+ * @param weiVal - The value in wei to convert.
+ * @param decimals - The number of decimal places to include in the converted value.
+ * @returns The converted value as a string.
+ */
+export function convertFromWei(weiVal: string, decimals: number): string {
+  const formatFunction = createFormatFunction(2, 4, false, decimals);
+  return formatFunction(weiVal);
+}
+
+/**
+ * Shortens a list of addresses to a shorter version with only the first 10 characters.
+ * @param addresses A list of addresses to shorten.
+ * @returns A list of shortened addresses.
+ * @see shortenHexString
+ */
+export function shortenHexStrings(addresses: string[]): string[] {
+  return addresses.map((address) => shortenHexString(address));
+}
+
+/**
+ * Shortens a hexadecimal string to a shorter version with only the first 10 characters.
+ * @param hexString A hexadecimal string to shorten.
+ * @returns The shortened hexadecimal string.
+ */
+export function shortenHexString(hexString: string): string {
+  return hexString.substring(0, 10);
+}

--- a/src/utils/common.test.ts
+++ b/src/utils/common.test.ts
@@ -6,9 +6,9 @@ import {
   createUnsignedFillRelayTransaction,
   estimateTotalGasRequiredByUnsignedTransaction,
   retry,
-  toBN,
   toBNWei,
 } from "./common";
+import { toBN } from "./FormattingUtils";
 
 dotenv.config();
 

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -7,9 +7,8 @@ import { SpokePool } from "../typechain";
 import assert from "assert";
 import { GasPriceEstimate, getGasPriceEstimate } from "../gasPriceOracle";
 import { TypedMessage } from "../interfaces/TypedData";
+import { BN, toBN, BigNumberish } from "./FormattingUtils";
 
-export type BigNumberish = string | number | BigNumber;
-export type BN = BigNumber;
 export type Decimalish = string | number | Decimal;
 export const AddressZero = ethers.constants.AddressZero;
 export const MAX_BIG_INT = BigNumber.from(Number.MAX_SAFE_INTEGER.toString());
@@ -25,14 +24,6 @@ const BlockScanSkipDistances: { [chainId: number]: number } = {
   288: 1000,
   42161: 100000,
 };
-
-/**
- * toBN.
- *
- * @param {BigNumberish} num
- * @returns {BN}
- */
-export const toBN = (num: BigNumberish): BN => BigNumber.from(num.toString());
 
 /**
  * toBNWei.
@@ -232,24 +223,6 @@ export const getSamplesBetween = (min: number, max: number, size: number) => {
  */
 export async function delay(seconds: number) {
   return new Promise((resolve) => setTimeout(resolve, seconds * 1000));
-}
-
-/**
- * Converts a string to a hex string
- * @param input The string to convert
- * @returns The hex string
- */
-export function utf8ToHex(input: string) {
-  return ethers.utils.formatBytes32String(input);
-}
-
-/**
- * Converts a hex string to a utf8 string
- * @param input The hex string to convert
- * @returns The utf8 string
- */
-export function hexToUtf8(input: string) {
-  return ethers.utils.parseBytes32String(input);
 }
 
 /**

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -15,3 +15,4 @@ export * from "./IPFSUtils";
 export * from "./NumberUtils";
 export * from "./DeploymentUtils";
 export * from "./FormattingUtils";
+export * from "./BlockExplorerUtils";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -14,3 +14,4 @@ export * from "./JSONUtils";
 export * from "./IPFSUtils";
 export * from "./NumberUtils";
 export * from "./DeploymentUtils";
+export * from "./FormattingUtils";


### PR DESCRIPTION
Correct etherscan link template for Base. Currently, without the trailing `/` after the URL then our assumptions break for logging. Also, `mainnet.basescan.org` is now defunct replaced by just `basescan.org`

This PR now also includes a refactoring to bring `./formattingUtils` from the relayer into the SDK.