### PR TITLE
refactor: New UMA SDK imports

### DIFF
--- a/src/interfaces/ConfigStore.ts
+++ b/src/interfaces/ConfigStore.ts
@@ -1,12 +1,12 @@
 import { BigNumber } from "ethers";
+import { RateModelDictionary } from "../lpFeeCalculator/rateModel";
 import { SortableEvent } from "./Common";
-import { across } from "@uma/sdk";
 
 export interface ParsedTokenConfig {
   transferThreshold: string;
-  rateModel: across.rateModel.RateModelDictionary;
+  rateModel: RateModelDictionary;
   routeRateModel?: {
-    [path: string]: across.rateModel.RateModelDictionary;
+    [path: string]: RateModelDictionary;
   };
   uba?: UBAOnChainConfigType;
   spokeTargetBalances?: {

--- a/src/lpFeeCalculator/rateModel.ts
+++ b/src/lpFeeCalculator/rateModel.ts
@@ -1,0 +1,183 @@
+import { ethers } from "ethers";
+import { isDefined } from "../utils";
+
+// Each L1 token is mapped to an array of stringified rate models, ordered by the block height at which they were
+// published on-chain. This dictionary is used internally to fetch a rate model for a block height.
+type RateModelEventsDictionary = {
+  [l1TokenAddress: string]: { blockNumber: number; rateModel: string }[];
+};
+
+// Events should be reformatted into this shape to be used as input into methods in this file.
+export type RateModelEvent = {
+  blockNumber: number;
+  transactionIndex: number;
+  logIndex: number;
+  rateModel: string;
+  l1Token: string;
+};
+
+interface RateModel {
+  UBar: string; // denote the utilization kink along the rate model where the slope of the interest rate model changes.
+  R0: string; // is the interest rate charged at 0 utilization
+  R1: string; // R_0+R_1 is the interest rate charged at UBar
+  R2: string; // R_0+R_1+R_2 is the interest rate charged at 100% utilization
+}
+
+const expectedRateModelKeys = ["UBar", "R0", "R1", "R2"];
+
+export class RateModelDictionary {
+  public rateModelDictionary: RateModelEventsDictionary = {};
+
+  private _throwIfNotInitialized() {
+    if (Object.keys(this.rateModelDictionary).length == 0)
+      throw new Error("RateModelUtility method called before updating rate model dictionary!");
+  }
+
+  updateWithEvents(rateModelEvents: RateModelEvent[]): void {
+    this.rateModelDictionary = createRateModelEventDictionary(rateModelEvents);
+  }
+
+  /**
+   * Return the rate model for L1 token set at the block height.
+   * @param l1Token L1 token address to get rate model for.
+   * @param blockNumber Block height to get rate model for.
+   * @returns Rate model object.
+   */
+  getRateModelForBlockNumber(l1Token: string, blockNumber?: number): RateModel {
+    this._throwIfNotInitialized();
+
+    const l1TokenNormalized = ethers.utils.getAddress(l1Token);
+
+    if (!this.rateModelDictionary[l1TokenNormalized] || this.rateModelDictionary[l1TokenNormalized].length === 0)
+      throw new Error(`No updated rate model events for L1 token: ${l1TokenNormalized}`);
+
+    if (!blockNumber) {
+      // If block number is undefined, use latest updated rate model.
+      return parseAndReturnRateModelFromString(this.rateModelDictionary[l1TokenNormalized].slice(-1)[0].rateModel);
+    } else {
+      const firstEventBlockNumber = this.rateModelDictionary[l1TokenNormalized][0].blockNumber;
+      if (blockNumber < firstEventBlockNumber) {
+        throw new Error(
+          `Block number #${blockNumber} is before first UpdatedRateModel event block ${firstEventBlockNumber}`
+        );
+      }
+
+      // We're looking for the latest rate model update that occurred at or before the block number.
+      // Rate model events are inserted into the array from oldest at index 0 to newest at index length-1, so we'll
+      // reverse the array so it goes from newest at index 0 to oldest at index length-1, and then find the first event
+      // who's block number is less than or equal to the target block number.
+      const rateModel = this.rateModelDictionary[l1TokenNormalized]
+        .slice()
+        .reverse() // reverse() modifies memory in place so create a copy first.
+        .find((event) => event.blockNumber <= blockNumber);
+
+      if (!rateModel)
+        throw new Error(`No updated rate model events before block #${blockNumber} for L1 token: ${l1TokenNormalized}`);
+      return parseAndReturnRateModelFromString(rateModel?.rateModel);
+    }
+  }
+
+  /**
+   * @notice Return all L1 tokens that had a rate model associated with it at the block number.
+   * @param blockNumber Returns l1 tokens that were mapped to a rate model at this block height. If undefined,
+   * this function will return all L1 tokens that have a block number as of the latest block height.
+   * @returns array of L1 token addresses.
+   */
+  getL1TokensFromRateModel(blockNumber: number | undefined = undefined): string[] {
+    this._throwIfNotInitialized();
+
+    return Object.keys(this.rateModelDictionary)
+      .map((l1Token) => {
+        const l1TokenNormalized = ethers.utils.getAddress(l1Token);
+
+        // Check that there is at least one UpdatedRateModel event before the provided block number, otherwise
+        // this L1 token didn't exist in the RateModel at the block height and we shouldn't include it in the returned
+        // array.
+        if (
+          !blockNumber ||
+          this.rateModelDictionary[l1TokenNormalized].find((event) => event.blockNumber <= blockNumber)
+        )
+          return ethers.utils.getAddress(l1Token);
+        else return null;
+      })
+      .filter(isDefined);
+  }
+}
+
+/**
+ * Helper method that returns parsed rate model from string, or throws.
+ * @param rateModelString Stringified rate model to parse.
+ * @returns Rate model object. Must conform to `expectedRateModelKeys` format.
+ */
+export const parseAndReturnRateModelFromString = (rateModelString: string): RateModel => {
+  const rateModelFromEvent = JSON.parse(rateModelString);
+
+  // Rate model must contain the exact same keys in `expectedRateModelKeys`.
+  for (const key of expectedRateModelKeys) {
+    if (!Object.keys(rateModelFromEvent).includes(key)) {
+      throw new Error(
+        `Rate model does not contain all expected keys. Expected keys: [${expectedRateModelKeys}], actual keys: [${Object.keys(
+          rateModelFromEvent
+        )}]`
+      );
+    }
+  }
+
+  for (const key of Object.keys(rateModelFromEvent)) {
+    if (!expectedRateModelKeys.includes(key)) {
+      throw new Error(
+        `Rate model contains unexpected keys. Expected keys: [${expectedRateModelKeys}], actual keys: [${Object.keys(
+          rateModelFromEvent
+        )}]`
+      );
+    }
+  }
+
+  return {
+    UBar: rateModelFromEvent.UBar,
+    R0: rateModelFromEvent.R0,
+    R1: rateModelFromEvent.R1,
+    R2: rateModelFromEvent.R2,
+  };
+};
+
+/**
+ * Given an unsorted array of updated rate model events, return a dictionary mapping token addresses to sorted
+ * rate model events. This method is used internally to enforce chronological sorting of events and mapping rate models
+ * to token addresses.
+ * @param rateModelEvents Unsorted updated rate model events, each of which contains a token address, the stringified
+ * rate model for that token, and the block height of the update.
+ * @returns Dictionary mapping token addresses to chronologically sorted rate model updates.
+ */
+const createRateModelEventDictionary = (rateModelEvents: RateModelEvent[]): RateModelEventsDictionary => {
+  const updatedRateModelEventsForToken: RateModelEventsDictionary = {};
+
+  // Sort events in-place from oldest to newest:
+  rateModelEvents.sort((a, b) => {
+    if (a.blockNumber !== b.blockNumber) {
+      return a.blockNumber - b.blockNumber;
+    }
+
+    if (a.transactionIndex !== b.transactionIndex) {
+      return a.transactionIndex - b.transactionIndex;
+    }
+
+    return a.logIndex - b.logIndex;
+  });
+
+  for (const updatedRateModelEvent of rateModelEvents) {
+    // The contract enforces that all rate models are mapped to addresses, therefore we do not need to check that
+    // `l1Token` is a valid address.
+    const l1TokenNormalized = ethers.utils.getAddress(updatedRateModelEvent.l1Token);
+    if (!updatedRateModelEventsForToken[l1TokenNormalized]) updatedRateModelEventsForToken[l1TokenNormalized] = [];
+
+    // We assume that events are returned from oldest to newest, so we can simply push events into the array and
+    // and maintain their time order.
+    updatedRateModelEventsForToken[l1TokenNormalized].push({
+      blockNumber: updatedRateModelEvent.blockNumber,
+      rateModel: updatedRateModelEvent.rateModel,
+    });
+  }
+
+  return updatedRateModelEventsForToken;
+};

--- a/src/pool/TransactionManager.ts
+++ b/src/pool/TransactionManager.ts
@@ -1,0 +1,73 @@
+import assert from "assert";
+import { Signer } from "ethers";
+import { TransactionRequest, TransactionReceipt } from "@ethersproject/abstract-provider";
+
+function makeKey(tx: TransactionRequest) {
+  return JSON.stringify(
+    Object.entries(tx).map(([key, value]) => {
+      return [key, (value || "").toString()];
+    })
+  );
+}
+
+type Config = {
+  confirmations?: number;
+};
+export type Emit = (event: string, key: string, data: TransactionReceipt | string | TransactionRequest | Error) => void;
+export default (config: Config, signer: Signer, emit: Emit = () => null) => {
+  assert(signer.provider, "signer requires a provider, use signer.connect(provider)");
+  const { confirmations = 3 } = config;
+  const requests = new Map<string, TransactionRequest>();
+  const submissions = new Map<string, string>();
+  const mined = new Map<string, TransactionReceipt>();
+  function request(unsignedTx: TransactionRequest) {
+    // this no longer calls signer.populateTransaction, to allow metamask to fill in missing details instead
+    // use overrides if you want to manually fill in other tx details, including the overrides.customData field.
+    const populated = unsignedTx;
+    const key = makeKey(populated);
+    assert(!requests.has(key), "Transaction already in progress");
+    requests.set(key, populated);
+    return key;
+  }
+  async function processRequest(key: string) {
+    const request = requests.get(key);
+    assert(request, "invalid request");
+    // always delete request, it should only be submitted once
+    requests.delete(key);
+    try {
+      const sent = await signer.sendTransaction(request);
+      submissions.set(key, sent.hash);
+      emit("submitted", key, sent.hash);
+    } catch (err) {
+      emit("error", key, err as Error);
+    }
+  }
+  async function processSubmission(key: string) {
+    const hash = submissions.get(key);
+    assert(hash, "invalid submission");
+    assert(signer.provider, "signer requires a provider, use signer.connect(provider)");
+    // we look for this transaction, but it may never find it if its sped up
+    const receipt = await signer.provider.getTransactionReceipt(hash).catch(() => undefined);
+    if (receipt == null) return;
+    if (receipt.confirmations < confirmations) return;
+    submissions.delete(key);
+    mined.set(key, receipt);
+    emit("mined", key, receipt);
+  }
+  async function isMined(key: string) {
+    return mined.get(key);
+  }
+  async function update() {
+    for (const key of requests.keys()) {
+      await processRequest(key);
+    }
+    for (const key of submissions.keys()) {
+      await processSubmission(key);
+    }
+  }
+  return {
+    request,
+    isMined,
+    update,
+  };
+};


### PR DESCRIPTION
Import the following from the UMA repo:
 - RateModelDictionary class (+ related definitions).
 - TransactionManager closure.

It was very simple to hoist the ConfigStore interface over to the new local definitions, so that has been applied here. Subsequent changes are needed for the TransactionManager; those will be applied in a follow-up commit so the modifications are explicitly identified.