### PR TITLE
feat(SpokePoolClient): Support filtering deposits by block number

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -141,8 +141,14 @@ export class SpokePoolClient extends BaseAbstractClient {
    * @returns A list of deposits.
    * @note This method returns all deposits, regardless of destination chain ID in sorted order.
    */
-  public getDeposits(): DepositWithBlock[] {
-    return sortEventsAscendingInPlace(Object.values(this.depositHashes));
+  public getDeposits(filter?: { fromBlock: number, toBlock: number }): DepositWithBlock[] {
+    let deposits = Object.values(this.depositHashes);
+    if (isDefined(filter)) {
+      const { fromBlock, toBlock } = filter;
+      deposits = deposits.filter(({ blockNumber }) => blockNumber >= fromBlock && toBlock >= blockNumber);
+    }
+
+    return sortEventsAscendingInPlace(deposits);
   }
 
   /**


### PR DESCRIPTION
To be used in relayer-v2, but it's a generally useful feature so it
makes sense to define it centrally.