### PR TITLE
improve(ConfigStoreClient): Improve logs and optimistically don't load `latestBlockNumber` if passed in as search config toBlock

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.17.13",
+  "version": "0.17.14",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/v/developer-docs/developers/across-sdk",
   "files": [

--- a/src/clients/mocks/MockConfigStoreClient.ts
+++ b/src/clients/mocks/MockConfigStoreClient.ts
@@ -108,7 +108,6 @@ export class MockConfigStoreClient extends AcrossConfigStoreClient {
     return {
       success: true,
       chainId: this.chainId as number,
-      latestBlockNumber,
       searchEndBlock: this.eventSearchConfig.toBlock || latestBlockNumber,
       events: {
         updatedGlobalConfigEvents: events["UpdatedGlobalConfig"],

--- a/src/relayFeeCalculator/chain-queries/optimism.ts
+++ b/src/relayFeeCalculator/chain-queries/optimism.ts
@@ -5,7 +5,7 @@ import {
   TOKEN_SYMBOLS_MAP,
   CHAIN_IDs,
   DEFAULT_SIMULATED_RELAYER_ADDRESS,
-  DEFAULT_SIMULATED_RELAYER_ADDRESS_TEST
+  DEFAULT_SIMULATED_RELAYER_ADDRESS_TEST,
 } from "../../constants";
 import { asL2Provider } from "@eth-optimism/sdk/dist/l2-provider";
 import QueryBase from "./baseQuery";

--- a/test/SpokePoolClient.ValidateFill.ts
+++ b/test/SpokePoolClient.ValidateFill.ts
@@ -274,7 +274,7 @@ describe("SpokePoolClient: Fill Validation", function () {
       amount: toBNWei("1"),
       destinationChainId: destinationChainId,
       relayerFeePct: toBNWei("0.01"),
-      quoteTimestamp: await spokePool_1.getCurrentTime()
+      quoteTimestamp: await spokePool_1.getCurrentTime(),
     });
     const depositData = await spokePool_1.populateTransaction.deposit(...depositParams);
     await spokePool_1.connect(depositor).multicall(Array(3).fill(depositData.data));


### PR DESCRIPTION
Precursor to support https://github.com/across-protocol/relayer-v2/pull/1085