### PR TITLE
fix: resolve bug in spoke pool deposit search

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -1,53 +1,53 @@
 import { Contract, providers } from "ethers";
 import { groupBy } from "lodash";
+import winston from "winston";
 import {
-  assign,
-  EventSearchConfig,
-  DefaultLogLevels,
-  MakeOptional,
-  mapAsync,
   AnyObject,
+  DefaultLogLevels,
+  EventSearchConfig,
   MAX_BIG_INT,
+  MakeOptional,
+  assign,
+  mapAsync,
   stringifyJSONWithNumericString,
   toBN,
 } from "../utils";
-import { validateFillForDeposit, filledSameDeposit } from "../utils/FlowUtils";
 import {
-  spreadEvent,
   paginatedEventQuery,
-  spreadEventWithBlockNumber,
   sortEventsAscending,
   sortEventsAscendingInPlace,
+  spreadEvent,
+  spreadEventWithBlockNumber,
 } from "../utils/EventUtils";
-import winston from "winston";
+import { filledSameDeposit, validateFillForDeposit } from "../utils/FlowUtils";
 
 import { BigNumber, Event, EventFilter, ethers } from "ethers";
 
+import { ZERO_ADDRESS } from "../constants";
 import {
   Deposit,
   DepositWithBlock,
+  DepositWithBlockStringified,
   Fill,
   FillWithBlock,
+  FillWithBlockStringified,
+  FundsDepositedEvent,
+  FundsDepositedEventStringified,
   RefundRequestWithBlock,
+  RefundRequestWithBlockStringified,
   RelayerRefundExecutionWithBlock,
+  RelayerRefundExecutionWithBlockStringified,
   RootBundleRelayWithBlock,
   SpeedUp,
-  TokensBridged,
-  FundsDepositedEvent,
-  DepositWithBlockStringified,
-  FillWithBlockStringified,
   SpeedUpStringified,
+  TokensBridged,
   TokensBridgedStringified,
-  RelayerRefundExecutionWithBlockStringified,
-  FundsDepositedEventStringified,
-  RefundRequestWithBlockStringified,
 } from "../interfaces";
-import { HubPoolClient } from "./HubPoolClient";
-import { ZERO_ADDRESS } from "../constants";
-import { getNetworkName } from "../utils/NetworkUtils";
-import { BaseAbstractClient } from "./BaseAbstractClient";
-import { getBlockRangeForDepositId, getDepositIdAtBlock } from "../utils/SpokeUtils";
 import { SpokePool } from "../typechain";
+import { getNetworkName } from "../utils/NetworkUtils";
+import { getBlockRangeForDepositId, getDepositIdAtBlock } from "../utils/SpokeUtils";
+import { BaseAbstractClient } from "./BaseAbstractClient";
+import { HubPoolClient } from "./HubPoolClient";
 
 type Block = providers.Block;
 

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -438,11 +438,22 @@ export class SpokePoolClient extends BaseAbstractClient {
     low: number;
     high: number;
   }> {
+    console.log("NEXT");
+
     if (initLow > initHigh) {
       throw new Error("Binary search failed because low > high");
     }
+    if (initLow < 0 || initHigh < 0) {
+      throw new Error("Binary search failed because low or high < 0");
+    }
     if (maxSearches <= 0) {
       throw new Error("maxSearches must be > 0");
+    }
+
+    // If the deposit ID at the initial high block is less than the target deposit ID, then we know that
+    // the target deposit ID must be greater than the initial high block, so we can throw an error.
+    if ((await this._getDepositIdAtBlock(initHigh)) < targetDepositId) {
+      throw new Error("Failed to find deposit ID");
     }
 
     let low = initLow;

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -1,4 +1,4 @@
-import { providers } from "ethers";
+import { Contract, providers } from "ethers";
 import { groupBy } from "lodash";
 import {
   assign,
@@ -99,7 +99,7 @@ export class SpokePoolClient extends BaseAbstractClient {
    */
   constructor(
     readonly logger: winston.Logger,
-    readonly spokePool: SpokePool,
+    readonly spokePool: Contract,
     // Can be excluded. This disables some deposit validation.
     readonly hubPoolClient: HubPoolClient | null,
     readonly chainId: number,
@@ -440,7 +440,7 @@ export class SpokePoolClient extends BaseAbstractClient {
     low: number;
     high: number;
   }> {
-    return getBlockRangeForDepositId(targetDepositId, initLow, initHigh, maxSearches, this.spokePool);
+    return getBlockRangeForDepositId(targetDepositId, initLow, initHigh, maxSearches, this.spokePool as SpokePool);
   }
 
   /**
@@ -449,7 +449,7 @@ export class SpokePoolClient extends BaseAbstractClient {
    * @returns The deposit ID.
    */
   public async _getDepositIdAtBlock(blockTag: number): Promise<number> {
-    return getDepositIdAtBlock(this.spokePool, blockTag);
+    return getDepositIdAtBlock(this.spokePool as SpokePool, blockTag);
   }
 
   /**

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -438,7 +438,6 @@ export class SpokePoolClient extends BaseAbstractClient {
     low: number;
     high: number;
   }> {
-    console.log("NEXT");
 
     if (initLow > initHigh) {
       throw new Error("Binary search failed because low > high");

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -1,4 +1,4 @@
-import { Contract, providers } from "ethers";
+import { BigNumber, Contract, Event, EventFilter, ethers, providers } from "ethers";
 import { groupBy } from "lodash";
 import winston from "winston";
 import {
@@ -20,8 +20,6 @@ import {
   spreadEventWithBlockNumber,
 } from "../utils/EventUtils";
 import { filledSameDeposit, validateFillForDeposit } from "../utils/FlowUtils";
-
-import { BigNumber, Event, EventFilter, ethers } from "ethers";
 
 import { ZERO_ADDRESS } from "../constants";
 import {
@@ -431,7 +429,7 @@ export class SpokePoolClient extends BaseAbstractClient {
    *        // contain the event emitted when deposit ID was incremented to targetDepositId + 1. This is the same transaction
    *        // where the deposit with deposit ID = targetDepositId was created.
    */
-  public async _getBlockRangeForDepositId(
+  public _getBlockRangeForDepositId(
     targetDepositId: number,
     initLow: number,
     initHigh: number,
@@ -455,7 +453,7 @@ export class SpokePoolClient extends BaseAbstractClient {
    * @param blockTag The block number to search for the deposit ID at.
    * @returns The deposit ID.
    */
-  public async _getDepositIdAtBlock(blockTag: number): Promise<number> {
+  public _getDepositIdAtBlock(blockTag: number): Promise<number> {
     return getDepositIdAtBlock(this.spokePool as SpokePool, blockTag);
   }
 
@@ -677,7 +675,7 @@ export class SpokePoolClient extends BaseAbstractClient {
       this.earlyDeposits = earlyDeposits;
 
       const dataForQuoteTime: { realizedLpFeePct: BigNumber | undefined; quoteBlock: number }[] = await Promise.all(
-        depositEvents.map(async (event) => this.computeRealizedLpFeePct(event))
+        depositEvents.map((event) => this.computeRealizedLpFeePct(event))
       );
 
       // Now add any newly fetched events from RPC.
@@ -844,7 +842,7 @@ export class SpokePoolClient extends BaseAbstractClient {
    * @param depositEvent The deposit event to compute the realized LP fee percentage for.
    * @returns The realized LP fee percentage.
    */
-  protected async computeRealizedLpFeePct(depositEvent: FundsDepositedEvent) {
+  protected computeRealizedLpFeePct(depositEvent: FundsDepositedEvent) {
     // If no hub pool client, we're using this for testing. So set quote block very high
     // so that if its ever used to look up a configuration for a block, it will always match with some
     // configuration because the quote block will always be greater than the updated config event block height.

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -26,8 +26,7 @@ export async function getBlockRangeForDepositId(
   low: number;
   high: number;
 }> {
-  // Define a mapping of block numbers to deposit IDs. This is used to cache the deposit ID at a block number
-  // so we don't need to make an eth_call request to get the deposit ID at a block number more than once.
+  // Define a mapping of block numbers to number of deposits at that block. This saves repeated lookups.
   const queriedIds: Record<number, number> = {};
 
   // Define a llambda function to get the deposit ID at a block number. This function will first check the

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -48,28 +48,30 @@ export async function getBlockRangeForDepositId(
     _getDepositIdAtBlock(initHigh),
     _getDepositIdAtBlock(Math.max(deploymentBlock, initLow - 1)),
   ]);
+
   // Set the initial high block to the most recent block number or the initial high block, whichever is smaller.
   initHigh = Math.min(initHigh, mostRecentBlockNumber);
 
-  // Sanity check to ensure that initHigh is greater than or equal to initLow.
-  if (initLow > initHigh) {
-    throw new Error("Binary search failed because low > high");
-  }
-
-  // Sanity check to ensure that init Low is greater than or equal to zero.
-  if (initLow < deploymentBlock) {
-    throw new Error("Binary search failed because low must be >= deploymentBlock");
-  }
-
-  // Sanity check to ensure that maxSearches is greater than zero.
-  if (maxSearches <= 0) {
-    throw new Error("maxSearches must be > 0");
-  }
-
-  // Sanity check to ensure that deploymentBlock is greater than or equal to zero.
-  if (deploymentBlock < 0) {
-    throw new Error("deploymentBlock must be >= 0");
-  }
+  // We will now set a list of sanity checks to ensure that the binary search will not fail
+  // due to invalid input parameters.
+  // If any of these sanity checks fail, then we will throw an error.
+  (
+    [
+      // Sanity check to ensure that initHigh is greater than or equal to initLow.
+      [initLow <= initHigh, "Binary search failed because low > high"],
+      // Sanity check to ensure that init Low is greater than or equal to zero.
+      [initLow >= deploymentBlock, "Binary search failed because low must be >= deploymentBlock"],
+      // Sanity check to ensure that maxSearches is greater than zero.
+      [maxSearches > 0, "maxSearches must be > 0"],
+      // Sanity check to ensure that deploymentBlock is greater than or equal to zero.
+      [deploymentBlock >= 0, "deploymentBlock must be >= 0"],
+    ] as [boolean, string][]
+  ).forEach(([condition, errorMessage]) => {
+    // If the condition is false, then we will throw an error.
+    if (!condition) {
+      throw new Error(errorMessage);
+    }
+  });
 
   // If the deposit ID at the initial high block is less than the target deposit ID, then we know that
   // the target deposit ID must be greater than the initial high block, so we can throw an error.

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -88,7 +88,7 @@ export async function getBlockRangeForDepositId(
     //                                     // targetId = 1 <- fail (triggers this error)
     //                                     // targetId = 2 <- pass (does not trigger this error)
     //                                     // targetId = 3 <- pass (does not trigger this error)
-    throw new Error("Failed to find deposit ID: Target Id is less than the initial low block");
+    throw new Error(`Target depositId is less than the initial low block (${targetDepositId} > ${initLow})`);
   }
 
   // Define the low and high block numbers for the binary search.

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -77,7 +77,7 @@ export async function getBlockRangeForDepositId(
     //                                     // targetId = 11  <- fail (triggers this error)          // 10 <= 11
     //                                     // targetId = 10  <- fail (triggers this error)          // 10 <= 10
     //                                     // targetId = 09  <- pass (does not trigger this error)  // 10 <= 09
-    throw new Error("Failed to find deposit ID: Target Id is greater than the initial high block");
+    throw new Error(`Target depositId is greater than the initial high block (${targetDepositId} > ${initHigh})`);
   }
 
   // If the deposit ID at the initial low block is greater than the target deposit ID, then we know that

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -1,0 +1,127 @@
+import { SpokePool } from "../typechain";
+
+/**
+ * Find the block range that contains the deposit ID. This is a binary search that searches for the block range
+ * that contains the deposit ID.
+ * @param targetDepositId The target deposit ID to search for.
+ * @param initLow The initial lower bound of the block range to search.
+ * @param initHigh The initial upper bound of the block range to search.
+ * @param maxSearches The maximum number of searches to perform. This is used to prevent infinite loops.
+ * @returns The block range that contains the deposit ID.
+ * @note  // We want to find the block range that satisfies these conditions:
+ *        // - the low block has deposit count <= targetDepositId
+ *        // - the high block has a deposit count > targetDepositId.
+ *        // This way the caller can search for a FundsDeposited event between [low, high] that will always
+ *        // contain the event emitted when deposit ID was incremented to targetDepositId + 1. This is the same transaction
+ *        // where the deposit with deposit ID = targetDepositId was created.
+ */
+export async function getBlockRangeForDepositId(
+  targetDepositId: number,
+  initLow: number,
+  initHigh: number,
+  maxSearches: number,
+  spokePool: SpokePool
+): Promise<{
+  low: number;
+  high: number;
+}> {
+  // Define a mapping of block numbers to deposit IDs. This is used to cache the deposit ID at a block number
+  // so we don't need to make an eth_call request to get the deposit ID at a block number more than once.
+  const queriedIds: Record<number, number> = {};
+
+  // Define a llambda function to get the deposit ID at a block number. This function will first check the
+  // queriedIds cache to see if the deposit ID at the block number has already been queried. If not, it will
+  // make an eth_call request to get the deposit ID at the block number. It will then cache the deposit ID
+  // in the queriedIds cache.
+  const getDepositIdAtBlock = async (blockNumber: number): Promise<number> => {
+    if (queriedIds[blockNumber] === undefined) {
+      queriedIds[blockNumber] = await spokePool.numberOfDeposits({ blockTag: blockNumber });
+    }
+    return queriedIds[blockNumber];
+  };
+
+  // Sanity check to ensure that init Low is greater than or equal to zero.
+  if (initLow < 0) {
+    throw new Error("Binary search failed because low must be >= 0");
+  }
+
+  // Sanity check to ensure that initHigh is greater than or equal to initLow.
+  if (initLow > initHigh) {
+    throw new Error("Binary search failed because low > high");
+  }
+
+  // Sanity check to ensure that maxSearches is greater than zero.
+  if (maxSearches <= 0) {
+    throw new Error("maxSearches must be > 0");
+  }
+
+  // If the deposit ID at the initial high block is less than the target deposit ID, then we know that
+  // the target deposit ID must be greater than the initial high block, so we can throw an error.
+  if ((await getDepositIdAtBlock(initHigh)) < targetDepositId) {
+    throw new Error("Failed to find deposit ID");
+  }
+
+  // If the deposit ID at the initial low block is greater than the target deposit ID, then we know that
+  // the target deposit ID must be less than the initial low block, so we can throw an error.
+  if ((await getDepositIdAtBlock(initLow)) > targetDepositId) {
+    throw new Error("Failed to find deposit ID");
+  }
+
+  // Define the low and high block numbers for the binary search.
+  let low = initLow;
+  let high = initHigh;
+
+  // Define the number of searches performed so far.
+  let searches = 0;
+
+  do {
+    // Resolve the mid point of the block range.
+    const mid = Math.floor((low + high) / 2);
+
+    // Get the deposit ID at the mid point.
+    const midDepositId = await getDepositIdAtBlock(mid);
+
+    // Get the deposit ID of the block previous to the mid point.
+    // We can use this to get the range that the current midpoint block
+    // has between the previous block and the current block.
+    // NOTE: If the midpoint is block 0, then we can assume that the deposit ID
+    //       of the previous block is 0.
+    const prevDepositId = mid === 0 ? 0 : await getDepositIdAtBlock(mid - 1);
+
+    // Let's define the range of the current midpoint block.
+    // The range is [prevDepositId, midDepositId - 1].
+    const lowRange = prevDepositId;
+    const highRange = midDepositId - 1;
+
+    // If our target deposit ID is less than the smallest range of our
+    // midpoint deposit ID range, then we know that the target deposit ID
+    // must be in the lower half of the block range.
+    if (targetDepositId < lowRange) {
+      high = mid - 1;
+    }
+    // If our target deposit ID is greater than the largest range of our
+    // midpoint deposit ID range, then we know that the target deposit ID
+    // must be in the upper half of the block range.
+    else if (targetDepositId > highRange) {
+      low = mid + 1;
+    }
+    // Otherwise, we've found the block range that contains the deposit ID.
+    else {
+      low = mid;
+      high = mid;
+    }
+  } while (++searches < maxSearches && low < high);
+
+  // We've either found the block range or we've exceeded the maximum number of searches.
+  // In either case, the block range is [low, high] so we can return it.
+  return { low, high };
+}
+
+/**
+ * Finds the deposit id at a specific block number.
+ * @param blockTag The block number to search for the deposit ID at.
+ * @returns The deposit ID.
+ */
+export async function getDepositIdAtBlock(contract: SpokePool, blockTag: number): Promise<number> {
+  return await contract.numberOfDeposits({ blockTag });
+}

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -50,14 +50,14 @@ export async function getBlockRangeForDepositId(
     return queriedIds[blockNumber];
   };
 
-  // Sanity check to ensure that init Low is greater than or equal to zero.
-  if (initLow < deploymentBlock) {
-    throw new Error("Binary search failed because low must be >= 0");
-  }
-
   // Sanity check to ensure that initHigh is greater than or equal to initLow.
   if (initLow > initHigh) {
     throw new Error("Binary search failed because low > high");
+  }
+
+  // Sanity check to ensure that init Low is greater than or equal to zero.
+  if (initLow < deploymentBlock) {
+    throw new Error("Binary search failed because low must be >= deploymentBlock");
   }
 
   // Sanity check to ensure that maxSearches is greater than zero.
@@ -105,13 +105,13 @@ export async function getBlockRangeForDepositId(
     // Get the deposit ID at the mid point.
     const midDepositId = await _getDepositIdAtBlock(mid);
 
-    // Let's define the range of the current midpoint block.
-    const highRange = midDepositId - 1;
+    // Let's define the latest ID of the current midpoint block.
+    const accountedIdByMidBlock = midDepositId - 1;
 
     // If our target deposit ID is less than the smallest range of our
     // midpoint deposit ID range, then we know that the target deposit ID
     // must be in the lower half of the block range.
-    if (targetDepositId <= highRange) {
+    if (targetDepositId <= accountedIdByMidBlock) {
       high = mid;
     }
     // If our target deposit ID is greater than the largest range of our
@@ -120,6 +120,9 @@ export async function getBlockRangeForDepositId(
     else {
       low = mid + 1;
     }
+
+    // We want to iterate until we've either found the block range or we've
+    // exceeded the maximum number of searches.
   } while (++searches <= maxSearches && low < high);
 
   // Sanity check to ensure that our low was not greater than our high.

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -41,11 +41,7 @@ export async function getBlockRangeForDepositId(
   // in the queriedIds cache.
   const _getDepositIdAtBlock = async (blockNumber: number): Promise<number> => {
     if (queriedIds[blockNumber] === undefined) {
-      const resultId = await getDepositIdAtBlock(spokePool, blockNumber);
-      if (!Number.isInteger(resultId)) {
-        throw new Error("Invalid deposit count");
-      }
-      queriedIds[blockNumber] = resultId;
+      queriedIds[blockNumber] = await getDepositIdAtBlock(spokePool, blockNumber);
     }
     return queriedIds[blockNumber];
   };
@@ -141,5 +137,10 @@ export async function getBlockRangeForDepositId(
  * @returns The deposit ID.
  */
 export async function getDepositIdAtBlock(contract: SpokePool, blockTag: number): Promise<number> {
-  return await contract.numberOfDeposits({ blockTag });
+  const depositIdAtBlock = await contract.numberOfDeposits({ blockTag });
+  // Sanity check to ensure that the deposit ID is an integer and is greater than or equal to zero.
+  if (!Number.isInteger(depositIdAtBlock) || depositIdAtBlock < 0) {
+    throw new Error("Invalid deposit count");
+  }
+  return depositIdAtBlock;
 }

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -123,7 +123,7 @@ export async function getBlockRangeForDepositId(
 
   // Sanity check to ensure that our low was not greater than our high.
   if (low > high) {
-    throw new Error("Binary search failed. (low > high) SHOULD NEVER HAPPEN (but here we are)");
+    throw new Error(`Binary search failed (${low} > ${high}). SHOULD NEVER HAPPEN (but here we are)`);
   }
 
   // We've either found the block range or we've exceeded the maximum number of searches.

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -1,4 +1,4 @@
-import { SpokePool } from "../typechain";
+import { Contract } from "ethers";
 
 /**
  * Find the block range that contains the deposit ID. This is a binary search that searches for the block range
@@ -20,7 +20,7 @@ export async function getBlockRangeForDepositId(
   initLow: number,
   initHigh: number,
   maxSearches: number,
-  spokePool: SpokePool,
+  spokePool: Contract,
   deploymentBlock = 0
 ): Promise<{
   low: number;
@@ -141,7 +141,7 @@ export async function getBlockRangeForDepositId(
  * @param blockTag The block number to search for the deposit ID at.
  * @returns The deposit ID.
  */
-export async function getDepositIdAtBlock(contract: SpokePool, blockTag: number): Promise<number> {
+export async function getDepositIdAtBlock(contract: Contract, blockTag: number): Promise<number> {
   const depositIdAtBlock = await contract.numberOfDeposits({ blockTag });
   // Sanity check to ensure that the deposit ID is an integer and is greater than or equal to zero.
   if (!Number.isInteger(depositIdAtBlock) || depositIdAtBlock < 0) {


### PR DESCRIPTION
There is a bug in the binary search function of the SpokePoolClient where, if the deposit ID is outside the range, then it still returns a non-failing value. This PR changes that by adding an additional safety check to ensure that the largest deposit ID is greater than or equal to the target search.