### PR TITLE
improve(HubPoolClient): Process LP fees in batch

### DIFF
--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -483,6 +483,16 @@ export class HubPoolClient extends BaseAbstractClient {
     return await mapAsync(deposits, (deposit) => computeRealizedLpFeePct(deposit));
   }
 
+  async computeRealizedLpFeePct(
+    deposit: Pick<
+      DepositWithBlock,
+      "quoteTimestamp" | "amount" | "originChainId" | "originToken" | "destinationChainId" | "blockNumber"
+    >
+  ): Promise<RealizedLpFee> {
+    const [lpFee] = await this.batchComputeRealizedLpFeePct([deposit]);
+    return lpFee;
+  }
+
   getL1Tokens(): L1Token[] {
     return this.l1Tokens;
   }

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -359,6 +359,16 @@ export class HubPoolClient extends BaseAbstractClient {
     return utilization;
   }
 
+  async computeRealizedLpFeePct(
+    deposit: Pick<
+      DepositWithBlock,
+      "quoteTimestamp" | "amount" | "originChainId" | "originToken" | "destinationChainId" | "blockNumber"
+    >
+  ): Promise<RealizedLpFee> {
+    const [lpFee] = await this.batchComputeRealizedLpFeePct([deposit]);
+    return lpFee;
+  }
+
   async batchComputeRealizedLpFeePct(
     deposits: Pick<
       DepositWithBlock,
@@ -481,16 +491,6 @@ export class HubPoolClient extends BaseAbstractClient {
     // For each deposit, compute the post-relay HubPool utilisation independently.
     // @dev The caller expects to receive an array in the same length and ordering as the input `deposits`.
     return await mapAsync(deposits, (deposit) => computeRealizedLpFeePct(deposit));
-  }
-
-  async computeRealizedLpFeePct(
-    deposit: Pick<
-      DepositWithBlock,
-      "quoteTimestamp" | "amount" | "originChainId" | "originToken" | "destinationChainId" | "blockNumber"
-    >
-  ): Promise<RealizedLpFee> {
-    const [lpFee] = await this.batchComputeRealizedLpFeePct([deposit]);
-    return lpFee;
   }
 
   getL1Tokens(): L1Token[] {

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -523,10 +523,8 @@ export class HubPoolClient extends BaseAbstractClient {
     );
 
     // For each deposit, compute the post-relay HubPool utilisation independently.
-    const lpFees = await mapAsync(deposits, (deposit) => computeRealizedLpFeePct(deposit));
-
     // @dev The caller expects to receive an array in the same length and ordering as the input `deposits`.
-    return lpFees;
+    return await mapAsync(deposits, (deposit) => computeRealizedLpFeePct(deposit));
   }
 
   getL1Tokens(): L1Token[] {

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -421,7 +421,7 @@ export class HubPoolClient extends BaseAbstractClient {
       const { originChainId, originToken, quoteTimestamp } = deposit;
       assert(
         originChainId === firstOriginChainId,
-        "Cannot compute bulk realizedLpFeePct for disparate origin chains" +
+        "Cannot compute bulk realizedLpFeePct for different origin chains" +
           ` (${originChainId} != ${firstOriginChainId})`
       );
 

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -359,19 +359,19 @@ export class HubPoolClient extends BaseAbstractClient {
   protected async _getUtilization(
     hubPoolToken: string,
     blockNumber: number,
-    amount: BigNumber,
+    depositAmount: BigNumber,
     timestamp: number,
     timeToCache: number
   ): Promise<BigNumber> {
     // Resolve this function call as an async anonymous function
     const resolver = async () => {
       const overrides = { blockTag: blockNumber };
-      if (amount.eq(0)) {
+      if (depositAmount.eq(0)) {
         // For zero amount, just get the utilisation at `blockNumber`.
         return await this.hubPool.callStatic.liquidityUtilizationCurrent(hubPoolToken, overrides);
       }
 
-      return await this.hubPool.callStatic.liquidityUtilizationPostRelay(hubPoolToken, amount, overrides);
+      return await this.hubPool.callStatic.liquidityUtilizationPostRelay(hubPoolToken, depositAmount, overrides);
     };
 
     // Resolve the cache locally so that we can appease typescript
@@ -383,9 +383,9 @@ export class HubPoolClient extends BaseAbstractClient {
     }
 
     // Otherwise, let's resolve the key
-    const key = amount.eq(0)
+    const key = depositAmount.eq(0)
       ? `utilization_${hubPoolToken}_${blockNumber}`
-      : `utilization_${hubPoolToken}_${blockNumber}_${amount.toString()}`;
+      : `utilization_${hubPoolToken}_${blockNumber}_${depositAmount.toString()}`;
     const result = await cache.get<string>(key);
     if (isDefined(result)) {
       return BigNumber.from(result);

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -18,6 +18,7 @@ import {
   PendingRootBundle,
   ProposedRootBundle,
   ProposedRootBundleStringified,
+  RealizedLpFee,
   SetPoolRebalanceRoot,
   TokenRunningBalance,
 } from "../interfaces";
@@ -363,7 +364,7 @@ export class HubPoolClient extends BaseAbstractClient {
       DepositWithBlock,
       "quoteTimestamp" | "amount" | "originChainId" | "originToken" | "destinationChainId" | "blockNumber"
     >[]
-  ): Promise<{ quoteBlock: number; realizedLpFeePct?: BigNumber }[]> {
+  ): Promise<RealizedLpFee[]> {
     assert(deposits.length > 0, "No deposits supplied to batchComputeRealizedLpFeePct");
     if (!isDefined(this.currentTime)) {
       throw new Error("HubPoolClient has not set a currentTime");

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -407,6 +407,7 @@ export class HubPoolClient extends BaseAbstractClient {
       "quoteTimestamp" | "amount" | "originChainId" | "originToken" | "destinationChainId" | "blockNumber"
     >[]
   ): Promise<{ quoteBlock: number; realizedLpFeePct?: BigNumber }[]> {
+    assert(deposits.length > 0, "No deposits supplied to batchComputeRealizedLpFeePct");
     if (!isDefined(this.currentTime)) {
       throw new Error("HubPoolClient has not set a currentTime");
     }

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -864,6 +864,16 @@ export class SpokePoolClient extends BaseAbstractClient {
   }
 
   /**
+   * Computes the realized LP fee percentage for a given deposit.
+   * @param depositEvent The deposit event to compute the realized LP fee percentage for.
+   * @returns The realized LP fee percentage.
+   */
+  protected async computeRealizedLpFeePct(depositEvent: FundsDepositedEvent): Promise<RealizedLpFee> {
+    const [lpFee] = await this.batchComputeRealizedLpFeePct([depositEvent]);
+    return lpFee;
+  }
+
+  /**
    * Computes the realized LP fee percentage for a batch of deposits.
    * @dev Computing in batch opens up for efficiencies, e.g. in quoteTimestamp -> blockNumber resolution.
    * @param depositEvents The array of deposit events to compute the realized LP fee percentage for.
@@ -892,16 +902,6 @@ export class SpokePoolClient extends BaseAbstractClient {
     });
 
     return deposits.length > 0 ? await this.hubPoolClient.batchComputeRealizedLpFeePct(deposits) : [];
-  }
-
-  /**
-   * Computes the realized LP fee percentage for a given deposit.
-   * @param depositEvent The deposit event to compute the realized LP fee percentage for.
-   * @returns The realized LP fee percentage.
-   */
-  protected async computeRealizedLpFeePct(depositEvent: FundsDepositedEvent): Promise<RealizedLpFee> {
-    const [lpFee] = await this.batchComputeRealizedLpFeePct([depositEvent]);
-    return lpFee;
   }
 
   /**

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -33,6 +33,7 @@ import {
   FillWithBlockStringified,
   FundsDepositedEvent,
   FundsDepositedEventStringified,
+  RealizedLpFee,
   RefundRequestWithBlock,
   RefundRequestWithBlockStringified,
   RelayerRefundExecutionWithBlock,
@@ -868,7 +869,7 @@ export class SpokePoolClient extends BaseAbstractClient {
    * @param depositEvents The array of deposit events to compute the realized LP fee percentage for.
    * @returns The array of realized LP fee percentages and associated HubPool block numbers.
    */
-  protected async batchComputeRealizedLpFeePct(depositEvents: FundsDepositedEvent[]) {
+  protected async batchComputeRealizedLpFeePct(depositEvents: FundsDepositedEvent[]): Promise<RealizedLpFee[]> {
     // If no hub pool client, we're using this for testing. Set quote block very high so that if it's ever
     // used to look up a configuration for a block, it will always match with the latest configuration.
     if (this.hubPoolClient === null) {
@@ -891,6 +892,16 @@ export class SpokePoolClient extends BaseAbstractClient {
     });
 
     return deposits.length > 0 ? await this.hubPoolClient.batchComputeRealizedLpFeePct(deposits) : [];
+  }
+
+  /**
+   * Computes the realized LP fee percentage for a given deposit.
+   * @param depositEvent The deposit event to compute the realized LP fee percentage for.
+   * @returns The realized LP fee percentage.
+   */
+  protected async computeRealizedLpFeePct(depositEvent: FundsDepositedEvent): Promise<RealizedLpFee> {
+    const [lpFee] = await this.batchComputeRealizedLpFeePct([depositEvent]);
+    return lpFee;
   }
 
   /**

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -918,9 +918,7 @@ export class SpokePoolClient extends BaseAbstractClient {
       };
     });
 
-    return deposits.length > 0
-      ? await this.hubPoolClient.batchComputeRealizedLpFeePct(deposits)
-      : [];
+    return deposits.length > 0 ? await this.hubPoolClient.batchComputeRealizedLpFeePct(deposits) : [];
   }
 
   /**

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -912,7 +912,9 @@ export class SpokePoolClient extends BaseAbstractClient {
       };
     });
 
-    return await this.hubPoolClient.batchComputeRealizedLpFeePct(deposits);
+    return deposits.length > 0
+      ? await this.hubPoolClient.batchComputeRealizedLpFeePct(deposits)
+      : [];
   }
 
   /**

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -680,8 +680,7 @@ export class SpokePoolClient extends BaseAbstractClient {
       const dataForQuoteTime = await this.batchComputeRealizedLpFeePct(depositEvents);
       this.logger.debug({
         at: "SpokePoolClient",
-        message: `Computed realizedLpFees on ${this.chainId}!`,
-        dataForQuoteTime,
+        message: `Computed ${dataForQuoteTime.length} realizedLpFees on ${this.chainId}!`,
       });
 
       // Now add any newly fetched events from RPC.

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -676,7 +676,6 @@ export class SpokePoolClient extends BaseAbstractClient {
       });
       this.earlyDeposits = earlyDeposits;
 
-      // const dataForQuoteTime = await Promise.all(depositEvents.map((event) => this.computeRealizedLpFeePct(event)));
       const dataForQuoteTime = await this.batchComputeRealizedLpFeePct(depositEvents);
       this.logger.debug({
         at: "SpokePoolClient",
@@ -861,32 +860,6 @@ export class SpokePoolClient extends BaseAbstractClient {
     } else {
       return eventL2Token;
     }
-  }
-
-  /**
-   * Computes the realized LP fee percentage for a given deposit.
-   * @param depositEvent The deposit event to compute the realized LP fee percentage for.
-   * @returns The realized LP fee percentage.
-   */
-  protected computeRealizedLpFeePct(depositEvent: FundsDepositedEvent) {
-    // If no hub pool client, we're using this for testing. So set quote block very high
-    // so that if its ever used to look up a configuration for a block, it will always match with some
-    // configuration because the quote block will always be greater than the updated config event block height.
-    if (this.hubPoolClient === null) {
-      return { realizedLpFeePct: toBN(0), quoteBlock: MAX_BIG_INT.toNumber() };
-    }
-
-    const deposit = {
-      amount: depositEvent.args.amount,
-      originChainId: Number(depositEvent.args.originChainId),
-      destinationChainId: Number(depositEvent.args.destinationChainId),
-      originToken: depositEvent.args.originToken,
-      quoteTimestamp: depositEvent.args.quoteTimestamp,
-      blockNumber: depositEvent.blockNumber,
-    };
-
-    const l1Token = this.hubPoolClient.getL1TokenForDeposit(deposit);
-    return this.hubPoolClient.computeRealizedLpFeePct(deposit, l1Token);
   }
 
   /**

--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -4,7 +4,7 @@ import { random } from "lodash";
 import winston from "winston";
 import { ZERO_ADDRESS } from "../../constants";
 import { DepositWithBlock, FillWithBlock, FundsDepositedEvent, RefundRequestWithBlock } from "../../interfaces";
-import { isDefined, toBN, toBNWei, forEachAsync, mapAsync, randomAddress } from "../../utils";
+import { bnZero, toBN, toBNWei, forEachAsync, randomAddress } from "../../utils";
 import { SpokePoolClient, SpokePoolUpdate } from "../SpokePoolClient";
 import { EventManager, getEventManager } from "./MockEvents";
 
@@ -15,7 +15,8 @@ type Block = providers.Block;
 export class MockSpokePoolClient extends SpokePoolClient {
   public eventManager: EventManager;
   private events: Event[] = [];
-  private realizedLpFeePctOverride: BigNumber | undefined;
+  private realizedLpFeePct: BigNumber | undefined = bnZero;
+  private realizedLpFeePctOverride = false;
   private destinationTokenForChainOverride: Record<number, string> = {};
   // Allow tester to set the numberOfDeposits() returned by SpokePool at a block height.
   public depositIdAtBlock: number[] = [];
@@ -29,21 +30,25 @@ export class MockSpokePoolClient extends SpokePoolClient {
   }
 
   setDefaultRealizedLpFeePct(fee: BigNumber | undefined): void {
-    this.realizedLpFeePctOverride = fee;
+    this.realizedLpFeePct = fee;
+    this.realizedLpFeePctOverride = true;
+  }
+
+  clearDefaultRealizedLpFeePct(): void {
+    this.realizedLpFeePctOverride = false;
   }
 
   async computeRealizedLpFeePct(depositEvent: FundsDepositedEvent) {
-    return (
-      {
-        realizedLpFeePct: this.realizedLpFeePctOverride,
-        quoteBlock: depositEvent.blockNumber,
-      } ?? (await super.computeRealizedLpFeePct(depositEvent))
-    );
+    const { realizedLpFeePct, realizedLpFeePctOverride } = this;
+    const { blockNumber: quoteBlock } = depositEvent;
+    return realizedLpFeePctOverride
+      ? { realizedLpFeePct, quoteBlock }
+      : super.computeRealizedLpFeePct(depositEvent);
   }
 
   async batchComputeRealizedLpFeePct(depositEvents: FundsDepositedEvent[]) {
-    const realizedLpFeePct = this.realizedLpFeePctOverride;
-    return isDefined(realizedLpFeePct)
+    const { realizedLpFeePct, realizedLpFeePctOverride } = this;
+    return realizedLpFeePctOverride
       ? depositEvents.map(({ blockNumber: quoteBlock }) => { return { realizedLpFeePct, quoteBlock } })
       : super.batchComputeRealizedLpFeePct(depositEvents);
   }

--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -43,14 +43,16 @@ export class MockSpokePoolClient extends SpokePoolClient {
     const { blockNumber: quoteBlock } = depositEvent;
     return realizedLpFeePctOverride
       ? { realizedLpFeePct, quoteBlock }
-      : super.computeRealizedLpFeePct(depositEvent);
+      : await super.computeRealizedLpFeePct(depositEvent);
   }
 
   async batchComputeRealizedLpFeePct(depositEvents: FundsDepositedEvent[]) {
     const { realizedLpFeePct, realizedLpFeePctOverride } = this;
     return realizedLpFeePctOverride
-      ? depositEvents.map(({ blockNumber: quoteBlock }) => { return { realizedLpFeePct, quoteBlock } })
-      : super.batchComputeRealizedLpFeePct(depositEvents);
+      ? depositEvents.map(({ blockNumber: quoteBlock }) => {
+          return { realizedLpFeePct, quoteBlock };
+        })
+      : await super.batchComputeRealizedLpFeePct(depositEvents);
   }
 
   setDestinationTokenForChain(chainId: number, token: string): void {

--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -4,7 +4,7 @@ import { random } from "lodash";
 import winston from "winston";
 import { ZERO_ADDRESS } from "../../constants";
 import { DepositWithBlock, FillWithBlock, FundsDepositedEvent, RefundRequestWithBlock } from "../../interfaces";
-import { toBN, toBNWei, forEachAsync, randomAddress } from "../../utils";
+import { isDefined, toBN, toBNWei, forEachAsync, mapAsync, randomAddress } from "../../utils";
 import { SpokePoolClient, SpokePoolUpdate } from "../SpokePoolClient";
 import { EventManager, getEventManager } from "./MockEvents";
 
@@ -39,6 +39,13 @@ export class MockSpokePoolClient extends SpokePoolClient {
         quoteBlock: depositEvent.blockNumber,
       } ?? (await super.computeRealizedLpFeePct(depositEvent))
     );
+  }
+
+  async batchComputeRealizedLpFeePct(depositEvents: FundsDepositedEvent[]) {
+    const realizedLpFeePct = this.realizedLpFeePctOverride;
+    return isDefined(realizedLpFeePct)
+      ? depositEvents.map(({ blockNumber: quoteBlock }) => { return { realizedLpFeePct, quoteBlock } })
+      : super.batchComputeRealizedLpFeePct(depositEvents);
   }
 
   setDestinationTokenForChain(chainId: number, token: string): void {

--- a/src/interfaces/HubPool.ts
+++ b/src/interfaces/HubPool.ts
@@ -30,6 +30,11 @@ export interface ProposedRootBundle extends SortableEvent {
   proposer: string;
 }
 
+export type RealizedLpFee = {
+  quoteBlock: number;
+  realizedLpFeePct?: BigNumber;
+};
+
 export type ProposedRootBundleStringified = Omit<ProposedRootBundle, "bundleEvaluationBlockNumbers"> & {
   bundleEvaluationBlockNumbers: string[];
 };

--- a/src/utils/BlockUtils.ts
+++ b/src/utils/BlockUtils.ts
@@ -66,7 +66,7 @@ export async function averageBlockTime(
   }
   blockRange ??= defaultBlockRange;
 
-  const earliestBlockNumber = latestBlockNumber - blockRange;
+  const earliestBlockNumber = Math.max(latestBlockNumber - blockRange, 0);
   const [firstBlock, lastBlock] = await Promise.all([
     provider.getBlock(earliestBlockNumber),
     provider.getBlock(latestBlockNumber),
@@ -87,7 +87,8 @@ export async function averageBlockTime(
 
 async function estimateBlocksElapsed(seconds: number, cushionPercentage = 0.0, provider: Provider): Promise<number> {
   const cushionMultiplier = cushionPercentage + 1.0;
-  const { average } = await averageBlockTime(provider);
+  const blockRange = await provider.getBlockNumber();
+  const { average } = await averageBlockTime(provider, { blockRange });
   return Math.floor((seconds * cushionMultiplier) / average);
 }
 

--- a/src/utils/BlockUtils.ts
+++ b/src/utils/BlockUtils.ts
@@ -103,32 +103,40 @@ export class BlockFinder {
    * @param {number} timestamp timestamp to search.
    */
   public async getBlockForTimestamp(timestamp: number | string): Promise<Block> {
+    const { chainId } = await this.provider.getNetwork();
     timestamp = Number(timestamp);
-    assert(timestamp !== undefined && timestamp !== null, "timestamp must be provided");
+    assert(timestamp !== undefined && timestamp !== null, `chain ${chainId} timestamp must be provided`);
     // If the last block we have stored is too early, grab the latest block.
     if (this.blocks.length === 0 || this.blocks[this.blocks.length - 1].timestamp < timestamp) {
       const block = await this.getLatestBlock();
       if (timestamp >= block.timestamp) return block;
     }
 
-    // Check the first block. If it's grater than our timestamp, we need to find an earlier block.
+    // Check the first block. If it's greater than our timestamp, we need to find an earlier block.
     if (this.blocks[0].timestamp > timestamp) {
       const initialBlock = this.blocks[0];
       // We use a 2x cushion to reduce the number of iterations in the following loop and increase the chance
       // that the first block we find sets a floor for the target timestamp. The loop converges on the correct block
       // slower than the following incremental search performed by `findBlock`, so we want to minimize the number of
       // loop iterations in favor of searching more blocks over the `findBlock` search.
-      const cushion = 1;
+      const cushion = 20;
       const incrementDistance = Math.max(
         // Ensure the increment block distance is _at least_ a single block to prevent an infinite loop.
         await estimateBlocksElapsed(initialBlock.timestamp - timestamp, cushion, this.provider),
         1
       );
+      console.log(
+        `Chain ${chainId}:` +
+        ` incrementDistance: ${incrementDistance}.` +
+        ` initialBlock.timestamp: ${initialBlock.timestamp}.` +
+        ` timestamp: ${timestamp}.`
+      );
 
       // Search backwards by a constant increment until we find a block before the timestamp or hit block 0.
-      for (let multiplier = 1; ; multiplier++) {
+      for (let multiplier = 1; ; ++multiplier) {
         const distance = multiplier * incrementDistance;
         const blockNumber = Math.max(0, initialBlock.number - distance);
+        console.log(`chainId ${chainId}: Resolving block ${blockNumber} on multiplier ${multiplier} (${initialBlock.number} - ${distance}).`);
         const block = await this.getBlock(blockNumber);
         if (block.timestamp <= timestamp) break; // Found an earlier block.
         assert(blockNumber > 0, "timestamp is before block 0"); // Block 0 was not earlier than this timestamp. The row.
@@ -137,6 +145,8 @@ export class BlockFinder {
 
     // Find the index where the block would be inserted and use that as the end block (since it is >= the timestamp).
     const index = sortedIndexBy(this.blocks, { timestamp } as Block, "timestamp");
+    const _block = this.blocks[index - 1];
+    console.log(`chainId ${chainId}: Selected ${_block.number} as the initial block (time delta ${timestamp - _block.timestamp} seconds).`);
     return this.findBlock(this.blocks[index - 1], this.blocks[index], timestamp);
   }
 
@@ -144,7 +154,9 @@ export class BlockFinder {
   private async getLatestBlock() {
     const block = await this.provider.getBlock("latest");
     const index = sortedIndexBy(this.blocks, block, "number");
-    if (this.blocks[index]?.number !== block.number) this.blocks.splice(index, 0, block);
+    if (this.blocks[index]?.number !== block.number) {
+      this.blocks.splice(index, 0, block);
+    }
     return this.blocks[index];
   }
 
@@ -167,6 +179,8 @@ export class BlockFinder {
   // Effectively, this is an interpolation search algorithm to minimize block requests.
   // Note: startBlock and endBlock _must_ be different blocks.
   private async findBlock(_startBlock: Block, _endBlock: Block, timestamp: number): Promise<Block> {
+    const { chainId } = await this.provider.getNetwork();
+
     const [startBlock, endBlock] = [_startBlock, _endBlock];
     // In the case of equality, the endBlock is expected to be passed as the one whose timestamp === the requested
     // timestamp.
@@ -187,6 +201,14 @@ export class BlockFinder {
     const totalBlockDistance = endBlock.number - startBlock.number;
     const blockPercentile = (timestamp - startBlock.timestamp) / totalTimeDifference;
     const estimatedBlock = startBlock.number + Math.round(blockPercentile * totalBlockDistance);
+    console.log(
+      `chainId ${chainId}:` +
+      ` Searching for timestamp ${timestamp} between blocks ${_startBlock.number} and ${_endBlock.number}.` +
+      ` totalTimeDifference: ${totalTimeDifference},` +
+      ` totalBlockDistance: ${totalBlockDistance},` +
+      ` blockPercentile: ${blockPercentile},` +
+      ` estimatedBlock: ${estimatedBlock},`
+    );
 
     // Clamp ensures the estimated block is strictly greater than the start block and strictly less than the end block.
     const newBlock = await this.getBlock(clamp(estimatedBlock, startBlock.number + 1, endBlock.number - 1));

--- a/test/HubPoolClient.Utilization.ts
+++ b/test/HubPoolClient.Utilization.ts
@@ -16,6 +16,7 @@ import {
   createSpyLogger,
   deployConfigStore,
   deploySpokePoolWithToken,
+  enableRoutesOnHubPool,
   ethers,
   expect,
   hubPoolFixture,
@@ -76,6 +77,11 @@ describe("HubPool Utilization", function () {
     ({ hubPool, timer, dai: l1Token, weth } = await hubPoolFixture());
     await hubPool.setCrossChainContracts(1, randomAddress(), randomAddress());
     await hubPool.enableL1TokenForLiquidityProvision(l1Token.address);
+
+    await enableRoutesOnHubPool(hubPool, [
+      { destinationChainId: originChainId, l1Token, destinationToken: l2Token },
+      { destinationChainId: destinationChainId, l1Token: l2Token, destinationToken: l1Token },
+    ]);
 
     let fromBlock: number;
     ({ configStore, deploymentBlock: fromBlock } = await deployConfigStore(owner, []));

--- a/test/HubPoolClient.Utilization.ts
+++ b/test/HubPoolClient.Utilization.ts
@@ -130,7 +130,7 @@ describe("HubPool Utilization", function () {
 
     // Relayed amount being 10% of total LP amount should give exact same results as this test in v1:
     // - https://github.com/UMAprotocol/protocol/blob/3b1a88ead18088e8056ecfefb781c97fce7fdf4d/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js#L1037
-    expect((await hubPoolClient.computeRealizedLpFeePct(depositData, l1Token.address)).realizedLpFeePct).to.equal(
+    expect((await hubPoolClient.computeRealizedLpFeePct(depositData)).realizedLpFeePct).to.equal(
       toBNWei("0.000117987509354032")
     );
 

--- a/test/HubPoolClient.Utilization.ts
+++ b/test/HubPoolClient.Utilization.ts
@@ -76,11 +76,8 @@ describe("HubPool Utilization", function () {
     ({ spokePool, erc20: l2Token } = await deploySpokePoolWithToken(originChainId, repaymentChainId));
     ({ hubPool, timer, dai: l1Token, weth } = await hubPoolFixture());
     await hubPool.setCrossChainContracts(1, randomAddress(), randomAddress());
-    await hubPool.enableL1TokenForLiquidityProvision(l1Token.address);
-
     await enableRoutesOnHubPool(hubPool, [
       { destinationChainId: originChainId, l1Token, destinationToken: l2Token },
-      { destinationChainId: destinationChainId, l1Token: l2Token, destinationToken: l1Token },
     ]);
 
     let fromBlock: number;
@@ -168,7 +165,6 @@ describe("HubPool Utilization", function () {
             // This is because the rate model uses the quote time to fetch the liquidity utilization at that quote time.
             quoteTimestamp: (await ethers.provider.getBlock("latest")).timestamp,
           },
-          l1Token.address
         )
       ).realizedLpFeePct
     ).to.equal(toBNWei("0.001371068779697899"));
@@ -185,7 +181,6 @@ describe("HubPool Utilization", function () {
             // the current pool utilization at 10%.
             quoteTimestamp: (await ethers.provider.getBlock("latest")).timestamp,
           },
-          l1Token.address
         )
       ).realizedLpFeePct
     ).to.equal(toBNWei("0.002081296752280018"));

--- a/test/HubPoolClient.Utilization.ts
+++ b/test/HubPoolClient.Utilization.ts
@@ -76,9 +76,7 @@ describe("HubPool Utilization", function () {
     ({ spokePool, erc20: l2Token } = await deploySpokePoolWithToken(originChainId, repaymentChainId));
     ({ hubPool, timer, dai: l1Token, weth } = await hubPoolFixture());
     await hubPool.setCrossChainContracts(1, randomAddress(), randomAddress());
-    await enableRoutesOnHubPool(hubPool, [
-      { destinationChainId: originChainId, l1Token, destinationToken: l2Token },
-    ]);
+    await enableRoutesOnHubPool(hubPool, [{ destinationChainId: originChainId, l1Token, destinationToken: l2Token }]);
 
     let fromBlock: number;
     ({ configStore, deploymentBlock: fromBlock } = await deployConfigStore(owner, []));
@@ -157,15 +155,13 @@ describe("HubPool Utilization", function () {
     // pool utilization factor.
     expect(
       (
-        await hubPoolClient.computeRealizedLpFeePct(
-          {
-            ...depositData,
-            amount: toBNWei("0.0000001"),
-            // Note: we need to set the deposit quote timestamp to one after the utilisation % jumped from 0% to 10%.
-            // This is because the rate model uses the quote time to fetch the liquidity utilization at that quote time.
-            quoteTimestamp: (await ethers.provider.getBlock("latest")).timestamp,
-          },
-        )
+        await hubPoolClient.computeRealizedLpFeePct({
+          ...depositData,
+          amount: toBNWei("0.0000001"),
+          // Note: we need to set the deposit quote timestamp to one after the utilisation % jumped from 0% to 10%.
+          // This is because the rate model uses the quote time to fetch the liquidity utilization at that quote time.
+          quoteTimestamp: (await ethers.provider.getBlock("latest")).timestamp,
+        })
       ).realizedLpFeePct
     ).to.equal(toBNWei("0.001371068779697899"));
 
@@ -174,14 +170,12 @@ describe("HubPool Utilization", function () {
     // - https://github.com/UMAprotocol/protocol/blob/3b1a88ead18088e8056ecfefb781c97fce7fdf4d/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js#L1064
     expect(
       (
-        await hubPoolClient.computeRealizedLpFeePct(
-          {
-            ...depositData,
-            // Same as before, we need to use a timestamp following the `executeRootBundle` call so that we can capture
-            // the current pool utilization at 10%.
-            quoteTimestamp: (await ethers.provider.getBlock("latest")).timestamp,
-          },
-        )
+        await hubPoolClient.computeRealizedLpFeePct({
+          ...depositData,
+          // Same as before, we need to use a timestamp following the `executeRootBundle` call so that we can capture
+          // the current pool utilization at 10%.
+          quoteTimestamp: (await ethers.provider.getBlock("latest")).timestamp,
+        })
       ).realizedLpFeePct
     ).to.equal(toBNWei("0.002081296752280018"));
   });

--- a/test/SpokePoolClient.ValidateFill.ts
+++ b/test/SpokePoolClient.ValidateFill.ts
@@ -108,7 +108,7 @@ describe("SpokePoolClient: Fill Validation", function () {
   });
 
   it("Accepts valid fills", async function () {
-    const deposit = await buildDeposit(hubPoolClient, spokePool_1, erc20_1, l1Token, depositor, destinationChainId);
+    const deposit = await buildDeposit(hubPoolClient, spokePool_1, erc20_1, depositor, destinationChainId);
     await buildFill(spokePool_2, erc20_2, depositor, relayer, deposit, 1);
 
     await spokePoolClient2.update();
@@ -129,7 +129,7 @@ describe("SpokePoolClient: Fill Validation", function () {
   });
 
   it("Returns deposit matched with fill", async function () {
-    const deposit_1 = await buildDeposit(hubPoolClient, spokePool_1, erc20_1, l1Token, depositor, destinationChainId);
+    const deposit_1 = await buildDeposit(hubPoolClient, spokePool_1, erc20_1, depositor, destinationChainId);
     const fill_1 = await buildFill(spokePool_2, erc20_2, depositor, relayer, deposit_1, 0.5);
     const spokePoolClientForDestinationChain = new SpokePoolClient(
       createSpyLogger().spyLogger,
@@ -162,7 +162,7 @@ describe("SpokePoolClient: Fill Validation", function () {
   });
 
   it("Returns all fills that match deposit and fill", async function () {
-    const deposit = await buildDeposit(hubPoolClient, spokePool_1, erc20_1, l1Token, depositor, destinationChainId);
+    const deposit = await buildDeposit(hubPoolClient, spokePool_1, erc20_1, depositor, destinationChainId);
     const fill1 = await buildFill(spokePool_2, erc20_2, depositor, relayer, deposit, 0.5);
     let matchingFills = await spokePoolClient2.queryHistoricalMatchingFills(
       fill1,
@@ -380,7 +380,7 @@ describe("SpokePoolClient: Fill Validation", function () {
   });
 
   it("Can fetch older deposit matching fill", async function () {
-    const deposit = await buildDeposit(hubPoolClient, spokePool_1, erc20_1, l1Token, depositor, destinationChainId);
+    const deposit = await buildDeposit(hubPoolClient, spokePool_1, erc20_1, depositor, destinationChainId);
     await buildFill(spokePool_2, erc20_2, depositor, relayer, deposit, 1);
     await spokePoolClient2.update();
     const [fill] = spokePoolClient2.getFills();
@@ -399,7 +399,7 @@ describe("SpokePoolClient: Fill Validation", function () {
   });
 
   it("Can fetch younger deposit matching fill", async function () {
-    const deposit = await buildDeposit(hubPoolClient, spokePool_1, erc20_1, l1Token, depositor, destinationChainId);
+    const deposit = await buildDeposit(hubPoolClient, spokePool_1, erc20_1, depositor, destinationChainId);
     const depositBlock = await spokePool_1.provider.getBlockNumber();
     await buildFill(spokePool_2, erc20_2, depositor, relayer, deposit, 1);
     await spokePoolClient2.update();
@@ -418,7 +418,7 @@ describe("SpokePoolClient: Fill Validation", function () {
   });
 
   it("Loads fills from memory with deposit ID > spoke pool client's earliest deposit ID queried", async function () {
-    const deposit = await buildDeposit(hubPoolClient, spokePool_1, erc20_1, l1Token, depositor, destinationChainId);
+    const deposit = await buildDeposit(hubPoolClient, spokePool_1, erc20_1, depositor, destinationChainId);
     const fill = await buildFill(spokePool_2, erc20_2, depositor, relayer, deposit, 1);
     await spokePoolClient1.update();
     expect(spokePoolClient1.earliestDepositIdQueried == 0).is.true;
@@ -435,7 +435,7 @@ describe("SpokePoolClient: Fill Validation", function () {
 
   it("Loads fills from memory with deposit ID < spoke pool client's latest deposit ID queried", async function () {
     // Send fill for deposit ID 0.
-    const deposit = await buildDeposit(hubPoolClient, spokePool_1, erc20_1, l1Token, depositor, destinationChainId);
+    const deposit = await buildDeposit(hubPoolClient, spokePool_1, erc20_1, depositor, destinationChainId);
     const fill = await buildFill(spokePool_2, erc20_2, depositor, relayer, deposit, 1);
     await spokePoolClient1.update();
     // Manually override latest deposit ID queried so that its > deposit ID.
@@ -452,7 +452,7 @@ describe("SpokePoolClient: Fill Validation", function () {
   });
 
   it("Ignores fills with deposit ID < first deposit ID in spoke pool", async function () {
-    const deposit = await buildDeposit(hubPoolClient, spokePool_1, erc20_1, l1Token, depositor, destinationChainId);
+    const deposit = await buildDeposit(hubPoolClient, spokePool_1, erc20_1, depositor, destinationChainId);
     await buildFill(spokePool_2, erc20_2, depositor, relayer, deposit, 1);
     await spokePoolClient2.update();
     const [fill] = spokePoolClient2.getFills();
@@ -470,7 +470,6 @@ describe("SpokePoolClient: Fill Validation", function () {
       hubPoolClient,
       spokePool_1,
       erc20_1,
-      l1Token,
       depositor,
       destinationChainId
     );
@@ -496,7 +495,7 @@ describe("SpokePoolClient: Fill Validation", function () {
   });
 
   it("Returns sped up deposit matched with fill", async function () {
-    const deposit_1 = await buildDeposit(hubPoolClient, spokePool_1, erc20_1, l1Token, depositor, destinationChainId);
+    const deposit_1 = await buildDeposit(hubPoolClient, spokePool_1, erc20_1, depositor, destinationChainId);
     // Override the fill's realized LP fee % and destination token so that it matches the deposit's default zero'd
     // out values. The destination token and realized LP fee % are set by the spoke pool client by querying the hub pool
     // contract state, however this test ignores the rate model contract and therefore there is no hub pool contract
@@ -548,7 +547,7 @@ describe("SpokePoolClient: Fill Validation", function () {
         realizedLpFeePct: toBN(0),
       })
     ).excludingEvery(["blockTimestamp", "logIndex", "transactionIndex", "transactionHash", "quoteBlockNumber"]);
-    const deposit = await buildDeposit(hubPoolClient, spokePool_1, erc20_1, l1Token, depositor, destinationChainId);
+    const deposit = await buildDeposit(hubPoolClient, spokePool_1, erc20_1, depositor, destinationChainId);
     await buildFill(spokePool_2, erc20_2, depositor, relayer, deposit, 1);
 
     await spokePoolClient2.update();

--- a/test/SpokePoolClient.ValidateFill.ts
+++ b/test/SpokePoolClient.ValidateFill.ts
@@ -466,13 +466,7 @@ describe("SpokePoolClient: Fill Validation", function () {
   });
 
   it("Ignores fills with deposit ID > latest deposit ID in spoke pool", async function () {
-    const sampleDeposit = await buildDeposit(
-      hubPoolClient,
-      spokePool_1,
-      erc20_1,
-      depositor,
-      destinationChainId
-    );
+    const sampleDeposit = await buildDeposit(hubPoolClient, spokePool_1, erc20_1, depositor, destinationChainId);
     // Override the deposit ID that we are "filling" to be > 1, the latest deposit ID in spoke pool 1.
     await buildFill(
       spokePool_2,

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -282,7 +282,6 @@ export async function addLiquidity(
 export async function buildDepositStruct(
   deposit: Omit<Deposit, "destinationToken" | "realizedLpFeePct">,
   hubPoolClient: HubPoolClient,
-  l1TokenForDepositedToken: Contract
 ): Promise<Deposit & { quoteBlockNumber: number; blockNumber: number }> {
   const blockNumber = await hubPoolClient.getBlockNumber(deposit.quoteTimestamp);
   if (!blockNumber) {
@@ -293,7 +292,6 @@ export async function buildDepositStruct(
       ...deposit,
       blockNumber,
     },
-    l1TokenForDepositedToken.address
   );
   return {
     ...deposit,
@@ -308,7 +306,6 @@ export async function buildDeposit(
   hubPoolClient: HubPoolClient,
   spokePool: Contract,
   tokenToDeposit: Contract,
-  l1TokenForDepositedToken: Contract,
   recipientAndDepositor: SignerWithAddress,
   _destinationChainId: number,
   _amountToDeposit: BigNumber = amountToDeposit,
@@ -325,7 +322,7 @@ export async function buildDeposit(
   );
   // Sanity Check: Ensure that the deposit was successful.
   expect(_deposit).to.not.be.null;
-  return await buildDepositStruct(appendMessageToResult(_deposit), hubPoolClient, l1TokenForDepositedToken);
+  return await buildDepositStruct(appendMessageToResult(_deposit), hubPoolClient);
 }
 
 // Submits a fillRelay transaction and returns the Fill struct that that clients will interact with.

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -281,18 +281,16 @@ export async function addLiquidity(
 // Submits a deposit transaction and returns the Deposit struct that that clients interact with.
 export async function buildDepositStruct(
   deposit: Omit<Deposit, "destinationToken" | "realizedLpFeePct">,
-  hubPoolClient: HubPoolClient,
+  hubPoolClient: HubPoolClient
 ): Promise<Deposit & { quoteBlockNumber: number; blockNumber: number }> {
   const blockNumber = await hubPoolClient.getBlockNumber(deposit.quoteTimestamp);
   if (!blockNumber) {
     throw new Error("Timestamp is undefined");
   }
-  const { quoteBlock, realizedLpFeePct } = await hubPoolClient.computeRealizedLpFeePct(
-    {
-      ...deposit,
-      blockNumber,
-    },
-  );
+  const { quoteBlock, realizedLpFeePct } = await hubPoolClient.computeRealizedLpFeePct({
+    ...deposit,
+    blockNumber,
+  });
   return {
     ...deposit,
     message: "0x",


### PR DESCRIPTION
This change removes a source of significant inefficiency in the HubPoolClient. The pre-existing implementation processes each Deposit's realizedLpFeePct independently, but in parallel. In cases where there are n deposits with the same quoteTimestamp, this results in n concurrent searches for the underlying block number. Additionally, when there are n deposits with matching originToken and quoteTimestamp (as can easily happen with the popular tokens like (W)ETH and USDC) this results in similarly duplicate queries for the "opening" HubPool utilization at the resolved block number.

This commit updates the implementation as follows:
 - Pass the set of Deposits to be computed by the HubPoolClient as an array, rather than individually.
 - Filter quoteTimestamps for uniqueness before resolving the corresponding HubPool block number.
 - Map HubPool tokens to quoteTimestamps and eventually block numbers in batch.
 - Query "opening" HubPool utilization for each HubPool token at the relevant block once, and reference the result later for each unique deposit.

Debug logging added indicates a significant drop in the number of HubPool block numbers that need to be resolved; this is especially the case on popular deposit chains like zkSync and Arbitrum.