### PR TITLE
fix: Move transfer threshold max supported version down to current version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "license": "AGPL-3.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -51,4 +51,3 @@ export const DEFAULT_CACHING_TTL = 60 * 60 * 24 * 7 * 2; // 2 Weeks
 
 export const UBA_BOUNDS_RANGE_MAX = BigNumber.from(String(Number.MAX_SAFE_INTEGER)).mul(utils.parseEther("1.0"));
 export const UBA_BOUNDS_RANGE_MIN = UBA_BOUNDS_RANGE_MAX.mul(-1);
-

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,7 +14,7 @@ export const SECONDS_PER_YEAR = 31557600; // 365.25 days per year.
 export const HUBPOOL_CHAIN_ID = 1;
 
 // List of versions where certain UMIP features were deprecated
-export const TRANSFER_THRESHOLD_MAX_CONFIG_STORE_VERSION = 2;
+export const TRANSFER_THRESHOLD_MAX_CONFIG_STORE_VERSION = 1;
 
 /**
  * A default list of chain Ids that the protocol supports. This is outlined

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -51,3 +51,4 @@ export const DEFAULT_CACHING_TTL = 60 * 60 * 24 * 7 * 2; // 2 Weeks
 
 export const UBA_BOUNDS_RANGE_MAX = BigNumber.from(String(Number.MAX_SAFE_INTEGER)).mul(utils.parseEther("1.0"));
 export const UBA_BOUNDS_RANGE_MIN = UBA_BOUNDS_RANGE_MAX.mul(-1);
+


### PR DESCRIPTION
We should support `transferThreshold` before but not including version 2