### PR TITLE
refator(SpokePoolClient): Make caller optional in events

### DIFF
--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -165,7 +165,7 @@ export interface RelayerRefundExecution {
   leafId: number;
   l2TokenAddress: string;
   refundAddresses: string[];
-  caller: string;
+  caller?: string;
 }
 
 export interface RelayerRefundExecutionWithBlock extends RelayerRefundExecution, SortableEvent {}
@@ -228,7 +228,7 @@ export interface TokensBridged extends SortableEvent {
   chainId: number;
   leafId: number;
   l2TokenAddress: string;
-  caller: string;
+  caller?: string;
 }
 
 export type TokensBridgedStringified = Omit<TokensBridged, "amountToReturn"> & {


### PR DESCRIPTION
The caller field is typically defaulting to the Multicall3 address. This has been eliminated for the USS and is not really useful pre-USS anyway.