### PR TITLE
improve(Clients): Set latestBlockNumber equal to latest block searched and remove redundant latestBlockSearched

### DIFF
--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -51,7 +51,6 @@ import { isUBAActivatedAtBlock } from "./UBAClient/UBAClientUtilities";
 type _HubPoolUpdate = {
   success: true;
   currentTime: number;
-  latestBlockNumber: number;
   pendingRootBundleProposal: PendingRootBundle;
   events: Record<string, Event[]>;
   searchEndBlock: number;
@@ -710,12 +709,11 @@ export class HubPoolClient extends BaseAbstractClient {
   }
 
   async _update(eventNames: HubPoolEvent[]): Promise<HubPoolUpdate> {
-    const latestBlockNumber = await this.hubPool.provider.getBlockNumber();
     const hubPoolEvents = this.hubPoolEventFilters();
 
     const searchConfig = {
       fromBlock: this.firstBlockToSearch,
-      toBlock: this.eventSearchConfig.toBlock || latestBlockNumber,
+      toBlock: this.eventSearchConfig.toBlock || (await this.hubPool.provider.getBlockNumber()),
       maxBlockLookBack: this.eventSearchConfig.maxBlockLookBack,
     };
     if (searchConfig.fromBlock > searchConfig.toBlock) {
@@ -745,7 +743,6 @@ export class HubPoolClient extends BaseAbstractClient {
     return {
       success: true,
       currentTime,
-      latestBlockNumber,
       pendingRootBundleProposal,
       searchEndBlock: searchConfig.toBlock,
       events: _events,
@@ -766,7 +763,7 @@ export class HubPoolClient extends BaseAbstractClient {
       // understand why we see this in test. @todo: Resolve.
       return;
     }
-    const { events, currentTime, latestBlockNumber, pendingRootBundleProposal } = update;
+    const { events, currentTime, pendingRootBundleProposal, searchEndBlock } = update;
 
     for (const event of events["CrossChainContractsSet"]) {
       const args = spreadEventWithBlockNumber(event) as CrossChainContractsSet;
@@ -906,11 +903,11 @@ export class HubPoolClient extends BaseAbstractClient {
     }
 
     this.currentTime = currentTime;
-    this.latestBlockNumber = latestBlockNumber;
+    this.latestBlockNumber = searchEndBlock;
     this.firstBlockToSearch = update.searchEndBlock + 1; // Next iteration should start off from where this one ended.
 
     this.isUpdated = true;
-    this.logger.debug({ at: "HubPoolClient::update", message: "HubPool client updated!", endBlock: latestBlockNumber });
+    this.logger.debug({ at: "HubPoolClient::update", message: "HubPool client updated!", searchEndBlock });
   }
 
   // Returns end block for `chainId` in ProposedRootBundle.bundleBlockEvalNumbers. Looks up chainId

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -56,7 +56,6 @@ type _SpokePoolUpdate = {
   success: boolean;
   currentTime: number;
   firstDepositId: number;
-  latestBlockNumber: number;
   latestDepositId: number;
   events: Event[][];
   // Blocks are only used if the UBA is active and events need to be ordered by blockTimestamp
@@ -85,7 +84,6 @@ export class SpokePoolClient extends BaseAbstractClient {
   public firstDepositIdForSpokePool = Number.MAX_SAFE_INTEGER;
   public lastDepositIdForSpokePool = Number.MAX_SAFE_INTEGER;
   public firstBlockToSearch: number;
-  public latestBlockSearched: number;
   public latestBlockNumber = 0;
   public fills: { [OriginChainId: number]: FillWithBlock[] } = {};
   public refundRequests: RefundRequestWithBlock[] = [];
@@ -110,7 +108,6 @@ export class SpokePoolClient extends BaseAbstractClient {
   ) {
     super();
     this.firstBlockToSearch = eventSearchConfig.fromBlock;
-    this.latestBlockSearched = eventSearchConfig.fromBlock;
     this.queryableEventNames = Object.keys(this._queryableEventNames());
   }
 
@@ -523,14 +520,9 @@ export class SpokePoolClient extends BaseAbstractClient {
       }
     }
 
-    const latestBlockNumber = await this.spokePool.provider.getBlockNumber();
-    if (isNaN(latestBlockNumber) || latestBlockNumber < this.latestBlockNumber) {
-      throw new Error(`SpokePoolClient::update: latestBlockNumber ${latestBlockNumber} < ${this.latestBlockNumber}`);
-    }
-
     const searchConfig = {
       fromBlock: this.firstBlockToSearch,
-      toBlock: this.eventSearchConfig.toBlock || latestBlockNumber,
+      toBlock: this.eventSearchConfig.toBlock || (await this.spokePool.provider.getBlockNumber()),
       maxBlockLookBack: this.eventSearchConfig.maxBlockLookBack,
     };
     if (searchConfig.fromBlock > searchConfig.toBlock) {
@@ -612,7 +604,6 @@ export class SpokePoolClient extends BaseAbstractClient {
       success: true,
       currentTime: currentTime.toNumber(), // uint32
       firstDepositId,
-      latestBlockNumber,
       latestDepositId: Math.max(numberOfDeposits - 1, 0),
       searchEndBlock: searchConfig.toBlock,
       events,
@@ -644,7 +635,7 @@ export class SpokePoolClient extends BaseAbstractClient {
       // understand why we see this in test. @todo: Resolve.
       return;
     }
-    const { events: queryResults, blocks, currentTime } = update;
+    const { events: queryResults, blocks, currentTime, searchEndBlock } = update;
 
     if (eventsToQuery.includes("TokensBridged")) {
       for (const event of queryResults[eventsToQuery.indexOf("TokensBridged")]) {
@@ -829,10 +820,9 @@ export class SpokePoolClient extends BaseAbstractClient {
     // Next iteration should start off from where this one ended.
     this.currentTime = currentTime;
     this.firstDepositIdForSpokePool = update.firstDepositId;
-    this.latestBlockNumber = update.latestBlockNumber;
+    this.latestBlockNumber = searchEndBlock;
     this.lastDepositIdForSpokePool = update.latestDepositId;
-    this.firstBlockToSearch = update.searchEndBlock + 1;
-    this.latestBlockSearched = update.searchEndBlock;
+    this.firstBlockToSearch = searchEndBlock + 1;
     this.isUpdated = true;
     this.log("debug", `SpokePool client for chain ${this.chainId} updated!`, {
       nextFirstBlockToSearch: this.firstBlockToSearch,
@@ -1096,7 +1086,6 @@ export class SpokePoolClient extends BaseAbstractClient {
     this.earliestDepositIdQueried = spokePoolClientState.earliestDepositIdQueried || this.earliestDepositIdQueried;
     this.latestDepositIdQueried = spokePoolClientState.latestDepositIdQueried || this.latestDepositIdQueried;
     this.firstBlockToSearch = spokePoolClientState.firstBlockToSearch || this.firstBlockToSearch;
-    this.latestBlockSearched = spokePoolClientState.latestBlockSearched || this.latestBlockSearched;
     this.fills = Object.entries(spokePoolClientState.fills || []).reduce(
       (acc, [chainId, fills]) => ({
         ...acc,
@@ -1160,7 +1149,6 @@ export class SpokePoolClient extends BaseAbstractClient {
       latestDepositIdQueried: this.latestDepositIdQueried,
       latestDepositIdForSpokePool: this.lastDepositIdForSpokePool,
       firstBlockToSearch: this.firstBlockToSearch,
-      latestBlockSearched: this.latestBlockSearched,
       isUpdated: this.isUpdated,
       fills: JSON.parse(stringifyJSONWithNumericString(this.fills)) as Record<string, FillWithBlockStringified[]>,
       refundRequests: JSON.parse(

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -237,7 +237,7 @@ export function getMostRecentBundleBlockRanges(
   if (isDefined(spokePoolClients[chainId])) {
     // Make the last bundle to cover until the last spoke client searched block, unless a spoke pool
     // client was provided for the chain. In this case we assume that chain is disabled.
-    bundleData[bundleData.length - 1].end = spokePoolClients[chainId].latestBlockSearched;
+    bundleData[bundleData.length - 1].end = spokePoolClients[chainId].latestBlockNumber;
   }
 
   return bundleData;

--- a/src/clients/UBAClient/UBAClientWithRefresh.ts
+++ b/src/clients/UBAClient/UBAClientWithRefresh.ts
@@ -839,7 +839,7 @@ export class UBAClientWithRefresh extends BaseAbstractClient {
           // Check 2: end block of last block range should be equal to latest spoke pool client block searched
           (isDefined(this.spokePoolClients[chainId]) &&
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            _blockRangesForChain.at(-1)![1] !== this.spokePoolClients[chainId].latestBlockSearched)
+            _blockRangesForChain.at(-1)![1] !== this.spokePoolClients[chainId].latestBlockNumber)
         ) {
           this.logger.error({
             at: "UBAClientWithRefresh#getMostRecentBundleBlockRangesPerChain",
@@ -847,7 +847,7 @@ export class UBAClientWithRefresh extends BaseAbstractClient {
             startBlockForChain: _blockRangesForChain[0][0],
             ubaActivationBundleStartBlockForChain,
             endBlockForChain: _blockRangesForChain.at(-1)?.[1],
-            latestSpokePoolClientBlockSearched: this.spokePoolClients[chainId]?.latestBlockSearched,
+            latestSpokePoolClientBlockSearched: this.spokePoolClients[chainId]?.latestBlockNumber,
           });
           throw new Error(
             `Block ranges for chain ${chainId} do not cover from UBA activation bundle start block to latest spoke pool client block searched`

--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -63,10 +63,6 @@ export class MockSpokePoolClient extends SpokePoolClient {
     return this.destinationTokenForChainOverride[deposit.originChainId] ?? super.getDestinationTokenForDeposit(deposit);
   }
 
-  setLatestBlockSearched(blockNumber: number): void {
-    this.latestBlockSearched = blockNumber;
-  }
-
   setLatestBlockNumber(blockNumber: number): void {
     this.latestBlockNumber = blockNumber;
   }

--- a/test/SpokePoolClient.ValidateFill.ts
+++ b/test/SpokePoolClient.ValidateFill.ts
@@ -411,6 +411,10 @@ describe("SpokePoolClient: Fill Validation", function () {
     spokePoolClient1.eventSearchConfig.toBlock = depositBlock - 1;
     await spokePoolClient1.update();
 
+    // Make sure that the client's latestBlockNumber encompasses the event so it can see it on the subsequent
+    // queryHistoricalDepositForFill call.
+    spokePoolClient1.latestBlockNumber = depositBlock;
+
     // Client has 0 deposits in memory so querying historical deposit sends fresh RPC requests.
     expect(spokePoolClient1.getDeposits().length).to.equal(0);
     const historicalDeposit = await queryHistoricalDepositForFill(spokePoolClient1, fill);

--- a/test/UBAClient.validateFlow.ts
+++ b/test/UBAClient.validateFlow.ts
@@ -99,7 +99,7 @@ describe("UBAClient: Flow validation", function () {
       const spokePoolClient = new MockSpokePoolClient(logger, spokePool, originChainId, deploymentBlock);
       spokePoolClients[originChainId] = spokePoolClient;
       hubPoolClient.setCrossChainContracts(originChainId, spokePool.address, deploymentBlock);
-      spokePoolClient.setLatestBlockSearched(deploymentBlock + 1000);
+      spokePoolClient.latestBlockNumber = deploymentBlock + 1000;
       await spokePoolClient.update();
     }
 

--- a/test/UBAClientUtilities.ts
+++ b/test/UBAClientUtilities.ts
@@ -76,7 +76,7 @@ describe("UBAClientUtilities", function () {
       const spokePoolClient = new MockSpokePoolClient(logger, spokePool, originChainId, deploymentBlock);
       spokePoolClients[originChainId] = spokePoolClient;
       hubPoolClient.setCrossChainContracts(originChainId, spokePool.address, deploymentBlock);
-      spokePoolClient.setLatestBlockSearched(deploymentBlock + 1000);
+      spokePoolClient.latestBlockNumber = deploymentBlock + 1000;
       spokePoolClient.setDestinationTokenForChain(originChainId, l2Token);
     }
   });
@@ -150,7 +150,7 @@ describe("UBAClientUtilities", function () {
       deepEqualsWithBigNumber(result, [
         {
           start: getUbaActivationBundleStartBlocks(hubPoolClient)[0],
-          end: spokePoolClients[chainIds[0]].latestBlockSearched,
+          end: spokePoolClients[chainIds[0]].latestBlockNumber,
         },
       ]);
     });
@@ -162,7 +162,7 @@ describe("UBAClientUtilities", function () {
       deepEqualsWithBigNumber(defaultResult, [
         {
           start: getUbaActivationBundleStartBlocks(hubPoolClient)[0],
-          end: spokePoolClients[chainIds[0]].latestBlockSearched,
+          end: spokePoolClients[chainIds[0]].latestBlockNumber,
         },
       ]);
     });
@@ -186,13 +186,13 @@ describe("UBAClientUtilities", function () {
 
       // Get 2 most recent bundles. Should return single range with start equal to UBA activation block
       // and end equal to latest block searched for spoke pool client. Override the spoke pool clients
-      // mapping to make sure that the new chain's "latestBlockSearched" is > 0.
+      // mapping to make sure that the new chain's "latestBlockNumber" is > 0.
       const spokePoolClientForNewChain = spokePoolClients[chainIds[0]];
       const result = getMostRecentBundleBlockRanges(99, 2, hubPoolClient, {
         ...spokePoolClients,
         [99]: spokePoolClientForNewChain,
       });
-      deepEqualsWithBigNumber(result, [{ start: 0, end: spokePoolClientForNewChain.latestBlockSearched }]);
+      deepEqualsWithBigNumber(result, [{ start: 0, end: spokePoolClientForNewChain.latestBlockNumber }]);
     });
   });
   describe("getOpeningRunningBalances", function () {

--- a/test/utils/HubPoolUtils.ts
+++ b/test/utils/HubPoolUtils.ts
@@ -95,7 +95,7 @@ export async function publishValidatedBundles(
   // client was provided for the chain. In this case we assume that chain is disabled.
   chainIds.forEach((chainId) => {
     expectedBlockRanges[chainId][expectedBlockRanges[chainId].length - 1].end =
-      spokePoolClients[chainId].latestBlockSearched;
+      spokePoolClients[chainId].latestBlockNumber;
   });
   return expectedBlockRanges;
 }


### PR DESCRIPTION
Downstream users of the HubPoolClient and the SpokePoolClient expect that the `latestBlockNumber` is the latest block seen by the appropriate providers. However, this is not the case if the clients' `searchConfig.toBlock` lags the HEAD block on the chain, which is possible in production especially since SpokePoolClient updates take a long time to run and are done in parallel.
