### PR TITLE
feat: include cache in SDK block finder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.17.6",
+  "version": "0.17.7",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/v/developer-docs/developers/across-sdk",
   "files": [

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -28,6 +28,7 @@ import {
   MakeOptional,
   assign,
   fetchTokenInfo,
+  getCachedBlockForTimestamp,
   getCurrentTime,
   isDefined,
   paginatedEventQuery,
@@ -232,8 +233,14 @@ export class HubPoolClient extends BaseAbstractClient {
     );
   }
 
-  protected async getBlockNumber(timestamp: number): Promise<number | undefined> {
-    return (await this.blockFinder.getBlockForTimestamp(timestamp)).number;
+  getBlockNumber(timestamp: number): Promise<number | undefined> {
+    return getCachedBlockForTimestamp(
+      this.chainId,
+      timestamp,
+      this.blockFinder,
+      this.hubPool.provider,
+      this.cachingMechanism
+    );
   }
 
   async getCurrentPoolUtilization(l1Token: string): Promise<BigNumberish> {

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -234,13 +234,7 @@ export class HubPoolClient extends BaseAbstractClient {
   }
 
   getBlockNumber(timestamp: number): Promise<number | undefined> {
-    return getCachedBlockForTimestamp(
-      this.chainId,
-      timestamp,
-      this.blockFinder,
-      this.hubPool.provider,
-      this.cachingMechanism
-    );
+    return getCachedBlockForTimestamp(this.chainId, timestamp, this.blockFinder, this.cachingMechanism);
   }
 
   async getCurrentPoolUtilization(l1Token: string): Promise<BigNumberish> {

--- a/src/utils/BlockUtils.ts
+++ b/src/utils/BlockUtils.ts
@@ -193,29 +193,29 @@ export async function getCachedBlockForTimestamp(
   if (!isDefined(cache)) {
     return resolver();
   }
+
   // Cache exists. We should first check if it's possible to retrieve the block number from cache.
-  else {
-    // Resolve the key for the block number.
-    const key = `${chainId}_block_number_${timestamp}`;
-    // See if it's even possible to retrieve the block number from cache.
-    if (shouldCache(timestamp, getCurrentTime(), DEFAULT_CACHING_SAFE_LAG)) {
-      // Attempt to retrieve the block number from cache.
-      const result = await cache.get<string>(key);
-      // If the block number is in cache, then return it.
-      if (result !== null) {
-        return parseInt(result);
-      }
-      // Otherwise, we need to resolve the block number and cache it.
-      else {
-        const blockNumber = await resolver();
-        // Expire key after 90 days.
-        await cache.set(key, blockNumber.toString(), 60 * 60 * 24 * 90); // 90 days
-        return blockNumber;
-      }
+
+  // Resolve the key for the block number.
+  const key = `${chainId}_block_number_${timestamp}`;
+  // See if it's even possible to retrieve the block number from cache.
+  if (shouldCache(timestamp, getCurrentTime(), DEFAULT_CACHING_SAFE_LAG)) {
+    // Attempt to retrieve the block number from cache.
+    const result = await cache.get<string>(key);
+    // If the block number is in cache, then return it.
+    if (result !== null) {
+      return parseInt(result);
     }
-    // It's too early to cache this key. Resolve the block number and return it.
+    // Otherwise, we need to resolve the block number and cache it.
     else {
-      return resolver();
+      const blockNumber = await resolver();
+      // Expire key after 90 days.
+      await cache.set(key, blockNumber.toString(), 60 * 60 * 24 * 90); // 90 days
+      return blockNumber;
     }
+  }
+  // It's too early to cache this key. Resolve the block number and return it.
+  else {
+    return resolver();
   }
 }

--- a/src/utils/BlockUtils.ts
+++ b/src/utils/BlockUtils.ts
@@ -183,7 +183,6 @@ export async function getCachedBlockForTimestamp(
   chainId: number,
   timestamp: number,
   blockFinder: BlockFinder,
-  provider: Provider,
   cache?: CachingMechanismInterface
 ): Promise<number> {
   // Resolve a convenience function to directly compute what we're
@@ -196,12 +195,10 @@ export async function getCachedBlockForTimestamp(
   }
   // Cache exists. We should first check if it's possible to retrieve the block number from cache.
   else {
-    // Grab the latest block number
-    const latestBlockNumber = await provider.getBlock("latest");
     // Resolve the key for the block number.
     const key = `${chainId}_block_number_${timestamp}`;
     // See if it's even possible to retrieve the block number from cache.
-    if (shouldCache(timestamp, latestBlockNumber.timestamp, DEFAULT_CACHING_SAFE_LAG)) {
+    if (shouldCache(timestamp, getCurrentTime(), DEFAULT_CACHING_SAFE_LAG)) {
       // Attempt to retrieve the block number from cache.
       const result = await cache.get<string>(key);
       // If the block number is in cache, then return it.

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -284,10 +284,14 @@ export async function buildDepositStruct(
   hubPoolClient: HubPoolClient,
   l1TokenForDepositedToken: Contract
 ): Promise<Deposit & { quoteBlockNumber: number; blockNumber: number }> {
+  const blockNumber = await hubPoolClient.getBlockNumber(deposit.quoteTimestamp);
+  if (!blockNumber) {
+    throw new Error("Timestamp is undefined");
+  }
   const { quoteBlock, realizedLpFeePct } = await hubPoolClient.computeRealizedLpFeePct(
     {
       ...deposit,
-      blockNumber: (await hubPoolClient.blockFinder.getBlockForTimestamp(deposit.quoteTimestamp)).number,
+      blockNumber,
     },
     l1TokenForDepositedToken.address
   );


### PR DESCRIPTION
This change introduces the function `getCachedBlockForTimestamp` into the SDK. All calls to blockfinder's `getBlockForTimestamp` have been diverted to either an available `hubPool.getBlock(timestamp: number)` function (which leverages `getCachedBlockForTimestamp` or with `getCachedBlockForTimestamp` directly.

The original code block is:

```
/**
 * @notice Get the block number for a given timestamp fresh from on-chain data if not found in redis cache.
 * If redis cache is not available, then requests block from blockFinder.
 * @param chainId Chain to load block finder for.
 * @param timestamp Approximate timestamp of the to requested block number.
 * @param blockFinder Caller can optionally pass in a block finder object to use instead of creating a new one
 * or loading from cache. This is useful for testing primarily.
 * @returns Block number for the requested timestamp.
 */
export async function getBlockForTimestamp(
  chainId: number,
  timestamp: number,
  blockFinder?: BlockFinder
): Promise<number> {
  blockFinder ??= await getBlockFinder(chainId);
  const redisClient = await getRedis();

  // If no redis client, then request block from blockFinder. Otherwise try to load from redis cache.
  if (redisClient === undefined) {
    return (await blockFinder.getBlockForTimestamp(timestamp)).number;
  }

  const key = `${chainId}_block_number_${timestamp}`;
  const result = await redisClient.get(key);
  if (result === null) {
    const provider = await getProvider(chainId);
    const [currentBlock, { number: blockNumber }] = await Promise.all([
      provider.getBlock("latest"),
      blockFinder.getBlockForTimestamp(timestamp),
    ]);

    // Expire key after 90 days.
    if (shouldCache(timestamp, currentBlock.timestamp)) {
      await setRedisKey(key, blockNumber.toString(), redisClient, 60 * 60 * 24 * 90);
    }
    return blockNumber;
  } else {
    return parseInt(result);
  }
}

```