### PR TITLE
improve(BlockFinder): Allow the caller to supply hints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.17.14",
+  "version": "0.17.15",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/v/developer-docs/developers/across-sdk",
   "files": [

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -235,8 +235,8 @@ export class HubPoolClient extends BaseAbstractClient {
   }
 
   getBlockNumber(timestamp: number): Promise<number | undefined> {
-    const hint = { lowBlock: this.deploymentBlock };
-    return getCachedBlockForTimestamp(this.chainId, timestamp, this.blockFinder, this.cachingMechanism, hint);
+    const hints = { lowBlock: this.deploymentBlock };
+    return getCachedBlockForTimestamp(this.chainId, timestamp, this.blockFinder, this.cachingMechanism, hints);
   }
 
   async getCurrentPoolUtilization(l1Token: string): Promise<BigNumberish> {

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -235,7 +235,8 @@ export class HubPoolClient extends BaseAbstractClient {
   }
 
   getBlockNumber(timestamp: number): Promise<number | undefined> {
-    return getCachedBlockForTimestamp(this.chainId, timestamp, this.blockFinder, this.cachingMechanism);
+    const hints = { lowBlock: this.deploymentBlock };
+    return getCachedBlockForTimestamp(this.chainId, timestamp, this.blockFinder, this.cachingMechanism, hints);
   }
 
   async getCurrentPoolUtilization(l1Token: string): Promise<BigNumberish> {

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -235,8 +235,8 @@ export class HubPoolClient extends BaseAbstractClient {
   }
 
   getBlockNumber(timestamp: number): Promise<number | undefined> {
-    const hints = { lowBlock: this.deploymentBlock };
-    return getCachedBlockForTimestamp(this.chainId, timestamp, this.blockFinder, this.cachingMechanism, hints);
+    const hint = { lowBlock: this.deploymentBlock };
+    return getCachedBlockForTimestamp(this.chainId, timestamp, this.blockFinder, this.cachingMechanism, hint);
   }
 
   async getCurrentPoolUtilization(l1Token: string): Promise<BigNumberish> {

--- a/src/utils/BlockUtils.ts
+++ b/src/utils/BlockUtils.ts
@@ -119,7 +119,7 @@ export class BlockFinder {
     // If the hint is accurate, then this will bypass the subsequent estimation.
     await Promise.all(
       Object.values(hint)
-        .filter((blockNumber) => isDefined)
+        .filter((blockNumber) => isDefined(blockNumber))
         .map((blockNumber) => this.getBlock(blockNumber))
     );
 

--- a/src/utils/BlockUtils.ts
+++ b/src/utils/BlockUtils.ts
@@ -104,7 +104,8 @@ export class BlockFinder {
 
   /**
    * @notice Gets the latest block whose timestamp is <= the provided timestamp.
-   * @param {number} timestamp timestamp to search.
+   * @param number Timestamp timestamp to search.
+   * @param hints Optional low and high block to bound the search space.
    */
   public async getBlockForTimestamp(timestamp: number | string, hints: BlockFinderHints = {}): Promise<Block> {
     timestamp = Number(timestamp);

--- a/src/utils/BlockUtils.ts
+++ b/src/utils/BlockUtils.ts
@@ -91,7 +91,7 @@ async function estimateBlocksElapsed(seconds: number, cushionPercentage = 0.0, p
   return Math.floor((seconds * cushionMultiplier) / average);
 }
 
-export type BlockFinderHint = {
+export type BlockFinderHints = {
   lowBlock?: number;
   highBlock?: number;
 };
@@ -106,7 +106,7 @@ export class BlockFinder {
    * @notice Gets the latest block whose timestamp is <= the provided timestamp.
    * @param {number} timestamp timestamp to search.
    */
-  public async getBlockForTimestamp(timestamp: number | string, hint: BlockFinderHint = {}): Promise<Block> {
+  public async getBlockForTimestamp(timestamp: number | string, hints: BlockFinderHints = {}): Promise<Block> {
     timestamp = Number(timestamp);
     assert(timestamp !== undefined && timestamp !== null, "timestamp must be provided");
     // If the last block we have stored is too early, grab the latest block.
@@ -118,7 +118,7 @@ export class BlockFinder {
     // Prime the BlockFinder cache with any supplied hints.
     // If the hint is accurate, then this will bypass the subsequent estimation.
     await Promise.all(
-      Object.values(hint)
+      Object.values(hints)
         .filter((blockNumber) => isDefined(blockNumber))
         .map((blockNumber) => this.getBlock(blockNumber))
     );
@@ -226,11 +226,11 @@ export async function getCachedBlockForTimestamp(
   timestamp: number,
   blockFinder: BlockFinder,
   cache?: CachingMechanismInterface,
-  hint?: BlockFinderHint
+  hints?: BlockFinderHints
 ): Promise<number> {
   // Resolve a convenience function to directly compute what we're
   // looking for.
-  const resolver = async () => (await blockFinder.getBlockForTimestamp(timestamp, hint)).number;
+  const resolver = async () => (await blockFinder.getBlockForTimestamp(timestamp, hints)).number;
 
   // If no redis client, then request block from blockFinder.
   if (!isDefined(cache)) {

--- a/src/utils/BlockUtils.ts
+++ b/src/utils/BlockUtils.ts
@@ -116,7 +116,7 @@ export class BlockFinder {
     }
 
     // Prime the BlockFinder cache with any supplied hints.
-    // If the hint is accurante then this will bypass the subsequent estimation.
+    // If the hint is accurate, then this will bypass the subsequent estimation.
     await Promise.all(
       Object.values(hint)
         .filter((blockNumber) => isDefined)

--- a/src/utils/BlockUtils.ts
+++ b/src/utils/BlockUtils.ts
@@ -106,7 +106,7 @@ export class BlockFinder {
    * @notice Gets the latest block whose timestamp is <= the provided timestamp.
    * @param {number} timestamp timestamp to search.
    */
-  public async getBlockForTimestamp(timestamp: number | string, hints: BlockFinderHint): Promise<Block> {
+  public async getBlockForTimestamp(timestamp: number | string, hint: BlockFinderHint = {}): Promise<Block> {
     timestamp = Number(timestamp);
     assert(timestamp !== undefined && timestamp !== null, "timestamp must be provided");
     // If the last block we have stored is too early, grab the latest block.
@@ -118,7 +118,7 @@ export class BlockFinder {
     // Prime the BlockFinder cache with any supplied hints.
     // If the hint is accurante then this will bypass the subsequent estimation.
     await Promise.all(
-      Object.values(hints)
+      Object.values(hint)
         .filter((blockNumber) => isDefined)
         .map((blockNumber) => this.getBlock(blockNumber))
     );
@@ -226,11 +226,11 @@ export async function getCachedBlockForTimestamp(
   timestamp: number,
   blockFinder: BlockFinder,
   cache?: CachingMechanismInterface,
-  hints: BlockFinderHint = {}
+  hint?: BlockFinderHint
 ): Promise<number> {
   // Resolve a convenience function to directly compute what we're
   // looking for.
-  const resolver = async () => (await blockFinder.getBlockForTimestamp(timestamp, hints)).number;
+  const resolver = async () => (await blockFinder.getBlockForTimestamp(timestamp, hint)).number;
 
   // If no redis client, then request block from blockFinder.
   if (!isDefined(cache)) {

--- a/src/utils/BlockUtils.ts
+++ b/src/utils/BlockUtils.ts
@@ -117,7 +117,11 @@ export class BlockFinder {
 
     // Prime the BlockFinder cache with any supplied hints.
     // If the hint is accurante then this will bypass the subsequent estimation.
-    await Promise.all(Object.values(hints).map((blockNumber) => this.getBlock(blockNumber)));
+    await Promise.all(
+      Object.values(hints)
+        .filter((blockNumber) => isDefined)
+        .map((blockNumber) => this.getBlock(blockNumber))
+    );
 
     // Check the first block. If it's greater than our timestamp, we need to find an earlier block.
     if (this.blocks[0].timestamp > timestamp) {


### PR DESCRIPTION
If the caller supplies a sensible hint then this will skip the initial lower-bound block estimation, which can be wildly inaccurate in cases where the average block time has changed (especially reduced) over time. This is also nice because one of the main beneficiaries of this is in the relayer, the hinted lowBlock can be set statically, so it has a much greater chance of being served out of the RPC provider cache.