### PR TITLE
improve: Export useful ethers constants

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,7 @@
+import { constants as ethersConstants } from "ethers";
 export { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "@across-protocol/contracts-v2/dist/utils/constants";
-export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+export const { AddressZero: ZERO_ADDRESS } = ethersConstants;
 
 /**
  * This is the protocol default chain Id for the hub pool.

--- a/src/utils/BigNumberUtils.ts
+++ b/src/utils/BigNumberUtils.ts
@@ -9,7 +9,7 @@ import { ethers, BigNumber } from "ethers";
 export type BigNumberish = ethers.BigNumberish;
 export type BN = ethers.BigNumber;
 
-export const { AddressZero: ZERO_ADDRESS, Zero: bnZero, One: bnOne, MaxUint256: bnUint256Max } = ethers.constants;
+export const { Zero: bnZero, One: bnOne, MaxUint256: bnUint256Max } = ethers.constants;
 
 /**
  * Converts a stringified number into a BigNumber with 18 decimal places.

--- a/src/utils/BigNumberUtils.ts
+++ b/src/utils/BigNumberUtils.ts
@@ -9,6 +9,8 @@ import { ethers, BigNumber } from "ethers";
 export type BigNumberish = ethers.BigNumberish;
 export type BN = ethers.BigNumber;
 
+export const { AddressZero: ZERO_ADDRESS, Zero: bnZero, One: bnOne, MaxUint256: bnUint256Max } = ethers.constants;
+
 /**
  * Converts a stringified number into a BigNumber with 18 decimal places.
  * @param num The number to parse.


### PR DESCRIPTION
Using these can deliver a small benefit over spinning up new BNs for common numbers like 0 and 1.