### PR TITLE
improve: reintroduce hub pool caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.15.21",
+  "version": "0.15.22",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/clients/BaseAbstractClient.ts
+++ b/src/clients/BaseAbstractClient.ts
@@ -1,10 +1,17 @@
+import { CachingMechanismInterface } from "../interfaces";
+import { isDefined } from "../utils";
+
 /**
  * Base class for all clients to extend.
  */
 export abstract class BaseAbstractClient {
   protected _isUpdated: boolean;
 
-  constructor() {
+  /**
+   * Creates a new client.
+   * @param cachingMechanism The caching mechanism to use for this client. If not provided, the client will not rely on an external cache.
+   */
+  constructor(protected cachingMechanism?: CachingMechanismInterface) {
     this._isUpdated = false;
   }
 
@@ -35,5 +42,13 @@ export abstract class BaseAbstractClient {
     if (!this.isUpdated) {
       throw new Error("Client not updated");
     }
+  }
+
+  /**
+   * Determines if the client has an external cache.
+   * @returns Whether the client has an external cache.
+   */
+  protected hasCachingMechanism(): boolean {
+    return isDefined(this.cachingMechanism);
   }
 }

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -39,6 +39,7 @@ import * as lpFeeCalculator from "../lpFeeCalculator";
 import { AcrossConfigStoreClient as ConfigStoreClient } from "./AcrossConfigStoreClient/AcrossConfigStoreClient";
 import { BaseAbstractClient } from "./BaseAbstractClient";
 import { isUBAActivatedAtBlock } from "./UBAClient/UBAClientUtilities";
+import { DEFAULT_CACHING_TTL } from "../constants";
 
 type _HubPoolUpdate = {
   success: true;
@@ -283,10 +284,12 @@ export class HubPoolClient extends BaseAbstractClient {
     // and store the result in the cache
     else {
       const { current, post } = await resolver();
-      // First determine if we should cache the result
+      // First determine if we should cache the result. We should cache the
+      // response if the is outside of 24 hours from the current time.
       if (shouldCache(getCurrentTime(), timestamp, 60 * 60 * 24)) {
         // If we should cache the result, then let's store it
-        await cache.set(key, `${current.toString()},${post.toString()}`, 60 * 60 * 24);
+        // We can store it as with the default 7 day TTL
+        await cache.set(key, `${current.toString()},${post.toString()}`, DEFAULT_CACHING_TTL);
       }
       // Return the result
       return { current, post };

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -10,6 +10,8 @@ import {
   BigNumberish,
   stringifyJSONWithNumericString,
   isDefined,
+  getCurrentTime,
+  shouldCache,
 } from "../utils";
 import {
   fetchTokenInfo,
@@ -29,6 +31,7 @@ import {
   DepositWithBlock,
   ProposedRootBundleStringified,
   ExecutedRootBundleStringified,
+  CachingMechanismInterface,
 } from "../interfaces";
 import { ExecutedRootBundle, PendingRootBundle, ProposedRootBundle } from "../interfaces";
 import { CrossChainContractsSet, DestinationTokenWithBlock, SetPoolRebalanceRoot } from "../interfaces";
@@ -92,9 +95,10 @@ export class HubPoolClient extends BaseAbstractClient {
     } = {
       ignoredHubExecutedBundles: [],
       ignoredHubProposedBundles: [],
-    }
+    },
+    cachingMechanism?: CachingMechanismInterface
   ) {
-    super();
+    super(cachingMechanism);
     this.latestBlockNumber = deploymentBlock === 0 ? deploymentBlock : deploymentBlock - 1;
     this.firstBlockToSearch = eventSearchConfig.fromBlock;
 
@@ -254,10 +258,39 @@ export class HubPoolClient extends BaseAbstractClient {
     l1Token: string,
     blockNumber: number,
     amount: BigNumber,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _timestamp: number
+    timestamp: number
   ): Promise<{ current: BigNumber; post: BigNumber }> {
-    return this.getPostRelayPoolUtilization(l1Token, blockNumber, amount);
+    // Resolve this function call as an async anonymous function
+    // This way, since we have to use this call several times, we
+    // only need to invoke the shorter function name.
+    const resolver = async () => this.getPostRelayPoolUtilization(l1Token, blockNumber, amount);
+    // Resolve the cache locally so that we can appease typescript
+    const cache = this.cachingMechanism;
+    // If there is no cache, just resolve the function
+    if (!cache) {
+      return resolver();
+    }
+    // Otherwise, let's resolve the key
+    const key = `utilization_${l1Token}_${blockNumber}_${amount.toString()}`;
+    // Resolve the key from the cache
+    const result = await cache.get<string>(key);
+    // We were able to find a valid result, so let's return it
+    if (isDefined(result)) {
+      const [current, post] = result.split(",").map(BigNumber.from);
+      return { current, post };
+    }
+    // We were not able to find a valid result, so let's resolve the function
+    // and store the result in the cache
+    else {
+      const { current, post } = await resolver();
+      // First determine if we should cache the result
+      if (shouldCache(getCurrentTime(), timestamp, 60 * 60 * 24 * 90)) {
+        // If we should cache the result, then let's store it
+        await cache.set(key, `${current.toString()},${post.toString()}`, 60 * 60 * 24 * 90);
+      }
+      // Return the result
+      return { current, post };
+    }
   }
 
   async computeRealizedLpFeePct(

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -284,9 +284,9 @@ export class HubPoolClient extends BaseAbstractClient {
     else {
       const { current, post } = await resolver();
       // First determine if we should cache the result
-      if (shouldCache(getCurrentTime(), timestamp, 60 * 60 * 24 * 90)) {
+      if (shouldCache(getCurrentTime(), timestamp, 60 * 60 * 24)) {
         // If we should cache the result, then let's store it
-        await cache.set(key, `${current.toString()},${post.toString()}`, 60 * 60 * 24 * 90);
+        await cache.set(key, `${current.toString()},${post.toString()}`, 60 * 60 * 24);
       }
       // Return the result
       return { current, post };

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -288,7 +288,7 @@ export class HubPoolClient extends BaseAbstractClient {
       // response if the is outside of 24 hours from the current time.
       if (shouldCache(getCurrentTime(), timestamp, 60 * 60 * 24)) {
         // If we should cache the result, then let's store it
-        // We can store it as with the default 7 day TTL
+        // We can store it as with the default 14 day TTL
         await cache.set(key, `${current.toString()},${post.toString()}`, DEFAULT_CACHING_TTL);
       }
       // Return the result

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,4 +39,4 @@ export const PUBLIC_NETWORKS: { [chainId: number]: { name: string; etherscan: st
 
 export const DEFAULT_BLOCKCHAIN_EXPLORER_DOMAIN = "https://etherscan.io";
 
-export const DEFAULT_CACHING_TTL = 60 * 60 * 24 * 7; // 1 week
+export const DEFAULT_CACHING_TTL = 60 * 60 * 24 * 7 * 2; // 2 Weeks

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,3 +38,5 @@ export const PUBLIC_NETWORKS: { [chainId: number]: { name: string; etherscan: st
 };
 
 export const DEFAULT_BLOCKCHAIN_EXPLORER_DOMAIN = "https://etherscan.io";
+
+export const DEFAULT_CACHING_TTL = 60 * 60 * 24 * 7; // 1 week

--- a/src/interfaces/CachingMechanism.ts
+++ b/src/interfaces/CachingMechanism.ts
@@ -11,7 +11,7 @@ export interface CachingMechanismInterface {
    * @param key The key to retrieve.
    * @returns The value if it exists, otherwise null.
    */
-  get<ObjectType, OverrideType>(
+  get<ObjectType, OverrideType = unknown>(
     key?: string,
     structValidator?: Struct<unknown, unknown>,
     overrides?: OverrideType

--- a/src/utils/CachingUtils.ts
+++ b/src/utils/CachingUtils.ts
@@ -1,0 +1,7 @@
+import { assert } from "./LogUtils";
+
+export function shouldCache(eventTimestamp: number, latestTime: number, cachingMaxAge: number): boolean {
+  assert(eventTimestamp.toString().length === 10, "eventTimestamp must be in seconds");
+  assert(latestTime.toString().length === 10, "eventTimestamp must be in seconds");
+  return latestTime - eventTimestamp >= cachingMaxAge;
+}

--- a/src/utils/LogUtils.ts
+++ b/src/utils/LogUtils.ts
@@ -24,3 +24,15 @@ export function formattedLog(
     });
   }
 }
+
+/**
+ * Asserts the truth of a condition. If the condition is false, an error is thrown with the provided message.
+ * @param condition The condition to assert.
+ * @param message The message to throw if the condition is false.
+ * @throws Error if the condition is false.
+ */
+export function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -17,3 +17,4 @@ export * from "./DeploymentUtils";
 export * from "./FormattingUtils";
 export * from "./BlockExplorerUtils";
 export * from "./BigNumberUtils";
+export * from "./CachingUtils";


### PR DESCRIPTION
This PR re-introduces the hub pool caching mechanism for storing utilization data in an external cache (i.e. redis). A subsequent PR will need to be introduced in relayer-v2 to make use of this functionality. Otherwise, it is completely pass through in the current state.

This functionality relies on the agnostic caching interface that the relayer can use to provide its own interpretation of a cache that exposes get and set functions.