### PR TITLE
chore: Bump poolClient e2e test timeout

### DIFF
--- a/src/pool/poolClient.e2e.ts
+++ b/src/pool/poolClient.e2e.ts
@@ -58,7 +58,6 @@ describe("PoolClient", function () {
     );
   });
   test("read users", async function () {
-    jest.setTimeout(30000);
     for (const userAddress of users) {
       for (const l1Token of l1Tokens) {
         await client.updateUser(userAddress, l1Token);
@@ -68,5 +67,5 @@ describe("PoolClient", function () {
         assert.ok(user);
       }
     }
-  });
+  }, 120000);
 });


### PR DESCRIPTION
This test falls back to public RPC endpoints, so it's necessary to bump the timeout to account for rate-limiting. Also, jest.setTimeout() changes the global timeout for the test file, so ensure that the increased timeout only applies to the specific test in question.