### PR TITLE
fix: Better gas estimation for Base

### DIFF
--- a/src/utils/NetworkUtils.ts
+++ b/src/utils/NetworkUtils.ts
@@ -46,3 +46,12 @@ export function getNativeTokenSymbol(chainId: number | string): string {
   }
   return "ETH";
 }
+
+/**
+ * Determines whether a chain ID is an Optimism OP Stack implementation.
+ * @param chainId Chain ID to evaluate.
+ * @returns True if chainId is an OP stack, otherwise false.
+ */
+export function chainIsOPStack(chainId: number): boolean {
+  return [10, 8453, 69, 420, 84531].includes(chainId);
+}


### PR DESCRIPTION
It was reported a few weeks ago that a gas spike on mainnet caused deposits destined for Base to be underpriced; I couldn't figure out why this would be the case for Base but not Optimism, but this may have contributed.

As part of this, add a simple utility to indicate whether a chain ID is an OP stack implementation.