### PR TITLE
feat: use new node_url for unit test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,3 +13,6 @@ jobs:
           node-version: 16
       - run: yarn install
       - run: yarn test
+        env:
+          NODE_URL_1: ${{ secrets.NODE_URL_1 }}
+


### PR DESCRIPTION
We should be using the newly defined `NODE_URL_1` secret for our `test/common.test.ts` test file.

This PR may be updated in the event that slight tweaks need to be made to the `.github/workflows/test.yml` file.