### PR TITLE
improve: enforce no capital cost default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/v/developer-docs/developers/across-sdk",
   "files": [

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -127,10 +127,11 @@ export class RelayFeeCalculator {
       "feeLimitPercent must be between 0 and 100 percent"
     );
     this.capitalCostsConfig = Object.fromEntries(
-      Object.entries(config.capitalCostsConfig || {}).map(([token, capitalCosts]) => {
+      Object.entries(config.capitalCostsConfig).map(([token, capitalCosts]) => {
         return [token.toUpperCase(), RelayFeeCalculator.validateAndTransformCapitalCostsConfigOverride(capitalCosts)];
       })
     );
+    assert(Object.keys(this.capitalCostsConfig).length > 0, "capitalCostsConfig must have at least one entry");
     this.logger = logger || DEFAULT_LOGGER;
   }
 

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -238,13 +238,10 @@ export class RelayFeeCalculator {
     // bound to an upper bound. After the kink, the fee % increase will be fixed, and slowly approach the upper bound
     // for very large amount inputs.
     else {
-      let config = tokenCostConfig.default;
-      if (_originRoute && _destinationRoute && tokenCostConfig.routeOverrides) {
-        const potentialDestinationRoutes = tokenCostConfig.routeOverrides[_originRoute];
-        if (potentialDestinationRoutes) {
-          config = potentialDestinationRoutes[_destinationRoute] || config;
-        }
-      }
+      const config =
+        isDefined(_originRoute) && isDefined(_destinationRoute)
+          ? tokenCostConfig.routeOverrides?.[_originRoute]?.[_destinationRoute] ?? tokenCostConfig.default
+          : tokenCostConfig.default;
 
       // Scale amount "y" to 18 decimals.
       const y = toBN(_amountToRelay).mul(toBNWei("1", 18 - config.decimals));

--- a/test/relayFeeCalculator.test.ts
+++ b/test/relayFeeCalculator.test.ts
@@ -6,7 +6,9 @@ import { assert, expect } from "./utils";
 dotenv.config({ path: ".env" });
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const testCapitalCostsConfig: { [token: string]: any } = {
+const testCapitalCostsConfig: {
+  [token: string]: { lowerBound: string; upperBound: string; cutoff: string; decimals: number };
+} = {
   WBTC: {
     lowerBound: toBNWei("0.0003").toString(),
     upperBound: toBNWei("0.002").toString(),
@@ -31,6 +33,12 @@ const testCapitalCostsConfig: { [token: string]: any } = {
     cutoff: "0",
     decimals: 8,
   },
+  USDC: {
+    lowerBound: toBNWei("0").toString(),
+    upperBound: toBNWei("0").toString(),
+    cutoff: toBNWei("0").toString(),
+    decimals: 6,
+  },
 };
 
 // Example of how to write this query class
@@ -54,7 +62,7 @@ describe("RelayFeeCalculator", () => {
     queries = new ExampleQueries();
   });
   it("gasPercentageFee", async () => {
-    client = new RelayFeeCalculator({ queries });
+    client = new RelayFeeCalculator({ queries, capitalCostsConfig: testCapitalCostsConfig });
     // A list of inputs and ground truth [input, ground truth]
     const gasFeePercents = [
       [0, Number.MAX_SAFE_INTEGER.toString()], // Infinite%
@@ -71,7 +79,8 @@ describe("RelayFeeCalculator", () => {
     }
   });
   it("relayerFeeDetails", async () => {
-    client = new RelayFeeCalculator({ queries });
+    client = new RelayFeeCalculator({ queries, capitalCostsConfig: testCapitalCostsConfig });
+
     const result = await client.relayerFeeDetails(100e6, "usdc");
     assert.ok(result);
 
@@ -90,7 +99,7 @@ describe("RelayFeeCalculator", () => {
     assert.equal(resultWithPrice.minDeposit, Number.MAX_SAFE_INTEGER.toString());
 
     // Set fee limit percent to 10%:
-    client = new RelayFeeCalculator({ queries, feeLimitPercent: 10 });
+    client = new RelayFeeCalculator({ queries, feeLimitPercent: 10, capitalCostsConfig: testCapitalCostsConfig });
     // Compute relay fee details for an $1000 transfer. Capital fee % is 0 so maxGasFeePercent should be equal to fee
     // limit percent.
     const relayerFeeDetails = await client.relayerFeeDetails(1000e6, "usdc");
@@ -171,11 +180,13 @@ describe("RelayFeeCalculator", () => {
     const client = new RelayFeeCalculator({
       queries,
       capitalCostsConfig: testCapitalCostsConfig,
-      capitalCostsPercent: 0.01,
     });
 
-    // If token doesn't have a config set, then returns default fixed fee %:
-    assert.equal((await client.capitalFeePercent(toBNWei("1"), "UNKNOWN")).toString(), toBNWei("0.0001").toString());
+    // If token doesn't have a config set, then throws an error.
+    assert.throws(
+      () => client.capitalFeePercent(toBNWei("1"), "UNKNOWN"),
+      /No capital cost config available for token/
+    );
 
     // Test with different decimals:
 


### PR DESCRIPTION
We shouldn't allow a default backup if a token doesn't have an associated default/overridden cost config. This is indicative of a malformed configuration.