### PR TITLE
improve(SpokePoolClient): Optimize algorithm for appending speed up data to deposits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.17.12",
+  "version": "0.17.11",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/v/developer-docs/developers/across-sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.17.11",
+  "version": "0.17.12",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/v/developer-docs/developers/across-sdk",
   "files": [

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -729,7 +729,7 @@ export class SpokePoolClient extends BaseAbstractClient {
         newSpeedUps.push(speedUp);
       }
 
-      // `appendMaxSpeedUpSignatureToDeposit` assu,es that all this.speedUps has all speedups stored into memory.
+      // `appendMaxSpeedUpSignatureToDeposit` assumes that all this.speedUps has all speedups stored into memory.
       for (const speedUp of newSpeedUps) {
         // Find deposit hash matching this speed up event and update the deposit data associated with the hash,
         // if the hash+data exists.

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -729,7 +729,7 @@ export class SpokePoolClient extends BaseAbstractClient {
         newSpeedUps.push(speedUp);
       }
 
-      // `appendMaxSpeedUpSignatureToDeposit` assumes that all this.speedUps has all speedups stored into memory.
+      // `appendMaxSpeedUpSignatureToDeposit` assu,es that all this.speedUps has all speedups stored into memory.
       for (const speedUp of newSpeedUps) {
         // Find deposit hash matching this speed up event and update the deposit data associated with the hash,
         // if the hash+data exists.

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -727,7 +727,7 @@ export class SpokePoolClient extends BaseAbstractClient {
         assign(this.speedUps, [speedUp.depositor, speedUp.depositId], [speedUp]);
       }
 
-      // `appendMaxSpeedUpSignatureToDeposit` assumes that all this.speedUps has all speedups stored in memory.
+      // `appendMaxSpeedUpSignatureToDeposit` assu,es that all this.speedUps has all speedups stored into memory.
       for (const [, speedUpDataByDepositId] of Object.entries(this.speedUps)) {
         for (const [, speedUps] of Object.entries(speedUpDataByDepositId)) {
           for (const speedUp of speedUps) {

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -722,15 +722,10 @@ export class SpokePoolClient extends BaseAbstractClient {
     if (eventsToQuery.includes("RequestedSpeedUpDeposit")) {
       const speedUpEvents = queryResults[eventsToQuery.indexOf("RequestedSpeedUpDeposit")];
 
-      const newSpeedUps: SpeedUp[] = [];
       for (const event of speedUpEvents) {
         const speedUp: SpeedUp = { ...spreadEvent(event.args), originChainId: this.chainId };
         assign(this.speedUps, [speedUp.depositor, speedUp.depositId], [speedUp]);
-        newSpeedUps.push(speedUp);
-      }
 
-      // `appendMaxSpeedUpSignatureToDeposit` assu,es that all this.speedUps has all speedups stored into memory.
-      for (const speedUp of newSpeedUps) {
         // Find deposit hash matching this speed up event and update the deposit data associated with the hash,
         // if the hash+data exists.
         const depositHash = this.getDepositHash(speedUp);

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -722,28 +722,24 @@ export class SpokePoolClient extends BaseAbstractClient {
     if (eventsToQuery.includes("RequestedSpeedUpDeposit")) {
       const speedUpEvents = queryResults[eventsToQuery.indexOf("RequestedSpeedUpDeposit")];
 
+      const newSpeedUps: SpeedUp[] = [];
       for (const event of speedUpEvents) {
         const speedUp: SpeedUp = { ...spreadEvent(event.args), originChainId: this.chainId };
         assign(this.speedUps, [speedUp.depositor, speedUp.depositId], [speedUp]);
+        newSpeedUps.push(speedUp);
       }
 
-      // `appendMaxSpeedUpSignatureToDeposit` assu,es that all this.speedUps has all speedups stored into memory.
-      for (const [, speedUpDataByDepositId] of Object.entries(this.speedUps)) {
-        for (const [, speedUps] of Object.entries(speedUpDataByDepositId)) {
-          for (const speedUp of speedUps) {
-            // Find deposit hash matching this speed up event and update the deposit data associated with the hash,
-            // if the hash+data exists.
-            const depositHash = this.getDepositHash(speedUp);
+      // `appendMaxSpeedUpSignatureToDeposit` assumes that all this.speedUps has all speedups stored into memory.
+      for (const speedUp of newSpeedUps) {
+        // Find deposit hash matching this speed up event and update the deposit data associated with the hash,
+        // if the hash+data exists.
+        const depositHash = this.getDepositHash(speedUp);
 
-            // We can assume all deposits in this lookback window are loaded in-memory already so if the depositHash
-            // is not mapped to a deposit, then we can throw away the speedup as it can't be applied to anything.
-            const depositDataAssociatedWithSpeedUp = this.depositHashes[depositHash];
-            if (isDefined(depositDataAssociatedWithSpeedUp)) {
-              this.depositHashes[depositHash] = this.appendMaxSpeedUpSignatureToDeposit(
-                depositDataAssociatedWithSpeedUp
-              );
-            }
-          }
+        // We can assume all deposits in this lookback window are loaded in-memory already so if the depositHash
+        // is not mapped to a deposit, then we can throw away the speedup as it can't be applied to anything.
+        const depositDataAssociatedWithSpeedUp = this.depositHashes[depositHash];
+        if (isDefined(depositDataAssociatedWithSpeedUp)) {
+          this.depositHashes[depositHash] = this.appendMaxSpeedUpSignatureToDeposit(depositDataAssociatedWithSpeedUp);
         }
       }
     }

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -722,10 +722,15 @@ export class SpokePoolClient extends BaseAbstractClient {
     if (eventsToQuery.includes("RequestedSpeedUpDeposit")) {
       const speedUpEvents = queryResults[eventsToQuery.indexOf("RequestedSpeedUpDeposit")];
 
+      const newSpeedUps: SpeedUp[] = [];
       for (const event of speedUpEvents) {
         const speedUp: SpeedUp = { ...spreadEvent(event.args), originChainId: this.chainId };
         assign(this.speedUps, [speedUp.depositor, speedUp.depositId], [speedUp]);
+        newSpeedUps.push(speedUp);
+      }
 
+      // `appendMaxSpeedUpSignatureToDeposit` assu,es that all this.speedUps has all speedups stored into memory.
+      for (const speedUp of newSpeedUps) {
         // Find deposit hash matching this speed up event and update the deposit data associated with the hash,
         // if the hash+data exists.
         const depositHash = this.getDepositHash(speedUp);

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -727,7 +727,7 @@ export class SpokePoolClient extends BaseAbstractClient {
         assign(this.speedUps, [speedUp.depositor, speedUp.depositId], [speedUp]);
       }
 
-      // `appendMaxSpeedUpSignatureToDeposit` assu,es that all this.speedUps has all speedups stored into memory.
+      // `appendMaxSpeedUpSignatureToDeposit` assumes that all this.speedUps has all speedups stored in memory.
       for (const [, speedUpDataByDepositId] of Object.entries(this.speedUps)) {
         for (const [, speedUps] of Object.entries(speedUpDataByDepositId)) {
           for (const speedUp of speedUps) {

--- a/test/SpokePoolClient.SpeedUp.ts
+++ b/test/SpokePoolClient.SpeedUp.ts
@@ -130,6 +130,9 @@ describe("SpokePoolClient: SpeedUp", function () {
     // Deposit is not returned until we reach deposit.quoteTimestamp.
     expect(spokePoolClient.getDepositsForDestinationChain(destinationChainId).length).to.equal(0);
     await spokePool.setCurrentTime(deposit.quoteTimestamp);
+
+    // Clear out spoke pool client data and re-update so that it should now see the formerly "early" deposit.
+    spokePoolClient = new SpokePoolClient(createSpyLogger().spyLogger, spokePool, null, originChainId, deploymentBlock);
     await spokePoolClient.update();
 
     // After speedup should return the appended object with the new fee information and signature.

--- a/test/SpokePoolClient.SpeedUp.ts
+++ b/test/SpokePoolClient.SpeedUp.ts
@@ -130,9 +130,6 @@ describe("SpokePoolClient: SpeedUp", function () {
     // Deposit is not returned until we reach deposit.quoteTimestamp.
     expect(spokePoolClient.getDepositsForDestinationChain(destinationChainId).length).to.equal(0);
     await spokePool.setCurrentTime(deposit.quoteTimestamp);
-
-    // Clear out spoke pool client data and re-update so that it should now see the formerly "early" deposit.
-    spokePoolClient = new SpokePoolClient(createSpyLogger().spyLogger, spokePool, null, originChainId, deploymentBlock);
     await spokePoolClient.update();
 
     // After speedup should return the appended object with the new fee information and signature.


### PR DESCRIPTION
This PR optimizes compute time for the case where there is a speed up deposit in a SpokePoolClient update.

Currently the algorithm for adding speed up data to deposits is:
- load all speed up events into memory
- loop through all deposits already stored in memory, detect if there is a speed up event newly saved into memory for the deposit, and update the deposit

We needlessly loop through all deposits since there are expected to very few speed ups in a given lookback window relative to the number of deposits loaded. Instead, the proposed algorithm is:
- load all speed up events into memory
- for each new speed up data newly saved, detect if there is a deposit data stored in memory matching the speed up, and update the deposit
Merge state
