### PR TITLE
fix(SpokePoolClient): Unset searchConfig toBlock after update

### DIFF
--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -908,6 +908,7 @@ export class HubPoolClient extends BaseAbstractClient {
     this.currentTime = currentTime;
     this.latestBlockNumber = latestBlockNumber;
     this.firstBlockToSearch = update.searchEndBlock + 1; // Next iteration should start off from where this one ended.
+    this.eventSearchConfig.toBlock = undefined; // Caller can re-set on subsequent updates if necessary.
 
     this.isUpdated = true;
     this.logger.debug({ at: "HubPoolClient::update", message: "HubPool client updated!", endBlock: latestBlockNumber });

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -833,6 +833,7 @@ export class SpokePoolClient extends BaseAbstractClient {
     this.lastDepositIdForSpokePool = update.latestDepositId;
     this.firstBlockToSearch = update.searchEndBlock + 1;
     this.latestBlockSearched = update.searchEndBlock;
+    this.eventSearchConfig.toBlock = undefined; // Caller can re-set on subsequent updates if necessary
     this.isUpdated = true;
     this.log("debug", `SpokePool client for chain ${this.chainId} updated!`, {
       nextFirstBlockToSearch: this.firstBlockToSearch,


### PR DESCRIPTION
In the event that the SpokePoolClient searchConfig toBlock is set externally, subsequent updates will always be ignored.