### PR TITLE
improve: rename `latestBlockNumber` to `latestBlockSearched`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.17.17",
+  "version": "0.18.0",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/v/developer-docs/developers/across-sdk",
   "files": [

--- a/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
+++ b/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
@@ -75,8 +75,6 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
   public cumulativeDisabledChainUpdates: DisabledChainsUpdate[] = [];
 
   protected rateModelDictionary: across.rateModel.RateModelDictionary;
-  public firstBlockToSearch: number;
-  public latestBlockSearched = 0;
 
   public hasLatestConfigStoreVersion = false;
   public chainId: number | undefined;
@@ -89,6 +87,7 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
   ) {
     super();
     this.firstBlockToSearch = eventSearchConfig.fromBlock;
+    this.latestBlockSearched = 0;
     this.rateModelDictionary = new across.rateModel.RateModelDictionary();
   }
 

--- a/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
+++ b/src/clients/AcrossConfigStoreClient/AcrossConfigStoreClient.ts
@@ -76,7 +76,7 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
 
   protected rateModelDictionary: across.rateModel.RateModelDictionary;
   public firstBlockToSearch: number;
-  public latestBlockNumber = 0;
+  public latestBlockSearched = 0;
 
   public hasLatestConfigStoreVersion = false;
   public chainId: number | undefined;
@@ -519,7 +519,7 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
     this.rateModelDictionary.updateWithEvents(this.cumulativeRateModelUpdates);
 
     this.hasLatestConfigStoreVersion = this.hasValidConfigStoreVersionForTimestamp();
-    this.latestBlockNumber = result.searchEndBlock;
+    this.latestBlockSearched = result.searchEndBlock;
     this.firstBlockToSearch = result.searchEndBlock + 1; // Next iteration should start off from where this one ended.
     this.chainId = this.chainId ?? chainId; // Update on the first run only.
     this.isUpdated = true;
@@ -576,7 +576,7 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
       cumulativeDisabledChainUpdates = this.cumulativeDisabledChainUpdates,
       firstBlockToSearch = this.firstBlockToSearch,
       hasLatestConfigStoreVersion = this.hasLatestConfigStoreVersion,
-      latestBlockNumber = this.latestBlockNumber,
+      latestBlockSearched = this.latestBlockSearched,
       ubaConfigUpdates,
       cumulativeSpokeTargetBalanceUpdates,
     } = configStoreClientState;
@@ -611,7 +611,7 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
     this.cumulativeDisabledChainUpdates = cumulativeDisabledChainUpdates;
     this.firstBlockToSearch = firstBlockToSearch;
     this.hasLatestConfigStoreVersion = hasLatestConfigStoreVersion;
-    this.latestBlockNumber = latestBlockNumber;
+    this.latestBlockSearched = latestBlockSearched;
     this.rateModelDictionary.updateWithEvents(cumulativeRateModelUpdates);
     this.isUpdated = true;
   }
@@ -634,7 +634,7 @@ export class AcrossConfigStoreClient extends BaseAbstractClient {
       cumulativeConfigStoreVersionUpdates: this.cumulativeConfigStoreVersionUpdates,
       cumulativeDisabledChainUpdates: this.cumulativeDisabledChainUpdates,
       firstBlockToSearch: this.firstBlockToSearch,
-      latestBlockNumber: this.latestBlockNumber,
+      latestBlockSearched: this.latestBlockSearched,
       hasLatestConfigStoreVersion: this.hasLatestConfigStoreVersion,
     };
   }

--- a/src/clients/BaseAbstractClient.ts
+++ b/src/clients/BaseAbstractClient.ts
@@ -6,6 +6,8 @@ import { isDefined } from "../utils";
  */
 export abstract class BaseAbstractClient {
   protected _isUpdated: boolean;
+  public firstBlockToSearch = 0;
+  public latestBlockSearched: number | undefined;
 
   /**
    * Creates a new client.

--- a/src/clients/BaseAbstractClient.ts
+++ b/src/clients/BaseAbstractClient.ts
@@ -7,7 +7,7 @@ import { isDefined } from "../utils";
 export abstract class BaseAbstractClient {
   protected _isUpdated: boolean;
   public firstBlockToSearch = 0;
-  public latestBlockSearched: number | undefined;
+  public latestBlockSearched = 0;
 
   /**
    * Creates a new client.

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -84,8 +84,6 @@ export class HubPoolClient extends BaseAbstractClient {
   } = {};
   protected pendingRootBundle: PendingRootBundle | undefined;
 
-  public firstBlockToSearch: number;
-  public latestBlockSearched: number | undefined;
   public currentTime: number | undefined;
   public readonly blockFinder: BlockFinder;
 

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -85,7 +85,7 @@ export class HubPoolClient extends BaseAbstractClient {
   protected pendingRootBundle: PendingRootBundle | undefined;
 
   public firstBlockToSearch: number;
-  public latestBlockNumber: number | undefined;
+  public latestBlockSearched: number | undefined;
   public currentTime: number | undefined;
   public readonly blockFinder: BlockFinder;
 
@@ -107,7 +107,7 @@ export class HubPoolClient extends BaseAbstractClient {
     cachingMechanism?: CachingMechanismInterface
   ) {
     super(cachingMechanism);
-    this.latestBlockNumber = deploymentBlock === 0 ? deploymentBlock : deploymentBlock - 1;
+    this.latestBlockSearched = deploymentBlock === 0 ? deploymentBlock : deploymentBlock - 1;
     this.firstBlockToSearch = eventSearchConfig.fromBlock;
 
     const provider = this.hubPool.provider;
@@ -466,7 +466,7 @@ export class HubPoolClient extends BaseAbstractClient {
   }
 
   getL1TokenInfoForL2Token(l2Token: string, chainId: number): L1Token | undefined {
-    const l1TokenCounterpart = this.getL1TokenCounterpartAtBlock(chainId, l2Token, this.latestBlockNumber || 0);
+    const l1TokenCounterpart = this.getL1TokenCounterpartAtBlock(chainId, l2Token, this.latestBlockSearched || 0);
     return this.getTokenInfoForL1Token(l1TokenCounterpart);
   }
 
@@ -623,7 +623,7 @@ export class HubPoolClient extends BaseAbstractClient {
     if (n === 0) {
       throw new Error("n cannot be 0");
     }
-    if (!this.latestBlockNumber) {
+    if (!this.latestBlockSearched) {
       throw new Error("HubPoolClient::getNthFullyExecutedRootBundle client not updated");
     }
 
@@ -632,7 +632,7 @@ export class HubPoolClient extends BaseAbstractClient {
     // If n is negative, then return the Nth latest executed bundle, otherwise return the Nth earliest
     // executed bundle.
     if (n < 0) {
-      let nextLatestMainnetBlock = startBlock ?? this.latestBlockNumber;
+      let nextLatestMainnetBlock = startBlock ?? this.latestBlockSearched;
       for (let i = 0; i < Math.abs(n); i++) {
         bundleToReturn = this.getLatestFullyExecutedRootBundle(nextLatestMainnetBlock);
         const bundleBlockNumber = bundleToReturn ? bundleToReturn.blockNumber : 0;
@@ -644,12 +644,12 @@ export class HubPoolClient extends BaseAbstractClient {
     } else {
       let nextStartBlock = startBlock ?? 0;
       for (let i = 0; i < n; i++) {
-        bundleToReturn = this.getEarliestFullyExecutedRootBundle(this.latestBlockNumber, nextStartBlock);
+        bundleToReturn = this.getEarliestFullyExecutedRootBundle(this.latestBlockSearched, nextStartBlock);
         const bundleBlockNumber = bundleToReturn ? bundleToReturn.blockNumber : 0;
 
         // Add 1 so that next `getEarliestFullyExecutedRootBundle` call filters out the root bundle we just found
         // because its block number is < nextStartBlock.
-        nextStartBlock = Math.min(bundleBlockNumber + 1, this.latestBlockNumber);
+        nextStartBlock = Math.min(bundleBlockNumber + 1, this.latestBlockSearched);
       }
     }
 
@@ -903,7 +903,7 @@ export class HubPoolClient extends BaseAbstractClient {
     }
 
     this.currentTime = currentTime;
-    this.latestBlockNumber = searchEndBlock;
+    this.latestBlockSearched = searchEndBlock;
     this.firstBlockToSearch = update.searchEndBlock + 1; // Next iteration should start off from where this one ended.
 
     this.isUpdated = true;
@@ -960,7 +960,7 @@ export class HubPoolClient extends BaseAbstractClient {
       crossChainContracts = this.crossChainContracts,
       l1TokensToDestinationTokensWithBlock = this.l1TokensToDestinationTokensWithBlock,
       firstBlockToSearch = this.firstBlockToSearch,
-      latestBlockNumber = this.latestBlockNumber,
+      latestBlockSearched = this.latestBlockSearched,
       currentTime = this.currentTime,
       proposedRootBundles,
       executedRootBundles,
@@ -990,7 +990,7 @@ export class HubPoolClient extends BaseAbstractClient {
     this.crossChainContracts = crossChainContracts;
     this.l1TokensToDestinationTokensWithBlock = l1TokensToDestinationTokensWithBlock;
     this.firstBlockToSearch = firstBlockToSearch;
-    this.latestBlockNumber = latestBlockNumber;
+    this.latestBlockSearched = latestBlockSearched;
     this.currentTime = currentTime;
     this.isUpdated = true;
   }
@@ -1003,7 +1003,7 @@ export class HubPoolClient extends BaseAbstractClient {
       configOverride: this.configOverride,
 
       firstBlockToSearch: this.firstBlockToSearch,
-      latestBlockNumber: this.latestBlockNumber,
+      latestBlockSearched: this.latestBlockSearched,
       currentTime: this.currentTime,
 
       l1TokensToDestinationTokens: this.l1TokensToDestinationTokens,

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -241,7 +241,7 @@ export class HubPoolClient extends BaseAbstractClient {
   }
 
   async getCurrentPoolUtilization(l1Token: string): Promise<BigNumber> {
-    const blockNumber = this.latestBlockNumber ?? await this.hubPool.provider.getBlockNumber();
+    const blockNumber = this.latestBlockSearched ?? await this.hubPool.provider.getBlockNumber();
     return await this.getUtilization(l1Token, blockNumber, bnZero, getCurrentTime(), 0);
   }
 

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -107,7 +107,7 @@ export class HubPoolClient extends BaseAbstractClient {
     cachingMechanism?: CachingMechanismInterface
   ) {
     super(cachingMechanism);
-    this.latestBlockSearched = deploymentBlock === 0 ? deploymentBlock : deploymentBlock - 1;
+    this.latestBlockSearched = Math.min(deploymentBlock - 1, 0);
     this.firstBlockToSearch = eventSearchConfig.fromBlock;
 
     const provider = this.hubPool.provider;

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -51,7 +51,6 @@ import { isUBAActivatedAtBlock } from "./UBAClient/UBAClientUtilities";
 type _HubPoolUpdate = {
   success: true;
   currentTime: number;
-  latestBlockNumber: number;
   pendingRootBundleProposal: PendingRootBundle;
   events: Record<string, Event[]>;
   searchEndBlock: number;
@@ -710,12 +709,11 @@ export class HubPoolClient extends BaseAbstractClient {
   }
 
   async _update(eventNames: HubPoolEvent[]): Promise<HubPoolUpdate> {
-    const latestBlockNumber = await this.hubPool.provider.getBlockNumber();
     const hubPoolEvents = this.hubPoolEventFilters();
 
     const searchConfig = {
       fromBlock: this.firstBlockToSearch,
-      toBlock: this.eventSearchConfig.toBlock || latestBlockNumber,
+      toBlock: this.eventSearchConfig.toBlock || (await this.hubPool.provider.getBlockNumber()),
       maxBlockLookBack: this.eventSearchConfig.maxBlockLookBack,
     };
     if (searchConfig.fromBlock > searchConfig.toBlock) {
@@ -745,7 +743,6 @@ export class HubPoolClient extends BaseAbstractClient {
     return {
       success: true,
       currentTime,
-      latestBlockNumber,
       pendingRootBundleProposal,
       searchEndBlock: searchConfig.toBlock,
       events: _events,
@@ -766,7 +763,7 @@ export class HubPoolClient extends BaseAbstractClient {
       // understand why we see this in test. @todo: Resolve.
       return;
     }
-    const { events, currentTime, latestBlockNumber, pendingRootBundleProposal } = update;
+    const { events, currentTime, pendingRootBundleProposal, searchEndBlock } = update;
 
     for (const event of events["CrossChainContractsSet"]) {
       const args = spreadEventWithBlockNumber(event) as CrossChainContractsSet;
@@ -906,11 +903,11 @@ export class HubPoolClient extends BaseAbstractClient {
     }
 
     this.currentTime = currentTime;
-    this.latestBlockNumber = latestBlockNumber;
+    this.latestBlockNumber = searchEndBlock;
     this.firstBlockToSearch = update.searchEndBlock + 1; // Next iteration should start off from where this one ended.
 
     this.isUpdated = true;
-    this.logger.debug({ at: "HubPoolClient::update", message: "HubPool client updated!", endBlock: latestBlockNumber });
+    this.logger.debug({ at: "HubPoolClient::update", message: "HubPool client updated!", searchEndBlock });
   }
 
   // Returns end block for `chainId` in ProposedRootBundle.bundleBlockEvalNumbers. Looks up chainId

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -84,7 +84,7 @@ export class SpokePoolClient extends BaseAbstractClient {
   public firstDepositIdForSpokePool = Number.MAX_SAFE_INTEGER;
   public lastDepositIdForSpokePool = Number.MAX_SAFE_INTEGER;
   public firstBlockToSearch: number;
-  public latestBlockNumber = 0;
+  public latestBlockSearched = 0;
   public fills: { [OriginChainId: number]: FillWithBlock[] } = {};
   public refundRequests: RefundRequestWithBlock[] = [];
 
@@ -820,7 +820,7 @@ export class SpokePoolClient extends BaseAbstractClient {
     // Next iteration should start off from where this one ended.
     this.currentTime = currentTime;
     this.firstDepositIdForSpokePool = update.firstDepositId;
-    this.latestBlockNumber = searchEndBlock;
+    this.latestBlockSearched = searchEndBlock;
     this.lastDepositIdForSpokePool = update.latestDepositId;
     this.firstBlockToSearch = searchEndBlock + 1;
     this.isUpdated = true;
@@ -948,7 +948,7 @@ export class SpokePoolClient extends BaseAbstractClient {
     const searchBounds = await this._getBlockRangeForDepositId(
       depositId,
       this.deploymentBlock,
-      this.latestBlockNumber,
+      this.latestBlockSearched,
       7
     );
 

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -56,7 +56,6 @@ type _SpokePoolUpdate = {
   success: boolean;
   currentTime: number;
   firstDepositId: number;
-  latestBlockNumber: number;
   latestDepositId: number;
   events: Event[][];
   // Blocks are only used if the UBA is active and events need to be ordered by blockTimestamp
@@ -85,7 +84,6 @@ export class SpokePoolClient extends BaseAbstractClient {
   public firstDepositIdForSpokePool = Number.MAX_SAFE_INTEGER;
   public lastDepositIdForSpokePool = Number.MAX_SAFE_INTEGER;
   public firstBlockToSearch: number;
-  public latestBlockSearched: number;
   public latestBlockNumber = 0;
   public fills: { [OriginChainId: number]: FillWithBlock[] } = {};
   public refundRequests: RefundRequestWithBlock[] = [];
@@ -110,7 +108,6 @@ export class SpokePoolClient extends BaseAbstractClient {
   ) {
     super();
     this.firstBlockToSearch = eventSearchConfig.fromBlock;
-    this.latestBlockSearched = eventSearchConfig.fromBlock;
     this.queryableEventNames = Object.keys(this._queryableEventNames());
   }
 
@@ -523,14 +520,9 @@ export class SpokePoolClient extends BaseAbstractClient {
       }
     }
 
-    const latestBlockNumber = await this.spokePool.provider.getBlockNumber();
-    if (isNaN(latestBlockNumber) || latestBlockNumber < this.latestBlockNumber) {
-      throw new Error(`SpokePoolClient::update: latestBlockNumber ${latestBlockNumber} < ${this.latestBlockNumber}`);
-    }
-
     const searchConfig = {
       fromBlock: this.firstBlockToSearch,
-      toBlock: this.eventSearchConfig.toBlock || latestBlockNumber,
+      toBlock: this.eventSearchConfig.toBlock || (await this.spokePool.provider.getBlockNumber()),
       maxBlockLookBack: this.eventSearchConfig.maxBlockLookBack,
     };
     if (searchConfig.fromBlock > searchConfig.toBlock) {
@@ -612,7 +604,6 @@ export class SpokePoolClient extends BaseAbstractClient {
       success: true,
       currentTime: currentTime.toNumber(), // uint32
       firstDepositId,
-      latestBlockNumber,
       latestDepositId: Math.max(numberOfDeposits - 1, 0),
       searchEndBlock: searchConfig.toBlock,
       events,
@@ -644,7 +635,7 @@ export class SpokePoolClient extends BaseAbstractClient {
       // understand why we see this in test. @todo: Resolve.
       return;
     }
-    const { events: queryResults, blocks, currentTime } = update;
+    const { events: queryResults, blocks, currentTime, searchEndBlock } = update;
 
     if (eventsToQuery.includes("TokensBridged")) {
       for (const event of queryResults[eventsToQuery.indexOf("TokensBridged")]) {
@@ -829,10 +820,9 @@ export class SpokePoolClient extends BaseAbstractClient {
     // Next iteration should start off from where this one ended.
     this.currentTime = currentTime;
     this.firstDepositIdForSpokePool = update.firstDepositId;
-    this.latestBlockNumber = update.latestBlockNumber;
+    this.latestBlockNumber = searchEndBlock;
     this.lastDepositIdForSpokePool = update.latestDepositId;
-    this.firstBlockToSearch = update.searchEndBlock + 1;
-    this.latestBlockSearched = update.searchEndBlock;
+    this.firstBlockToSearch = searchEndBlock + 1;
     this.isUpdated = true;
     this.log("debug", `SpokePool client for chain ${this.chainId} updated!`, {
       nextFirstBlockToSearch: this.firstBlockToSearch,
@@ -1096,7 +1086,6 @@ export class SpokePoolClient extends BaseAbstractClient {
     this.earliestDepositIdQueried = spokePoolClientState.earliestDepositIdQueried || this.earliestDepositIdQueried;
     this.latestDepositIdQueried = spokePoolClientState.latestDepositIdQueried || this.latestDepositIdQueried;
     this.firstBlockToSearch = spokePoolClientState.firstBlockToSearch || this.firstBlockToSearch;
-    this.latestBlockSearched = spokePoolClientState.latestBlockSearched || this.latestBlockSearched;
     this.fills = Object.entries(spokePoolClientState.fills || []).reduce(
       (acc, [chainId, fills]) => ({
         ...acc,
@@ -1160,7 +1149,6 @@ export class SpokePoolClient extends BaseAbstractClient {
       latestDepositIdQueried: this.latestDepositIdQueried,
       latestDepositIdForSpokePool: this.lastDepositIdForSpokePool,
       firstBlockToSearch: this.firstBlockToSearch,
-      latestBlockSearched: this.latestBlockSearched,
       isUpdated: this.isUpdated,
       fills: JSON.parse(stringifyJSONWithNumericString(this.fills)) as Record<string, FillWithBlockStringified[]>,
       refundRequests: JSON.parse(

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -83,8 +83,6 @@ export class SpokePoolClient extends BaseAbstractClient {
   public latestDepositIdQueried = 0;
   public firstDepositIdForSpokePool = Number.MAX_SAFE_INTEGER;
   public lastDepositIdForSpokePool = Number.MAX_SAFE_INTEGER;
-  public firstBlockToSearch: number;
-  public latestBlockSearched = 0;
   public fills: { [OriginChainId: number]: FillWithBlock[] } = {};
   public refundRequests: RefundRequestWithBlock[] = [];
 
@@ -108,6 +106,7 @@ export class SpokePoolClient extends BaseAbstractClient {
   ) {
     super();
     this.firstBlockToSearch = eventSearchConfig.fromBlock;
+    this.latestBlockSearched = 0;
     this.queryableEventNames = Object.keys(this._queryableEventNames());
   }
 

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -237,7 +237,7 @@ export function getMostRecentBundleBlockRanges(
   if (isDefined(spokePoolClients[chainId])) {
     // Make the last bundle to cover until the last spoke client searched block, unless a spoke pool
     // client was provided for the chain. In this case we assume that chain is disabled.
-    bundleData[bundleData.length - 1].end = spokePoolClients[chainId].latestBlockNumber;
+    bundleData[bundleData.length - 1].end = spokePoolClients[chainId].latestBlockSearched;
   }
 
   return bundleData;

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -161,9 +161,6 @@ export function getMostRecentBundleBlockRanges(
   spokePoolClients: SpokePoolClients
 ): { start: number; end: number }[] {
   let toBlock = hubPoolClient.latestBlockSearched;
-  if (!isDefined(toBlock)) {
-    throw new Error("HubPoolClient has undefined latestBlockSearched");
-  }
 
   // Reconstruct bundle ranges based on published end blocks.
   const ubaActivationStartBlocks = getUbaActivationBundleStartBlocks(hubPoolClient);
@@ -425,9 +422,6 @@ export function isUBAActivatedAtBlock(hubPoolClient: HubPoolClient, block: numbe
  * */
 export function getUbaActivationBundleStartBlocks(hubPoolClient: HubPoolClient): number[] {
   const latestHubPoolBlock = hubPoolClient.latestBlockSearched;
-  if (!isDefined(latestHubPoolBlock)) {
-    throw new Error("HubPoolClient has undefined latestBlockSearched");
-  }
   const chainIdIndices = hubPoolClient.configStoreClient.getChainIdIndicesForBlock();
   const ubaActivationBlock = hubPoolClient.configStoreClient.getUBAActivationBlock();
   if (isDefined(ubaActivationBlock)) {

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -237,7 +237,7 @@ export function getMostRecentBundleBlockRanges(
   if (isDefined(spokePoolClients[chainId])) {
     // Make the last bundle to cover until the last spoke client searched block, unless a spoke pool
     // client was provided for the chain. In this case we assume that chain is disabled.
-    bundleData[bundleData.length - 1].end = spokePoolClients[chainId].latestBlockSearched;
+    bundleData[bundleData.length - 1].end = spokePoolClients[chainId].latestBlockNumber;
   }
 
   return bundleData;

--- a/src/clients/UBAClient/UBAClientUtilities.ts
+++ b/src/clients/UBAClient/UBAClientUtilities.ts
@@ -160,9 +160,9 @@ export function getMostRecentBundleBlockRanges(
   hubPoolClient: HubPoolClient,
   spokePoolClients: SpokePoolClients
 ): { start: number; end: number }[] {
-  let toBlock = hubPoolClient.latestBlockNumber;
+  let toBlock = hubPoolClient.latestBlockSearched;
   if (!isDefined(toBlock)) {
-    throw new Error("HubPoolClient has undefined latestBlockNumber");
+    throw new Error("HubPoolClient has undefined latestBlockSearched");
   }
 
   // Reconstruct bundle ranges based on published end blocks.
@@ -237,7 +237,7 @@ export function getMostRecentBundleBlockRanges(
   if (isDefined(spokePoolClients[chainId])) {
     // Make the last bundle to cover until the last spoke client searched block, unless a spoke pool
     // client was provided for the chain. In this case we assume that chain is disabled.
-    bundleData[bundleData.length - 1].end = spokePoolClients[chainId].latestBlockNumber;
+    bundleData[bundleData.length - 1].end = spokePoolClients[chainId].latestBlockSearched;
   }
 
   return bundleData;
@@ -424,9 +424,9 @@ export function isUBAActivatedAtBlock(hubPoolClient: HubPoolClient, block: numbe
  * @param chainIds Chains to return start blocks for.
  * */
 export function getUbaActivationBundleStartBlocks(hubPoolClient: HubPoolClient): number[] {
-  const latestHubPoolBlock = hubPoolClient.latestBlockNumber;
+  const latestHubPoolBlock = hubPoolClient.latestBlockSearched;
   if (!isDefined(latestHubPoolBlock)) {
-    throw new Error("HubPoolClient has undefined latestBlockNumber");
+    throw new Error("HubPoolClient has undefined latestBlockSearched");
   }
   const chainIdIndices = hubPoolClient.configStoreClient.getChainIdIndicesForBlock();
   const ubaActivationBlock = hubPoolClient.configStoreClient.getUBAActivationBlock();
@@ -656,11 +656,11 @@ export async function refundRequestIsValid(
   }
   const destSpoke = spokePoolClients[destinationChainId];
 
-  if (fillBlock.lt(destSpoke.deploymentBlock) || fillBlock.gt(destSpoke.latestBlockNumber)) {
-    const { deploymentBlock, latestBlockNumber } = destSpoke;
+  if (fillBlock.lt(destSpoke.deploymentBlock) || fillBlock.gt(destSpoke.latestBlockSearched)) {
+    const { deploymentBlock, latestBlockSearched } = destSpoke;
     return {
       valid: false,
-      reason: `FillBlock (${fillBlock} out of SpokePool range [${deploymentBlock}, ${latestBlockNumber}]`,
+      reason: `FillBlock (${fillBlock} out of SpokePool range [${deploymentBlock}, ${latestBlockSearched}]`,
     };
   }
 

--- a/src/clients/UBAClient/UBAClientWithRefresh.ts
+++ b/src/clients/UBAClient/UBAClientWithRefresh.ts
@@ -447,7 +447,7 @@ export class UBAClientWithRefresh extends BaseAbstractClient {
    * @returns Validated flow or undefined if flow cannot be validated.
    */
   protected async validateFlow(flow: UbaFlow): Promise<ModifiedUBAFlow | undefined> {
-    const latestHubPoolBlock = this.hubPoolClient.latestBlockNumber;
+    const latestHubPoolBlock = this.hubPoolClient.latestBlockSearched;
     if (!isDefined(latestHubPoolBlock)) throw new Error("HubPoolClient not updated");
 
     // Load common information that depends on what type of flow we're validating:
@@ -839,7 +839,7 @@ export class UBAClientWithRefresh extends BaseAbstractClient {
           // Check 2: end block of last block range should be equal to latest spoke pool client block searched
           (isDefined(this.spokePoolClients[chainId]) &&
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            _blockRangesForChain.at(-1)![1] !== this.spokePoolClients[chainId].latestBlockNumber)
+            _blockRangesForChain.at(-1)![1] !== this.spokePoolClients[chainId].latestBlockSearched)
         ) {
           this.logger.error({
             at: "UBAClientWithRefresh#getMostRecentBundleBlockRangesPerChain",
@@ -847,7 +847,7 @@ export class UBAClientWithRefresh extends BaseAbstractClient {
             startBlockForChain: _blockRangesForChain[0][0],
             ubaActivationBundleStartBlockForChain,
             endBlockForChain: _blockRangesForChain.at(-1)?.[1],
-            latestSpokePoolClientBlockSearched: this.spokePoolClients[chainId]?.latestBlockNumber,
+            latestSpokePoolClientBlockSearched: this.spokePoolClients[chainId]?.latestBlockSearched,
           });
           throw new Error(
             `Block ranges for chain ${chainId} do not cover from UBA activation bundle start block to latest spoke pool client block searched`
@@ -895,7 +895,7 @@ export class UBAClientWithRefresh extends BaseAbstractClient {
    * Updates the bundle state.
    */
   public async update(): Promise<void> {
-    const latestHubPoolBlock = this.hubPoolClient.latestBlockNumber;
+    const latestHubPoolBlock = this.hubPoolClient.latestBlockSearched;
     if (!isDefined(latestHubPoolBlock)) throw new Error("HubPoolClient not updated");
 
     this.logger.debug({

--- a/src/clients/UBAClient/UBAClientWithRefresh.ts
+++ b/src/clients/UBAClient/UBAClientWithRefresh.ts
@@ -839,7 +839,7 @@ export class UBAClientWithRefresh extends BaseAbstractClient {
           // Check 2: end block of last block range should be equal to latest spoke pool client block searched
           (isDefined(this.spokePoolClients[chainId]) &&
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            _blockRangesForChain.at(-1)![1] !== this.spokePoolClients[chainId].latestBlockNumber)
+            _blockRangesForChain.at(-1)![1] !== this.spokePoolClients[chainId].latestBlockSearched)
         ) {
           this.logger.error({
             at: "UBAClientWithRefresh#getMostRecentBundleBlockRangesPerChain",
@@ -847,7 +847,7 @@ export class UBAClientWithRefresh extends BaseAbstractClient {
             startBlockForChain: _blockRangesForChain[0][0],
             ubaActivationBundleStartBlockForChain,
             endBlockForChain: _blockRangesForChain.at(-1)?.[1],
-            latestSpokePoolClientBlockSearched: this.spokePoolClients[chainId]?.latestBlockNumber,
+            latestSpokePoolClientBlockSearched: this.spokePoolClients[chainId]?.latestBlockSearched,
           });
           throw new Error(
             `Block ranges for chain ${chainId} do not cover from UBA activation bundle start block to latest spoke pool client block searched`

--- a/src/clients/UBAClient/UBAClientWithRefresh.ts
+++ b/src/clients/UBAClient/UBAClientWithRefresh.ts
@@ -447,9 +447,6 @@ export class UBAClientWithRefresh extends BaseAbstractClient {
    * @returns Validated flow or undefined if flow cannot be validated.
    */
   protected async validateFlow(flow: UbaFlow): Promise<ModifiedUBAFlow | undefined> {
-    const latestHubPoolBlock = this.hubPoolClient.latestBlockSearched;
-    if (!isDefined(latestHubPoolBlock)) throw new Error("HubPoolClient not updated");
-
     // Load common information that depends on what type of flow we're validating:
     let flowChain: number, tokenSymbol: string | undefined;
     if (isUbaInflow(flow)) {
@@ -847,7 +844,7 @@ export class UBAClientWithRefresh extends BaseAbstractClient {
             startBlockForChain: _blockRangesForChain[0][0],
             ubaActivationBundleStartBlockForChain,
             endBlockForChain: _blockRangesForChain.at(-1)?.[1],
-            latestSpokePoolClientBlockSearched: this.spokePoolClients[chainId]?.latestBlockSearched,
+            latestSpokePoolClientBlockSearched: this.spokePoolClients[chainId].latestBlockSearched,
           });
           throw new Error(
             `Block ranges for chain ${chainId} do not cover from UBA activation bundle start block to latest spoke pool client block searched`
@@ -896,8 +893,6 @@ export class UBAClientWithRefresh extends BaseAbstractClient {
    */
   public async update(): Promise<void> {
     const latestHubPoolBlock = this.hubPoolClient.latestBlockSearched;
-    if (!isDefined(latestHubPoolBlock)) throw new Error("HubPoolClient not updated");
-
     this.logger.debug({
       at: "UBAClientWithRefresh",
       message: "❤️‍🔥😭  Updating UBA Client",

--- a/src/clients/UBAClient/UBAClientWithRefresh.ts
+++ b/src/clients/UBAClient/UBAClientWithRefresh.ts
@@ -839,7 +839,7 @@ export class UBAClientWithRefresh extends BaseAbstractClient {
           // Check 2: end block of last block range should be equal to latest spoke pool client block searched
           (isDefined(this.spokePoolClients[chainId]) &&
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            _blockRangesForChain.at(-1)![1] !== this.spokePoolClients[chainId].latestBlockSearched)
+            _blockRangesForChain.at(-1)![1] !== this.spokePoolClients[chainId].latestBlockNumber)
         ) {
           this.logger.error({
             at: "UBAClientWithRefresh#getMostRecentBundleBlockRangesPerChain",
@@ -847,7 +847,7 @@ export class UBAClientWithRefresh extends BaseAbstractClient {
             startBlockForChain: _blockRangesForChain[0][0],
             ubaActivationBundleStartBlockForChain,
             endBlockForChain: _blockRangesForChain.at(-1)?.[1],
-            latestSpokePoolClientBlockSearched: this.spokePoolClients[chainId]?.latestBlockSearched,
+            latestSpokePoolClientBlockSearched: this.spokePoolClients[chainId]?.latestBlockNumber,
           });
           throw new Error(
             `Block ranges for chain ${chainId} do not cover from UBA activation bundle start block to latest spoke pool client block searched`

--- a/src/clients/mocks/MockConfigStoreClient.ts
+++ b/src/clients/mocks/MockConfigStoreClient.ts
@@ -83,7 +83,7 @@ export class MockConfigStoreClient extends AcrossConfigStoreClient {
     }
 
     const eventNames = ["UpdatedGlobalConfig", "UpdatedTokenConfig"];
-    const latestBlockNumber = this.eventManager.blockNumber;
+    const latestBlockSearched = this.eventManager.blockNumber;
 
     // Ensure an array for every requested event exists, in the requested order.
     // All requested event types must be populated in the array (even if empty).
@@ -108,7 +108,7 @@ export class MockConfigStoreClient extends AcrossConfigStoreClient {
     return {
       success: true,
       chainId: this.chainId as number,
-      searchEndBlock: this.eventSearchConfig.toBlock || latestBlockNumber,
+      searchEndBlock: this.eventSearchConfig.toBlock || latestBlockSearched,
       events: {
         updatedGlobalConfigEvents: events["UpdatedGlobalConfig"],
         globalConfigUpdateTimes,

--- a/src/clients/mocks/MockHubPoolClient.ts
+++ b/src/clients/mocks/MockHubPoolClient.ts
@@ -56,7 +56,7 @@ export class MockHubPoolClient extends HubPoolClient {
   }
 
   setLatestBlockNumber(blockNumber: number) {
-    this.latestBlockNumber = blockNumber;
+    this.latestBlockSearched = blockNumber;
   }
 
   addEvent(event: Event): void {
@@ -121,7 +121,7 @@ export class MockHubPoolClient extends HubPoolClient {
 
   _update(eventNames: string[]): Promise<HubPoolUpdate> {
     // Generate new "on chain" responses.
-    const latestBlockNumber = this.eventManager.blockNumber;
+    const latestBlockSearched = this.eventManager.blockNumber;
     const currentTime = Math.floor(Date.now() / 1000);
 
     // Ensure an array for every requested event exists, in the requested order.
@@ -141,10 +141,10 @@ export class MockHubPoolClient extends HubPoolClient {
     return Promise.resolve({
       success: true,
       currentTime,
-      latestBlockNumber,
+      latestBlockSearched,
       pendingRootBundleProposal: this.rootBundleProposal,
       events,
-      searchEndBlock: this.eventSearchConfig.toBlock || latestBlockNumber,
+      searchEndBlock: this.eventSearchConfig.toBlock || latestBlockSearched,
     });
   }
 

--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -63,10 +63,6 @@ export class MockSpokePoolClient extends SpokePoolClient {
     return this.destinationTokenForChainOverride[deposit.originChainId] ?? super.getDestinationTokenForDeposit(deposit);
   }
 
-  setLatestBlockSearched(blockNumber: number): void {
-    this.latestBlockSearched = blockNumber;
-  }
-
   setLatestBlockNumber(blockNumber: number): void {
     this.latestBlockNumber = blockNumber;
   }

--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -25,7 +25,7 @@ export class MockSpokePoolClient extends SpokePoolClient {
 
   constructor(logger: winston.Logger, spokePool: Contract, chainId: number, deploymentBlock: number) {
     super(logger, spokePool, null, chainId, deploymentBlock);
-    this.latestBlockNumber = deploymentBlock;
+    this.latestBlockSearched = deploymentBlock;
     this.eventManager = getEventManager(chainId, this.eventSignatures, deploymentBlock);
   }
 
@@ -64,7 +64,7 @@ export class MockSpokePoolClient extends SpokePoolClient {
   }
 
   setLatestBlockNumber(blockNumber: number): void {
-    this.latestBlockNumber = blockNumber;
+    this.latestBlockSearched = blockNumber;
   }
 
   addEvent(event: Event): void {
@@ -95,7 +95,7 @@ export class MockSpokePoolClient extends SpokePoolClient {
     eventsToQuery.push("RefundRequested");
 
     // Generate new "on chain" responses.
-    const latestBlockNumber = this.eventManager.blockNumber;
+    const latestBlockSearched = this.eventManager.blockNumber;
     const currentTime = Math.floor(Date.now() / 1000);
 
     const blocks: { [blockNumber: number]: Block } = {};
@@ -123,12 +123,12 @@ export class MockSpokePoolClient extends SpokePoolClient {
     return {
       success: true,
       firstDepositId: 0,
-      latestBlockNumber,
+      latestBlockSearched,
       latestDepositId,
       currentTime,
       events,
       blocks,
-      searchEndBlock: this.eventSearchConfig.toBlock || latestBlockNumber,
+      searchEndBlock: this.eventSearchConfig.toBlock || latestBlockSearched,
     };
   }
 

--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -123,7 +123,6 @@ export class MockSpokePoolClient extends SpokePoolClient {
     return {
       success: true,
       firstDepositId: 0,
-      latestBlockSearched,
       latestDepositId,
       currentTime,
       events,

--- a/src/transfers-history/services/SpokePoolEventsQueryService.ts
+++ b/src/transfers-history/services/SpokePoolEventsQueryService.ts
@@ -6,7 +6,7 @@ import { ChainId } from "../adapters/web3/model";
 import { clientConfig } from "../config";
 
 export class SpokePoolEventsQueryService {
-  private latestBlockNumber: number | undefined;
+  private latestBlockSearched: number | undefined;
 
   constructor(
     private chainId: ChainId,
@@ -23,8 +23,8 @@ export class SpokePoolEventsQueryService {
     let speedUpDepositEvents: RequestedSpeedUpDepositEvent[] = [];
     let blockTimestampMap: { [blockNumber: number]: number } = {};
 
-    if (this.latestBlockNumber) {
-      from = this.latestBlockNumber + 1;
+    if (this.latestBlockSearched) {
+      from = this.latestBlockSearched + 1;
     } else {
       from = clientConfig.spokePools[this.chainId].lowerBoundBlockNumber ?? -1;
     }
@@ -66,7 +66,7 @@ export class SpokePoolEventsQueryService {
       "[SpokePoolEventsQueryService::getEvents]",
       `🟢 chain ${this.chainId}: fetched block numbers in ${(end.valueOf() - start.valueOf()) / 1000} seconds`
     );
-    this.latestBlockNumber = to;
+    this.latestBlockSearched = to;
 
     return {
       emittedFromChainId: this.chainId,

--- a/src/utils/BlockUtils.ts
+++ b/src/utils/BlockUtils.ts
@@ -10,7 +10,7 @@ import { DEFAULT_CACHING_SAFE_LAG } from "../constants";
 
 type Opts = {
   highBlock?: number;
-  latestBlockOffset?: number;
+  highBlockOffset?: number;
   blockRange?: number;
 };
 
@@ -24,12 +24,11 @@ type BlockTimeAverage = {
 // Round down to 120 blocks to avoid slipping into archive territory.
 const defaultBlockRange = 120;
 
-// Default offset to the latest block number. This is subtracted from the block number
-// of the latest block when it is queried from the network, rather than having been
-// specified by the caller. This is useful since the supplied Provider instance may be
-// backed by multiple RPC rovider backends, which can lead to some providers running
-// slower than others and taking time to sychonise on the latest block.
-const defaultLatestBlockOffset = 10;
+// Default offset to the high block number. This is subtracted from the block number of the high block
+// when it is queried from the network, rather than having been specified by the caller. This is useful
+// since the supplied Provider instance may be backed by multiple RPC providers, which can lead to some
+// providers running slower than others and taking time to synchronise on the latest block.
+const defaultHighBlockOffset = 10;
 
 // Retain computations for 15 minutes.
 const cacheTTL = 60 * 15;
@@ -46,7 +45,7 @@ const blockTimes: { [chainId: number]: BlockTimeAverage } = {
  */
 export async function averageBlockTime(
   provider: Provider,
-  { highBlock, latestBlockOffset, blockRange }: Opts = {}
+  { highBlock, highBlockOffset, blockRange }: Opts = {}
 ): Promise<Pick<BlockTimeAverage, "average" | "blockRange">> {
   // Does not block for StaticJsonRpcProvider.
   const chainId = (await provider.getNetwork()).chainId;
@@ -57,12 +56,11 @@ export async function averageBlockTime(
     return { average: cache.average, blockRange: cache.blockRange };
   }
 
-  // If the caller was not specific about highBlock, resolve it via the
-  // RPC provider. Subtract an offset to account for various RPC provider sync
-  // issues that might occur when querying the latest block.
+  // If the caller was not specific about highBlock, resolve it via the RPC provider. Subtract an offset
+  // to account for various RPC provider sync issues that might occur when querting the latest block.
   if (!isDefined(highBlock)) {
     highBlock = await provider.getBlockNumber();
-    highBlock -= latestBlockOffset ?? defaultLatestBlockOffset;
+    highBlock -= highBlockOffset ?? defaultHighBlockOffset;
   }
   blockRange ??= defaultBlockRange;
 

--- a/src/utils/BundleUtils.ts
+++ b/src/utils/BundleUtils.ts
@@ -131,7 +131,7 @@ export function blockRangesAreInvalidForSpokeClients(
     }
 
     const clientLastBlockQueried =
-      spokePoolClients[chainId].eventSearchConfig.toBlock ?? spokePoolClients[chainId].latestBlockNumber;
+      spokePoolClients[chainId].eventSearchConfig.toBlock ?? spokePoolClients[chainId].latestBlockSearched;
 
     // Note: Math.max the from block with the deployment block of the spoke pool to handle the edge case for the first
     // bundle that set its start blocks equal 0.

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -30,7 +30,7 @@ export async function getBlockRangeForDepositId(
   const deploymentBlock = spokePool.deploymentBlock;
 
   // Set the initial high block to the most recent block number or the initial high block, whichever is smaller.
-  initHigh = Math.min(initHigh, spokePool.latestBlockNumber);
+  initHigh = Math.min(initHigh, spokePool.latestBlockSearched);
 
   // We will now set a list of sanity checks to ensure that the binary search will not fail
   // due to invalid input parameters.

--- a/test/HubPoolClient.RootBundleEvents.ts
+++ b/test/HubPoolClient.RootBundleEvents.ts
@@ -162,7 +162,7 @@ describe("HubPoolClient: RootBundle Events", function () {
       logIndex: 0,
       transactionHash: "",
     };
-    expect(hubPoolClient.isRootBundleValid(rootBundle, hubPoolClient.latestBlockNumber!)).to.equal(false);
+    expect(hubPoolClient.isRootBundleValid(rootBundle, hubPoolClient.latestBlockSearched!)).to.equal(false);
 
     // Execute leaves.
     await timer.connect(dataworker).setCurrentTime(proposeTime + liveness + 1);
@@ -170,12 +170,12 @@ describe("HubPoolClient: RootBundle Events", function () {
 
     // Not valid until all leaves are executed.
     await hubPoolClient.update();
-    expect(hubPoolClient.isRootBundleValid(rootBundle, hubPoolClient.latestBlockNumber!)).to.equal(false);
-    const blockNumberBeforeAllLeavesExecuted = hubPoolClient.latestBlockNumber;
+    expect(hubPoolClient.isRootBundleValid(rootBundle, hubPoolClient.latestBlockSearched!)).to.equal(false);
+    const blockNumberBeforeAllLeavesExecuted = hubPoolClient.latestBlockSearched;
 
     await hubPool.connect(dataworker).executeRootBundle(...Object.values(leaves[1]), tree.getHexProof(leaves[1]));
     await hubPoolClient.update();
-    expect(hubPoolClient.isRootBundleValid(rootBundle, hubPoolClient.latestBlockNumber!)).to.equal(true);
+    expect(hubPoolClient.isRootBundleValid(rootBundle, hubPoolClient.latestBlockSearched!)).to.equal(true);
 
     // Only searches for executed leaves up to input latest mainnet block to search
     expect(hubPoolClient.isRootBundleValid(rootBundle, blockNumberBeforeAllLeavesExecuted!)).to.equal(false);
@@ -497,7 +497,7 @@ describe("HubPoolClient: RootBundle Events", function () {
 
         const executedLeaves = hubPoolClient.getExecutedLeavesForRootBundle(
           proposedRootBundle,
-          hubPoolClient.latestBlockNumber as number
+          hubPoolClient.latestBlockSearched as number
         );
         expect(executedLeaves.length).to.equal(leafEvents.length);
 
@@ -556,7 +556,7 @@ describe("HubPoolClient: RootBundle Events", function () {
 
         const executedLeaves = hubPoolClient.getExecutedLeavesForRootBundle(
           proposedRootBundle,
-          hubPoolClient.latestBlockNumber as number
+          hubPoolClient.latestBlockSearched as number
         );
         expect(executedLeaves.length).to.equal(leafEvents.length);
 

--- a/test/SpokePoolClient.RefundRequests.ts
+++ b/test/SpokePoolClient.RefundRequests.ts
@@ -56,15 +56,15 @@ describe("SpokePoolClient: Refund Requests", function () {
   });
 
   it("Correctly filters out refund requests based on blockNumber", async function () {
-    // New events must come _after_ the current latestBlockNumber.
-    const { chainId: repaymentChainId, latestBlockNumber } = spokePoolClient;
+    // New events must come _after_ the current latestBlockSearched.
+    const { chainId: repaymentChainId, latestBlockSearched } = spokePoolClient;
     const nEvents = 5;
-    const minExpectedBlockNumber = latestBlockNumber + nEvents;
+    const minExpectedBlockNumber = latestBlockSearched + nEvents;
 
     let refundRequestEvents: RefundRequestWithBlock[] = [];
     for (let txn = 0; txn < nEvents; ++txn) {
       // Barebones Event - only absolutely necessary fields are populated.
-      const blockNumber = latestBlockNumber + 1 + txn;
+      const blockNumber = latestBlockSearched + 1 + txn;
       const refundRequest = { relayer, originChainId, blockNumber } as RefundRequestWithBlock;
       const testEvent = spokePoolClient.generateRefundRequest(refundRequest);
       spokePoolClient.addEvent(testEvent);
@@ -82,10 +82,10 @@ describe("SpokePoolClient: Refund Requests", function () {
         blockTimestamp: block.timestamp,
       };
     }) as RefundRequestWithBlock[];
-    expect(spokePoolClient.latestBlockNumber - latestBlockNumber).to.be.at.least(nEvents);
+    expect(spokePoolClient.latestBlockSearched - latestBlockSearched).to.be.at.least(nEvents);
 
     // Filter out the RefundRequests at the fringes.
-    const fromBlock = latestBlockNumber + 2;
+    const fromBlock = latestBlockSearched + 2;
     const toBlock = minExpectedBlockNumber - 2;
     const { filteredRequests = [], excludedRequests = [] } = groupBy(refundRequestEvents, (refundRequest) => {
       return refundRequest.blockNumber >= fromBlock && refundRequest.blockNumber <= toBlock

--- a/test/SpokePoolClient.ValidateFill.ts
+++ b/test/SpokePoolClient.ValidateFill.ts
@@ -411,6 +411,10 @@ describe("SpokePoolClient: Fill Validation", function () {
     spokePoolClient1.eventSearchConfig.toBlock = depositBlock - 1;
     await spokePoolClient1.update();
 
+    // Make sure that the client's latestBlockNumber encompasses the event so it can see it on the subsequent
+    // queryHistoricalDepositForFill call.
+    spokePoolClient1.latestBlockNumber = depositBlock;
+
     // Client has 0 deposits in memory so querying historical deposit sends fresh RPC requests.
     expect(spokePoolClient1.getDeposits().length).to.equal(0);
     const historicalDeposit = await queryHistoricalDepositForFill(spokePoolClient1, fill);

--- a/test/UBAClient.validateFlow.ts
+++ b/test/UBAClient.validateFlow.ts
@@ -85,8 +85,8 @@ describe("UBAClient: Flow validation", function () {
       symbol: tokenSymbols[0],
     });
     await hubPoolClient.update();
-    const latestBlockNumber = await hubPool.provider.getBlockNumber();
-    hubPoolClient.setLatestBlockNumber(latestBlockNumber);
+    const latestBlockSearched = await hubPool.provider.getBlockNumber();
+    hubPoolClient.setLatestBlockNumber(latestBlockSearched);
 
     await hubPoolClient.update();
 
@@ -99,7 +99,7 @@ describe("UBAClient: Flow validation", function () {
       const spokePoolClient = new MockSpokePoolClient(logger, spokePool, originChainId, deploymentBlock);
       spokePoolClients[originChainId] = spokePoolClient;
       hubPoolClient.setCrossChainContracts(originChainId, spokePool.address, deploymentBlock);
-      spokePoolClient.latestBlockNumber = deploymentBlock + 1000;
+      spokePoolClient.latestBlockSearched = deploymentBlock + 1000;
       await spokePoolClient.update();
     }
 

--- a/test/UBAClient.validateFlow.ts
+++ b/test/UBAClient.validateFlow.ts
@@ -99,7 +99,7 @@ describe("UBAClient: Flow validation", function () {
       const spokePoolClient = new MockSpokePoolClient(logger, spokePool, originChainId, deploymentBlock);
       spokePoolClients[originChainId] = spokePoolClient;
       hubPoolClient.setCrossChainContracts(originChainId, spokePool.address, deploymentBlock);
-      spokePoolClient.setLatestBlockSearched(deploymentBlock + 1000);
+      spokePoolClient.latestBlockNumber = deploymentBlock + 1000;
       await spokePoolClient.update();
     }
 

--- a/test/UBAClientUtilities.ts
+++ b/test/UBAClientUtilities.ts
@@ -63,8 +63,8 @@ describe("UBAClientUtilities", function () {
     hubPoolClient.setDestinationTokenForL1Token(l2Token);
 
     await hubPoolClient.update();
-    const latestBlockNumber = await hubPool.provider.getBlockNumber();
-    hubPoolClient.setLatestBlockNumber(latestBlockNumber);
+    const latestBlockSearched = await hubPool.provider.getBlockNumber();
+    hubPoolClient.setLatestBlockNumber(latestBlockSearched);
 
     spokePoolClients = {};
     for (const originChainId of chainIds) {
@@ -76,7 +76,7 @@ describe("UBAClientUtilities", function () {
       const spokePoolClient = new MockSpokePoolClient(logger, spokePool, originChainId, deploymentBlock);
       spokePoolClients[originChainId] = spokePoolClient;
       hubPoolClient.setCrossChainContracts(originChainId, spokePool.address, deploymentBlock);
-      spokePoolClient.latestBlockNumber = deploymentBlock + 1000;
+      spokePoolClient.latestBlockSearched = deploymentBlock + 1000;
       spokePoolClient.setDestinationTokenForChain(originChainId, l2Token);
     }
   });
@@ -150,7 +150,7 @@ describe("UBAClientUtilities", function () {
       deepEqualsWithBigNumber(result, [
         {
           start: getUbaActivationBundleStartBlocks(hubPoolClient)[0],
-          end: spokePoolClients[chainIds[0]].latestBlockNumber,
+          end: spokePoolClients[chainIds[0]].latestBlockSearched,
         },
       ]);
     });
@@ -162,7 +162,7 @@ describe("UBAClientUtilities", function () {
       deepEqualsWithBigNumber(defaultResult, [
         {
           start: getUbaActivationBundleStartBlocks(hubPoolClient)[0],
-          end: spokePoolClients[chainIds[0]].latestBlockNumber,
+          end: spokePoolClients[chainIds[0]].latestBlockSearched,
         },
       ]);
     });
@@ -186,13 +186,13 @@ describe("UBAClientUtilities", function () {
 
       // Get 2 most recent bundles. Should return single range with start equal to UBA activation block
       // and end equal to latest block searched for spoke pool client. Override the spoke pool clients
-      // mapping to make sure that the new chain's "latestBlockNumber" is > 0.
+      // mapping to make sure that the new chain's "latestBlockSearched" is > 0.
       const spokePoolClientForNewChain = spokePoolClients[chainIds[0]];
       const result = getMostRecentBundleBlockRanges(99, 2, hubPoolClient, {
         ...spokePoolClients,
         [99]: spokePoolClientForNewChain,
       });
-      deepEqualsWithBigNumber(result, [{ start: 0, end: spokePoolClientForNewChain.latestBlockNumber }]);
+      deepEqualsWithBigNumber(result, [{ start: 0, end: spokePoolClientForNewChain.latestBlockSearched }]);
     });
   });
   describe("getOpeningRunningBalances", function () {

--- a/test/UBAClientUtilities.ts
+++ b/test/UBAClientUtilities.ts
@@ -76,7 +76,7 @@ describe("UBAClientUtilities", function () {
       const spokePoolClient = new MockSpokePoolClient(logger, spokePool, originChainId, deploymentBlock);
       spokePoolClients[originChainId] = spokePoolClient;
       hubPoolClient.setCrossChainContracts(originChainId, spokePool.address, deploymentBlock);
-      spokePoolClient.setLatestBlockSearched(deploymentBlock + 1000);
+      spokePoolClient.latestBlockNumber = deploymentBlock + 1000;
       spokePoolClient.setDestinationTokenForChain(originChainId, l2Token);
     }
   });
@@ -150,7 +150,7 @@ describe("UBAClientUtilities", function () {
       deepEqualsWithBigNumber(result, [
         {
           start: getUbaActivationBundleStartBlocks(hubPoolClient)[0],
-          end: spokePoolClients[chainIds[0]].latestBlockSearched,
+          end: spokePoolClients[chainIds[0]].latestBlockNumber,
         },
       ]);
     });
@@ -162,7 +162,7 @@ describe("UBAClientUtilities", function () {
       deepEqualsWithBigNumber(defaultResult, [
         {
           start: getUbaActivationBundleStartBlocks(hubPoolClient)[0],
-          end: spokePoolClients[chainIds[0]].latestBlockSearched,
+          end: spokePoolClients[chainIds[0]].latestBlockNumber,
         },
       ]);
     });
@@ -186,13 +186,13 @@ describe("UBAClientUtilities", function () {
 
       // Get 2 most recent bundles. Should return single range with start equal to UBA activation block
       // and end equal to latest block searched for spoke pool client. Override the spoke pool clients
-      // mapping to make sure that the new chain's "latestBlockSearched" is > 0.
+      // mapping to make sure that the new chain's "latestBlockNumber" is > 0.
       const spokePoolClientForNewChain = spokePoolClients[chainIds[0]];
       const result = getMostRecentBundleBlockRanges(99, 2, hubPoolClient, {
         ...spokePoolClients,
         [99]: spokePoolClientForNewChain,
       });
-      deepEqualsWithBigNumber(result, [{ start: 0, end: spokePoolClientForNewChain.latestBlockSearched }]);
+      deepEqualsWithBigNumber(result, [{ start: 0, end: spokePoolClientForNewChain.latestBlockNumber }]);
     });
   });
   describe("getOpeningRunningBalances", function () {

--- a/test/UBAClientUtilities.ts
+++ b/test/UBAClientUtilities.ts
@@ -150,7 +150,7 @@ describe("UBAClientUtilities", function () {
       deepEqualsWithBigNumber(result, [
         {
           start: getUbaActivationBundleStartBlocks(hubPoolClient)[0],
-          end: spokePoolClients[chainIds[0]].latestBlockNumber,
+          end: spokePoolClients[chainIds[0]].latestBlockSearched,
         },
       ]);
     });
@@ -162,7 +162,7 @@ describe("UBAClientUtilities", function () {
       deepEqualsWithBigNumber(defaultResult, [
         {
           start: getUbaActivationBundleStartBlocks(hubPoolClient)[0],
-          end: spokePoolClients[chainIds[0]].latestBlockNumber,
+          end: spokePoolClients[chainIds[0]].latestBlockSearched,
         },
       ]);
     });
@@ -186,13 +186,13 @@ describe("UBAClientUtilities", function () {
 
       // Get 2 most recent bundles. Should return single range with start equal to UBA activation block
       // and end equal to latest block searched for spoke pool client. Override the spoke pool clients
-      // mapping to make sure that the new chain's "latestBlockNumber" is > 0.
+      // mapping to make sure that the new chain's "latestBlockSearched" is > 0.
       const spokePoolClientForNewChain = spokePoolClients[chainIds[0]];
       const result = getMostRecentBundleBlockRanges(99, 2, hubPoolClient, {
         ...spokePoolClients,
         [99]: spokePoolClientForNewChain,
       });
-      deepEqualsWithBigNumber(result, [{ start: 0, end: spokePoolClientForNewChain.latestBlockNumber }]);
+      deepEqualsWithBigNumber(result, [{ start: 0, end: spokePoolClientForNewChain.latestBlockSearched }]);
     });
   });
   describe("getOpeningRunningBalances", function () {

--- a/test/utils/HubPoolUtils.ts
+++ b/test/utils/HubPoolUtils.ts
@@ -95,7 +95,7 @@ export async function publishValidatedBundles(
   // client was provided for the chain. In this case we assume that chain is disabled.
   chainIds.forEach((chainId) => {
     expectedBlockRanges[chainId][expectedBlockRanges[chainId].length - 1].end =
-      spokePoolClients[chainId].latestBlockNumber;
+      spokePoolClients[chainId].latestBlockSearched;
   });
   return expectedBlockRanges;
 }

--- a/test/utils/HubPoolUtils.ts
+++ b/test/utils/HubPoolUtils.ts
@@ -95,7 +95,7 @@ export async function publishValidatedBundles(
   // client was provided for the chain. In this case we assume that chain is disabled.
   chainIds.forEach((chainId) => {
     expectedBlockRanges[chainId][expectedBlockRanges[chainId].length - 1].end =
-      spokePoolClients[chainId].latestBlockSearched;
+      spokePoolClients[chainId].latestBlockNumber;
   });
   return expectedBlockRanges;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1009,6 +1009,11 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
+"@fastify/busboy@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.0.0.tgz#f22824caff3ae506b18207bad4126dbc6ccdb6b8"
+  integrity sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==
+
 "@ganache/ethereum-address@0.1.4":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@ganache/ethereum-address/-/ethereum-address-0.1.4.tgz#0e6d66f4a24f64bf687cb3ff7358fb85b9d9005e"
@@ -3951,13 +3956,6 @@ bundle-name@^3.0.0:
   integrity sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==
   dependencies:
     run-applescript "^5.0.0"
-
-busboy@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/busboy/-/busboy-1.6.0.tgz#966ea36a9502e43cdb9146962523b92f531f6893"
-  integrity sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
-  dependencies:
-    streamsearch "^1.1.0"
 
 bytes-iec@^3.1.1:
   version "3.1.1"
@@ -11830,11 +11828,6 @@ stream-to-it@^0.2.2:
   dependencies:
     get-iterator "^1.0.2"
 
-streamsearch@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
-  integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
-
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
@@ -12604,11 +12597,11 @@ underscore@~1.13.2:
   integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
 
 undici@^5.14.0:
-  version "5.21.2"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-5.21.2.tgz#329f628aaea3f1539a28b9325dccc72097d29acd"
-  integrity sha512-f6pTQ9RF4DQtwoWSaC42P/NKlUjvezVvd9r155ohqkwFNRyBKM3f3pcty3ouusefNRyM25XhIQEbeQ46sZDJfQ==
+  version "5.26.3"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.26.3.tgz#ab3527b3d5bb25b12f898dfd22165d472dd71b79"
+  integrity sha512-H7n2zmKEWgOllKkIUkLvFmsJQj062lSm3uA4EYApG8gLuiOM0/go9bIoC3HVaSnfg4xunowDE2i9p8drkXuvDw==
   dependencies:
-    busboy "^1.6.0"
+    "@fastify/busboy" "^2.0.0"
 
 unfetch@^4.2.0:
   version "4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6772,9 +6772,9 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-func-name@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
-  integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.2.tgz#0d7cf20cd13fda808669ffa88f4ffc7a3943fc41"
+  integrity sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==
 
 get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.0, get-intrinsic@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
The current name `latestBlockNumber` usually implies that it should return the HEAD block for the provider but the way its used, it 
should actually return the latest block searched by the client.
