### PR TITLE
improve: supply super() with cache in UBAClient

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.17.5",
+  "version": "0.17.6",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/v/developer-docs/developers/across-sdk",
   "files": [


### PR DESCRIPTION
This PR uses the `super()` call to set the caching client within the `BaseAbstractClient`