### PR TITLE
improve(constants): Allow HubPoolClient constructor to override default caching safe lag

### DIFF
--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -94,7 +94,7 @@ export class HubPoolClient extends BaseAbstractClient {
     protected readonly configOverride: {
       ignoredHubExecutedBundles: number[];
       ignoredHubProposedBundles: number[];
-      cacheFollowDistance?: number;
+      timeToCache?: number;
     } = {
       ignoredHubExecutedBundles: [],
       ignoredHubProposedBundles: [],
@@ -262,7 +262,7 @@ export class HubPoolClient extends BaseAbstractClient {
     blockNumber: number,
     amount: BigNumber,
     timestamp: number,
-    cacheFollowDistance: number
+    timeToCache: number
   ): Promise<{ current: BigNumber; post: BigNumber }> {
     // Resolve this function call as an async anonymous function
     // This way, since we have to use this call several times, we
@@ -289,7 +289,7 @@ export class HubPoolClient extends BaseAbstractClient {
       const { current, post } = await resolver();
       // First determine if we should cache the result. We should cache the
       // response if the is outside of 24 hours from the current time.
-      if (shouldCache(getCurrentTime(), timestamp, cacheFollowDistance)) {
+      if (shouldCache(getCurrentTime(), timestamp, timeToCache)) {
         // If we should cache the result, then let's store it
         // We can store it as with the default 14 day TTL
         await cache.set(key, `${current.toString()},${post.toString()}`, DEFAULT_CACHING_TTL);
@@ -331,13 +331,13 @@ export class HubPoolClient extends BaseAbstractClient {
       quoteBlock
     );
 
-    const cacheFollowDistance = this.configOverride.cacheFollowDistance ?? DEFAULT_CACHING_SAFE_LAG;
+    const timeToCache = this.configOverride.timeToCache ?? DEFAULT_CACHING_SAFE_LAG;
     const { current, post } = await this.getUtilization(
       l1Token,
       quoteBlock,
       deposit.amount,
       deposit.quoteTimestamp,
-      cacheFollowDistance
+      timeToCache
     );
     const realizedLpFeePct = lpFeeCalculator.calculateRealizedLpFeePct(rateModel, current, post);
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,7 @@
 import { constants as ethersConstants, BigNumber, utils } from "ethers";
+import dotenv from "dotenv";
 export { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "@across-protocol/constants-v2";
+dotenv.config();
 
 export const { AddressZero: ZERO_ADDRESS } = ethersConstants;
 
@@ -48,7 +50,7 @@ export const PUBLIC_NETWORKS: { [chainId: number]: { name: string; etherscan: st
 export const DEFAULT_BLOCKCHAIN_EXPLORER_DOMAIN = "https://etherscan.io";
 
 export const DEFAULT_CACHING_TTL = 60 * 60 * 24 * 7 * 2; // 2 Weeks
-export const DEFAULT_CACHING_SAFE_LAG = 60 * 60 * 24; // 1 Day
+export const DEFAULT_CACHING_SAFE_LAG = Number(process.env.CACHING_SAFE_LAG) ?? 60 * 10; // 10 mins
 
 export const UBA_BOUNDS_RANGE_MAX = BigNumber.from(String(Number.MAX_SAFE_INTEGER)).mul(utils.parseEther("1.0"));
 export const UBA_BOUNDS_RANGE_MIN = UBA_BOUNDS_RANGE_MAX.mul(-1);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,5 @@
 import { constants as ethersConstants, BigNumber, utils } from "ethers";
-import dotenv from "dotenv";
 export { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "@across-protocol/constants-v2";
-dotenv.config();
 
 export const { AddressZero: ZERO_ADDRESS } = ethersConstants;
 
@@ -50,7 +48,7 @@ export const PUBLIC_NETWORKS: { [chainId: number]: { name: string; etherscan: st
 export const DEFAULT_BLOCKCHAIN_EXPLORER_DOMAIN = "https://etherscan.io";
 
 export const DEFAULT_CACHING_TTL = 60 * 60 * 24 * 7 * 2; // 2 Weeks
-export const DEFAULT_CACHING_SAFE_LAG = Number(process.env.CACHING_SAFE_LAG) ?? 60 * 10; // 10 mins
+export const DEFAULT_CACHING_SAFE_LAG = 60 * 60; // 1 hour
 
 export const UBA_BOUNDS_RANGE_MAX = BigNumber.from(String(Number.MAX_SAFE_INTEGER)).mul(utils.parseEther("1.0"));
 export const UBA_BOUNDS_RANGE_MIN = UBA_BOUNDS_RANGE_MAX.mul(-1);

--- a/src/utils/CachingUtils.ts
+++ b/src/utils/CachingUtils.ts
@@ -26,7 +26,8 @@ export async function setDepositInCache(
   deposit: Deposit,
   currentChainTime: number,
   cache: CachingMechanismInterface,
-  expirySeconds = DEFAULT_CACHING_TTL
+  expirySeconds = DEFAULT_CACHING_TTL,
+  cacheFollowDistance = DEFAULT_CACHING_SAFE_LAG
 ): Promise<void> {
   const currentTimeInSeconds = getCurrentTime();
   // We should first confirm that neither the deposit's quoteTimestamp nor the currentChainTime
@@ -37,7 +38,7 @@ export async function setDepositInCache(
 
   // We should note here that the user can theoretically set the deposit's quoteTimestamp
   // to whatever they want. As a result, this could be used to manipulate the caching mechanism.
-  if (shouldCache(deposit.quoteTimestamp, currentChainTime, DEFAULT_CACHING_SAFE_LAG)) {
+  if (shouldCache(deposit.quoteTimestamp, currentChainTime, cacheFollowDistance)) {
     await cache.set(getDepositKey(deposit), JSON.stringify(deposit), expirySeconds);
   }
 }

--- a/src/utils/CachingUtils.ts
+++ b/src/utils/CachingUtils.ts
@@ -27,7 +27,7 @@ export async function setDepositInCache(
   currentChainTime: number,
   cache: CachingMechanismInterface,
   expirySeconds = DEFAULT_CACHING_TTL,
-  cacheFollowDistance = DEFAULT_CACHING_SAFE_LAG
+  timeToCache = DEFAULT_CACHING_SAFE_LAG
 ): Promise<void> {
   const currentTimeInSeconds = getCurrentTime();
   // We should first confirm that neither the deposit's quoteTimestamp nor the currentChainTime
@@ -38,7 +38,7 @@ export async function setDepositInCache(
 
   // We should note here that the user can theoretically set the deposit's quoteTimestamp
   // to whatever they want. As a result, this could be used to manipulate the caching mechanism.
-  if (shouldCache(deposit.quoteTimestamp, currentChainTime, cacheFollowDistance)) {
+  if (shouldCache(deposit.quoteTimestamp, currentChainTime, timeToCache)) {
     await cache.set(getDepositKey(deposit), JSON.stringify(deposit), expirySeconds);
   }
 }


### PR DESCRIPTION
This caching lag is used to store utilization cached values read from the HubPoolClient, and deposit structs

Signed-off-by: nicholaspai <npai.nyc@gmail.com>
