### PR TITLE
fix(HubPoolClient): Avoid utilization cache collisions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.17.16",
+  "version": "0.17.17",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/v/developer-docs/developers/across-sdk",
   "files": [

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -301,7 +301,7 @@ export class HubPoolClient extends BaseAbstractClient {
 
     // Otherwise, let's resolve the key
     // @note Avoid collisions with pre-existing cache keys by appending an underscore (_) for post-relay utilization.
-    // This can be removed once the existing keys have been ejected from the cache (i.e. 7 days).
+    // @fixme This can be removed once the existing keys have been ejected from the cache (i.e. 7 days).
     const key = depositAmount.eq(0)
       ? `utilization_${hubPoolToken}_${blockNumber}`
       : `utilization_${hubPoolToken}_${blockNumber}_${depositAmount.toString()}_`;


### PR DESCRIPTION
The last change to HubPool utilization computation ended up reusing the same cache key for post-relay utilization, but storing the value with a different format (1 number instead of 2 comma-separated).

This PR replaces the existing getUtilization() function because it's no longer used, and adds a temporarily change to the post-relay utilization key to avoid collisions until the original keys are ejected.

This was caught during final local testing of the PR to bump sdk-v2 within relayer-v2.