### PR TITLE
refactor: Hoist HubPool off UMA dependencies

### DIFF
--- a/src/contracts/utils.ts
+++ b/src/contracts/utils.ts
@@ -1,0 +1,53 @@
+import assert from "assert";
+import { BigNumber, BigNumberish, Event } from "ethers";
+import { isDefined } from "../utils";
+
+/**
+ * Migrated directly from @uma/sdk.
+ * @dev This code is intended to support existing use of contracts/hubPool.ts and should not be used for new code.
+ * @todo Refactor contracts/hubPool.ts to avoid the need for this.
+ */
+
+// useful for maintaining balances from events
+export type Balances = { [key: string]: string };
+
+export function Balances(balances: Balances = {}) {
+  function create(id: string, amount = "0") {
+    assert(!has(id), "balance already exists");
+    return set(id, amount);
+  }
+
+  function has(id: string) {
+    return isDefined(balances[id]);
+  }
+
+  function set(id: string, amount: string) {
+    balances[id] = amount;
+    return amount;
+  }
+
+  function add(id: string, amount: BigNumberish) {
+    return set(id, BigNumber.from(amount).add(getOrCreate(id)).toString());
+  }
+
+  function sub(id: string, amount: BigNumberish) {
+    return set(id, BigNumber.from(getOrCreate(id)).sub(amount).toString());
+  }
+
+  function get(id: string) {
+    assert(has(id), "balance does not exist");
+    return balances[id];
+  }
+
+  function getOrCreate(id: string) {
+    if (has(id)) return get(id);
+    return create(id);
+  }
+
+  return { create, add, sub, get, balances, set, has, getOrCreate };
+}
+
+export type SerializableEvent = Omit<
+  Event,
+  "decode" | "removeListener" | "getBlock" | "getTransaction" | "getTransactionReceipt"
+>;


### PR DESCRIPTION
This PR migrates in `Balances` (type and function) and 
`SerializableEvent` from @uma. It also refactors the `reduceEvents`
function to avoid the need for generics. This has a nice side-effect of
removing a lot of duplicated code, so the implementation becomes
simpler.

This hubPool implementation is only used by the poolClient class, and I
have verified the pre- and post-change behaviour via `poolClient.e2e.ts`
- it can still extract the necessary event data after this change.