### PR TITLE
fix: disallow computing lp fees for future timestamps

### DIFF
--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -270,6 +270,13 @@ export class HubPoolClient extends BaseAbstractClient {
     if (!isDefined(this.currentTime)) {
       throw new Error("HubPoolClient has not set a currentTime");
     }
+
+    if (deposit.quoteTimestamp > this.currentTime) {
+      throw new Error(
+        `Cannot compute lp fee percent for quote timestamp ${deposit.quoteTimestamp} in the future. Current time: ${this.currentTime}.`
+      );
+    }
+
     const quoteBlock = await this.getBlockNumber(deposit.quoteTimestamp);
     if (!isDefined(quoteBlock)) {
       throw new Error(`Could not find block for timestamp ${deposit.quoteTimestamp}`);

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -10,6 +10,7 @@ import {
   MAX_BIG_INT,
   stringifyJSONWithNumericString,
   toBN,
+  isDefined,
 } from "../utils";
 import { validateFillForDeposit, filledSameDeposit } from "../utils/FlowUtils";
 import {
@@ -672,6 +673,11 @@ export class SpokePoolClient extends BaseAbstractClient {
       }
     }
 
+    const hubCurrentTime = this.hubPoolClient?.currentTime;
+    if (!isDefined(hubCurrentTime)) {
+      throw new Error("HubPoolClient's currentTime is not defined");
+    }
+
     // For each depositEvent, compute the realizedLpFeePct. Note this means that we are only finding this value on the
     // new deposits that were found in the searchConfig (new from the previous run). This is important as this operation
     // is heavy as there is a fair bit of block number lookups that need to happen. Note this call REQUIRES that the
@@ -682,7 +688,7 @@ export class SpokePoolClient extends BaseAbstractClient {
         ...this.earlyDeposits,
       ];
       const { earlyDeposits = [], depositEvents = [] } = groupBy(allDeposits, (depositEvent) => {
-        if (depositEvent.args.quoteTimestamp > currentTime) {
+        if (depositEvent.args.quoteTimestamp > currentTime || depositEvent.args.quoteTimestamp > hubCurrentTime) {
           const { args, transactionHash } = depositEvent;
           this.logger.debug({
             at: "SpokePoolClient#update",


### PR DESCRIPTION
This should not happen, in general, but this adds a check to throw an error if a future timestamp is ever requested.