### PR TITLE
feat: failover historic query if deposit is malformed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/v/developer-docs/developers/across-sdk",
   "files": [

--- a/src/utils/DepositUtils.ts
+++ b/src/utils/DepositUtils.ts
@@ -65,6 +65,9 @@ export async function queryHistoricalDepositForFill(
         fill,
         cachedDeposit,
       });
+      // By setting this value to undefined, we eventually have to pull
+      // the deposit from our spoke pool client. Because this new deposit
+      // is formed correctly, we will cache it below.
       cachedDeposit = undefined;
     }
   }

--- a/src/utils/DepositUtils.ts
+++ b/src/utils/DepositUtils.ts
@@ -55,6 +55,9 @@ export async function queryHistoricalDepositForFill(
   let deposit: DepositWithBlock, cachedDeposit: Deposit | undefined;
   if (cache) {
     cachedDeposit = await getDepositInCache(getDepositKey(fill), cache);
+    // We only want to warn and remove the cached deposit if it
+    //    A: exists
+    //    B: is not formed correctly
     if (isDefined(cachedDeposit) && !isDepositFormedCorrectly(cachedDeposit)) {
       spokePoolClient.logger.warn({
         at: "[SDK]:DepositUtils#queryHistoricalDepositForFill",

--- a/src/utils/ValidatorUtils.ts
+++ b/src/utils/ValidatorUtils.ts
@@ -1,0 +1,29 @@
+import { BigNumber, ethers } from "ethers";
+import { object, number as Number, min as Min, define, optional, string } from "superstruct";
+import { Deposit } from "../interfaces";
+
+const AddressValidator = define<string>("AddressValidator", (v) => ethers.utils.isAddress(String(v)));
+const BigNumberValidator = define<BigNumber>("BigNumberValidator", (v) => ethers.BigNumber.isBigNumber(v));
+
+const DepositSchema = object({
+  depositId: Min(Number(), 0),
+  depositor: AddressValidator,
+  recipient: AddressValidator,
+  originToken: AddressValidator,
+  amount: BigNumberValidator,
+  originChainId: Min(Number(), 0),
+  destinationChainId: Min(Number(), 0),
+  relayerFeePct: BigNumberValidator,
+  quoteTimestamp: Min(Number(), 0),
+  realizedLpFeePct: optional(BigNumberValidator),
+  destinationToken: AddressValidator,
+  message: string(),
+  speedUpSignature: optional(string()),
+  newRelayerFeePct: optional(BigNumberValidator),
+  updatedRecipient: optional(string()),
+  updatedMessage: optional(string()),
+});
+
+export function isDepositFormedCorrectly(deposit: unknown): deposit is Deposit {
+  return DepositSchema.is(deposit);
+}

--- a/src/utils/ValidatorUtils.ts
+++ b/src/utils/ValidatorUtils.ts
@@ -1,20 +1,21 @@
 import { BigNumber, ethers } from "ethers";
-import { object, number as Number, min as Min, define, optional, string } from "superstruct";
-import { Deposit } from "../interfaces";
+import { object, min as Min, define, optional, string, integer } from "superstruct";
+import { DepositWithBlock } from "../interfaces";
 
 const AddressValidator = define<string>("AddressValidator", (v) => ethers.utils.isAddress(String(v)));
+const HexValidator = define<string>("HexValidator", (v) => ethers.utils.isHexString(String(v)));
 const BigNumberValidator = define<BigNumber>("BigNumberValidator", (v) => ethers.BigNumber.isBigNumber(v));
 
 const DepositSchema = object({
-  depositId: Min(Number(), 0),
+  depositId: Min(integer(), 0),
   depositor: AddressValidator,
   recipient: AddressValidator,
   originToken: AddressValidator,
   amount: BigNumberValidator,
-  originChainId: Min(Number(), 0),
-  destinationChainId: Min(Number(), 0),
+  originChainId: Min(integer(), 0),
+  destinationChainId: Min(integer(), 0),
   relayerFeePct: BigNumberValidator,
-  quoteTimestamp: Min(Number(), 0),
+  quoteTimestamp: Min(integer(), 0),
   realizedLpFeePct: optional(BigNumberValidator),
   destinationToken: AddressValidator,
   message: string(),
@@ -22,8 +23,14 @@ const DepositSchema = object({
   newRelayerFeePct: optional(BigNumberValidator),
   updatedRecipient: optional(string()),
   updatedMessage: optional(string()),
+  blockNumber: Min(integer(), 0),
+  transactionIndex: Min(integer(), 0),
+  logIndex: Min(integer(), 0),
+  quoteBlockNumber: Min(integer(), 0),
+  transactionHash: HexValidator,
+  blockTimestamp: optional(Min(integer(), 0)),
 });
 
-export function isDepositFormedCorrectly(deposit: unknown): deposit is Deposit {
+export function isDepositFormedCorrectly(deposit: unknown): deposit is DepositWithBlock {
   return DepositSchema.is(deposit);
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -22,3 +22,4 @@ export * from "./CachingUtils";
 export * from "./NetworkUtils";
 export * from "./ReviverUtils";
 export * from "./DepositUtils";
+export * from "./ValidatorUtils";

--- a/test/validatorUtils.test.ts
+++ b/test/validatorUtils.test.ts
@@ -3,10 +3,12 @@ import { utils, interfaces } from "../src";
 import { ZERO_ADDRESS } from "../src/constants";
 import { toBN } from "@across-protocol/contracts-v2";
 import { cloneDeep } from "lodash";
+import { objectWithBigNumberReviver } from "../src/utils";
+import { Deposit } from "../src/interfaces";
 
 describe("validatorUtils", () => {
   describe("isDeposit", () => {
-    let deposit: interfaces.Deposit;
+    let deposit: interfaces.DepositWithBlock;
     beforeEach(() => {
       deposit = {
         depositId: 1,
@@ -21,6 +23,12 @@ describe("validatorUtils", () => {
         originToken: ZERO_ADDRESS,
         relayerFeePct: toBN(0),
         destinationToken: ZERO_ADDRESS,
+        transactionHash: "0xa",
+        blockNumber: 0,
+        transactionIndex: 0,
+        logIndex: 0,
+        quoteBlockNumber: 0,
+        blockTimestamp: 0,
       };
     });
 
@@ -75,6 +83,13 @@ describe("validatorUtils", () => {
         // Ensure that the deposit is now invalid
         expect(utils.isDepositFormedCorrectly(depositCopy)).to.be.false;
       }
+    });
+    it("should successfully rehydrate real deposits", () => {
+      const deposits: string[] = [
+        '{"amount":{"type":"BigNumber","hex":"0x038d7ea4c68000"},"originChainId":42161,"destinationChainId":10,"relayerFeePct":{"type":"BigNumber","hex":"0xee042a4c72e9a8"},"depositId":1160366,"quoteTimestamp":1697088000,"originToken":"0x82aF49447D8a07e3bd95BD0d56f35241523fBab1","recipient":"0x525D59654479cFaED622C1Ca06f237ce1072c2AB","depositor":"0x269727F088F16E1Aea52Cf5a97B1CD41DAA3f02D","message":"0x","blockNumber":139874261,"transactionIndex":1,"logIndex":1,"transactionHash":"0x4c4273f4cceb288a76aa7d6c057a8e3ab571a19711a59a965726e06b04e6b821","realizedLpFeePct":{"type":"BigNumber","hex":"0x016b90ac8ef5b9"},"destinationToken":"0x4200000000000000000000000000000000000006","quoteBlockNumber":18332204}',
+      ];
+      const rehydratedDeposits = deposits.map((d) => JSON.parse(d, objectWithBigNumberReviver) as Deposit);
+      expect(rehydratedDeposits.every(utils.isDepositFormedCorrectly)).to.be.true;
     });
   });
 });

--- a/test/validatorUtils.test.ts
+++ b/test/validatorUtils.test.ts
@@ -1,0 +1,80 @@
+import { expect } from "chai";
+import { utils, interfaces } from "../src";
+import { ZERO_ADDRESS } from "../src/constants";
+import { toBN } from "@across-protocol/contracts-v2";
+import { cloneDeep } from "lodash";
+
+describe("validatorUtils", () => {
+  describe("isDeposit", () => {
+    let deposit: interfaces.Deposit;
+    beforeEach(() => {
+      deposit = {
+        depositId: 1,
+        depositor: ZERO_ADDRESS,
+        destinationChainId: 1,
+        originChainId: 1,
+        amount: toBN(100),
+        message: "",
+        quoteTimestamp: 0,
+        recipient: ZERO_ADDRESS,
+        updatedRecipient: ZERO_ADDRESS,
+        originToken: ZERO_ADDRESS,
+        relayerFeePct: toBN(0),
+        destinationToken: ZERO_ADDRESS,
+      };
+    });
+
+    it("should return false if an undefined value is passed", () => {
+      expect(utils.isDepositFormedCorrectly(undefined)).to.be.false;
+    });
+    it("should return true on positive conditions", () => {
+      // We should be able to return true for the default deposit
+      expect(utils.isDepositFormedCorrectly(deposit)).to.be.true;
+      // Let's change the recipient to a valid address
+      deposit.recipient = utils.randomAddress();
+      expect(utils.isDepositFormedCorrectly(deposit)).to.be.true;
+    });
+    it("should return false if deposit is not close to being formed correctly", () => {
+      // Empty Object
+      expect(utils.isDepositFormedCorrectly({})).to.be.false;
+      // A number
+      expect(utils.isDepositFormedCorrectly(1)).to.be.false;
+      // A string
+      expect(utils.isDepositFormedCorrectly("")).to.be.false;
+      // A boolean
+      expect(utils.isDepositFormedCorrectly(false)).to.be.false;
+      // An array
+      expect(utils.isDepositFormedCorrectly([])).to.be.false;
+      // A null value
+      expect(utils.isDepositFormedCorrectly(null)).to.be.false;
+      // A undefined value
+      expect(utils.isDepositFormedCorrectly(undefined)).to.be.false;
+    });
+    it("should return false for nearly valid deposits", () => {
+      // Construct a list of changes to make to the deposit to make it invalid
+      const changesToMakeInvalid: ((d: interfaces.Deposit) => unknown)[] = [
+        // Change the deposit ID to a negative number
+        (d) => (d.depositId = -1),
+        // Change the depositor to an invalid address
+        (d) => (d.depositor = "0x123"),
+        // Change the destination chain ID to a negative number
+        (d) => (d.destinationChainId = -1),
+        // Remove a required field
+        (d) => delete (d as unknown as Record<string, unknown>)["originChainId"],
+      ];
+
+      // Iterate over each change and ensure that the deposit is made to be invalid
+      // We can also sanity check that the deposit is valid before the change
+      for (const change of changesToMakeInvalid) {
+        // Perform a deep copy
+        const depositCopy = cloneDeep(deposit);
+        // Sanity check - ensure that default deposit is valid
+        expect(utils.isDepositFormedCorrectly(depositCopy)).to.be.true;
+        // Make the change
+        change(depositCopy);
+        // Ensure that the deposit is now invalid
+        expect(utils.isDepositFormedCorrectly(depositCopy)).to.be.false;
+      }
+    });
+  });
+});


### PR DESCRIPTION
We should allow our queries to _self-heal_ if they detect a malformed deposit. This will check if a deposit returned from the cache is malformed. If it is found to be malformed, we will ignore it and re-cache a correct version.