### PR TITLE
feat: carry in `createFormatFunction`

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@pinata/sdk": "^2.1.0",
     "@uma/sdk": "^0.34.1",
     "axios": "^0.27.2",
+    "big-number": "^2.0.0",
     "decimal.js": "^10.3.1",
     "ethers": "^5.7.2",
     "lodash.get": "^4.4.2",

--- a/src/utils/FormattingUtils.ts
+++ b/src/utils/FormattingUtils.ts
@@ -1,10 +1,57 @@
-import { ethers, BigNumber } from "ethers";
-import { createFormatFunction } from "@uma/common";
-import { toBN } from "./BigNumberUtils";
+import { ethers } from "ethers";
+import { BN, toBN } from "./BigNumberUtils";
+import { fromWei } from "./common";
+import assert from "assert";
+import { BigNumber } from "bignumber.js";
 
-export { createFormatFunction };
+// Formats the input to round to decimalPlaces number of decimals if the number has a magnitude larger than 1 and fixes
+// precision to minPrecision if the number has a magnitude less than 1.
+export const formatWithMaxDecimals = (
+  num: number | string,
+  decimalPlaces: number,
+  minPrecision: number,
+  roundUp: boolean,
+  showSign: boolean
+): string => {
+  if (roundUp) {
+    BigNumber.set({ ROUNDING_MODE: BigNumber.ROUND_UP });
+  } else {
+    BigNumber.set({ ROUNDING_MODE: BigNumber.ROUND_DOWN });
+  }
 
-export const formatFeePct = (relayerFeePct: BigNumber): string => {
+  const fullPrecisionFloat = new BigNumber(num);
+  const positiveSign = showSign && fullPrecisionFloat.gt(0) ? "+" : "";
+  let fixedPrecisionFloat;
+  // Convert back to BN to truncate any trailing 0s that the toFixed() output would print. If the number is equal to or larger than
+  // 1 then truncate to `decimalPlaces` number of decimal places. EG 999.999 -> 999.99 with decimalPlaces=2 If the number
+  // is less than 1 then truncate to minPrecision precision. EG: 0.0022183471 -> 0.002218 with minPrecision=4
+  if (fullPrecisionFloat.abs().gte(new BigNumber(1))) {
+    fixedPrecisionFloat = new BigNumber(fullPrecisionFloat).toFixed(decimalPlaces).toString();
+  } else {
+    fixedPrecisionFloat = new BigNumber(fullPrecisionFloat).toPrecision(minPrecision).toString();
+  }
+  // This puts commas in the thousands places, but only before the decimal point.
+  const fixedPrecisionFloatParts = fixedPrecisionFloat.split(".");
+  fixedPrecisionFloatParts[0] = fixedPrecisionFloatParts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  return positiveSign + fixedPrecisionFloatParts.join(".");
+};
+
+export const createFormatFunction = (
+  numDisplayedDecimals: number,
+  minDisplayedPrecision: number,
+  showSign = false,
+  decimals = 18
+) => {
+  return (valInWei: string | BN): string =>
+    formatWithMaxDecimals(
+      formatWei(ConvertDecimals(decimals, 18)(valInWei)),
+      numDisplayedDecimals,
+      minDisplayedPrecision,
+      false,
+      showSign
+    );
+};
+export const formatFeePct = (relayerFeePct: BN): string => {
   // 1e18 = 100% so 1e16 = 1%.
   return createFormatFunction(2, 4, false, 16)(toBN(relayerFeePct).toString());
 };
@@ -64,7 +111,7 @@ export function hexToUtf8(input: string): string {
  * @param input - The BigNumber to convert.
  * @returns The 32-byte hexadecimal string representation of the input.
  */
-export function bnToHex(input: BigNumber): string {
+export function bnToHex(input: BN): string {
   return ethers.utils.hexZeroPad(ethers.utils.hexlify(toBN(input)), 32);
 }
 
@@ -88,3 +135,34 @@ export function convertFromWei(weiVal: string, decimals: number): string {
 export function shortenHexStrings(addresses: string[]): string[] {
   return addresses.map((h) => createShortHexString(h));
 }
+
+// formatWei converts a string or BN instance from Wei to Ether, e.g., 1e19 -> 10.
+export const formatWei = (num: string | BN): string => {
+  // Web3's `fromWei` function doesn't work on BN objects in minified mode (e.g.,
+  // `web3.utils.isBN(web3.utils.fromBN("5"))` is false), so we use a workaround where we always pass in strings.
+  // See https://github.com/ethereum/web3.js/issues/1777.
+  return fromWei(num.toString());
+};
+
+// Take an amount based on fromDecimals and convert it to an amount based on toDecimals. For example 100 usdt = 100e6,
+// with 6 decimals. If you wanted to convert this to a base 18 decimals you would get:
+// convertDecimals(6,18)(100000000)  => 100000000000000000000 = 100e18.
+// Returns a BigNumber you will need to call toString on
+// fromDecimals: number - decimal value of amount
+// toDecimals: number - decimal value to convert to
+// web3: web3 object to get a big number function.
+// return => (amount:string)=>BN
+export const ConvertDecimals = (fromDecimals: number, toDecimals: number): ((amountIn: string | number | BN) => BN) => {
+  assert(fromDecimals >= 0, "requires fromDecimals as an integer >= 0");
+  assert(toDecimals >= 0, "requires toDecimals as an integer >= 0");
+  // amount: string, BN, number - integer amount in fromDecimals smallest unit that want to convert toDecimals
+  // returns: BN with toDecimals in smallest unit
+  return (amountIn: string | number | BN) => {
+    const amount = toBN(amountIn.toString());
+    if (amount.isZero()) return amount;
+    const diff = fromDecimals - toDecimals;
+    if (diff == 0) return amount;
+    if (diff > 0) return amount.div(toBN("10").pow(toBN(diff.toString())));
+    return amount.mul(toBN("10").pow(toBN((-1 * diff).toString())));
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4915,6 +4915,11 @@ big-integer@^1.6.44:
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
   integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
 
+big-number@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/big-number/-/big-number-2.0.0.tgz#98548eda9393b445791670a213aed6f6dcd66ee3"
+  integrity sha512-C67Su0g+XsmXADX/UM9L/+xSbqqwq0D/qGJs2ky6Noy2FDuCZnC38ZSXODiaBvqWma2VYRZEXgm4H74PS6tCDg==
+
 big.js@^6.0.3:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-6.1.1.tgz#63b35b19dc9775c94991ee5db7694880655d5537"


### PR DESCRIPTION
This PR carries over the `createFormatFunction` from `@uma/common` into the `@across-protocol/sdk-v2` directly.