### PR TITLE
chore: Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/v/developer-docs/developers/across-sdk",
   "files": [


### PR DESCRIPTION
Make the HubPoolClient Hub <-> Spoke token updates available. Bumping the minor since it's a breaking change.