### PR TITLE
chore: Don't force lint, build & test on commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-yarn lint-staged
-yarn build
-yarn test


### PR DESCRIPTION
Enforcing this on commit is a productivity killer and I have to keep typing --no-verify when committing.

If we want additional checks before code is submitted to GitHub, I'd probably be keen to explore a pre-push hook instead. But I am generally happier if CI is instrumented to catch everything so that we don't waste local developer time waiting for standard checks to occur.