### PR TITLE
refactor: Relocate Deposit utilities from relayer-v2

### DIFF
--- a/src/utils/DepositUtils.ts
+++ b/src/utils/DepositUtils.ts
@@ -1,3 +1,4 @@
+import assert from "assert";
 import { SpokePoolClient } from "../clients";
 import { DEFAULT_CACHING_TTL } from "../constants";
 import { CachingMechanismInterface, Deposit, DepositWithBlock, Fill } from "../interfaces";
@@ -82,4 +83,24 @@ export async function queryHistoricalDepositForFill(
   }
 
   return validateFillForDeposit(fill, deposit) ? deposit : undefined;
+}
+
+/**
+ * Determines if a deposit was updated via a speed-up transaction.
+ * @param deposit Deposit to evaluate.
+ * @returns True if the deposit was updated, otherwise false.
+ */
+export function isDepositSpedUp(deposit: Deposit): boolean {
+  return isDefined(deposit.speedUpSignature) && isDefined(deposit.newRelayerFeePct);
+}
+
+/**
+ * Resolves the applicable message for a deposit.
+ * @param deposit Deposit to evaluate.
+ * @returns Original or updated message string, depending on whether the depositor updated the deposit.
+ */
+export function resolveDepositMessage(deposit: Deposit): string {
+  const message = isDepositSpedUp(deposit) ? deposit.updatedMessage : deposit.message;
+  assert(isDefined(message)); // Appease tsc about the updatedMessage being possibly undefined.
+  return message;
 }


### PR DESCRIPTION
Also add a `resolveDepositMessage()` helper to make it simple for callers to fetch the correct message for a given Deposit object.