### PR TITLE
revert: don't error when handling future quote timestamps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.15.23",
+  "version": "0.15.24",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -306,13 +306,6 @@ export class HubPoolClient extends BaseAbstractClient {
     if (!isDefined(this.currentTime)) {
       throw new Error("HubPoolClient has not set a currentTime");
     }
-
-    if (deposit.quoteTimestamp > this.currentTime) {
-      throw new Error(
-        `Cannot compute lp fee percent for quote timestamp ${deposit.quoteTimestamp} in the future. Current time: ${this.currentTime}.`
-      );
-    }
-
     const quoteBlock = await this.getBlockNumber(deposit.quoteTimestamp);
     if (!isDefined(quoteBlock)) {
       throw new Error(`Could not find block for timestamp ${deposit.quoteTimestamp}`);

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -10,7 +10,6 @@ import {
   MAX_BIG_INT,
   stringifyJSONWithNumericString,
   toBN,
-  isDefined,
 } from "../utils";
 import { validateFillForDeposit, filledSameDeposit } from "../utils/FlowUtils";
 import {
@@ -673,11 +672,6 @@ export class SpokePoolClient extends BaseAbstractClient {
       }
     }
 
-    const hubCurrentTime = this.hubPoolClient?.currentTime;
-    if (!isDefined(hubCurrentTime)) {
-      throw new Error("HubPoolClient's currentTime is not defined");
-    }
-
     // For each depositEvent, compute the realizedLpFeePct. Note this means that we are only finding this value on the
     // new deposits that were found in the searchConfig (new from the previous run). This is important as this operation
     // is heavy as there is a fair bit of block number lookups that need to happen. Note this call REQUIRES that the
@@ -688,7 +682,7 @@ export class SpokePoolClient extends BaseAbstractClient {
         ...this.earlyDeposits,
       ];
       const { earlyDeposits = [], depositEvents = [] } = groupBy(allDeposits, (depositEvent) => {
-        if (depositEvent.args.quoteTimestamp > currentTime || depositEvent.args.quoteTimestamp > hubCurrentTime) {
+        if (depositEvent.args.quoteTimestamp > currentTime) {
           const { args, transactionHash } = depositEvent;
           this.logger.debug({
             at: "SpokePoolClient#update",


### PR DESCRIPTION
This reverts commit a43657b3ad34c7239b5b88264ce71c0fcf767209.

The relayer-v2 tests are not well equipped yet to handle this change

Ideally this change gets reimplemented but perhaps at the relayer/dataworker level