### PR TITLE
feat: Propagate invalid fill reasons to caller

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/v/developer-docs/developers/across-sdk",
   "files": [

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -318,6 +318,11 @@ export class SpokePoolClient extends BaseAbstractClient {
     };
   }
 
+  public getDeposit(depositId: number): DepositWithBlock | undefined {
+    const depositHash = this.getDepositHash({ depositId, originChainId: this.chainId });
+    return this.depositHashes[depositHash];
+  }
+
   /**
    * Find a corresponding deposit for a given fill.
    * @param fill The fill to find a corresponding deposit for.

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -318,6 +318,12 @@ export class SpokePoolClient extends BaseAbstractClient {
     };
   }
 
+  /**
+   * Find a deposit based on its deposit ID.
+   * @notice If evaluating a fill, be sure to verify it against the resulting deposit.
+   * @param depositId The unique ID of the deposit being queried.
+   * @returns The corresponding deposit if found, undefined otherwise.
+   */
   public getDeposit(depositId: number): DepositWithBlock | undefined {
     const depositHash = this.getDepositHash({ depositId, originChainId: this.chainId });
     return this.depositHashes[depositHash];

--- a/src/utils/DepositUtils.ts
+++ b/src/utils/DepositUtils.ts
@@ -69,7 +69,7 @@ export async function queryHistoricalDepositForFill(
 
     return {
       found: false,
-      code: InvalidFill.DepositIdNotFound,
+      code: isDefined(deposit) ? InvalidFill.FillMismatch : InvalidFill.DepositIdNotFound,
       reason: `Deposit ID ${depositId} not found in SpokePoolClient event buffer.`
     };
   }
@@ -104,10 +104,7 @@ export async function queryHistoricalDepositForFill(
   }
 
   if (validateFillForDeposit(fill, deposit)) {
-    return {
-      found: true,
-      deposit,
-    };
+    return { found: true, deposit };
   }
 
   return {

--- a/src/utils/DepositUtils.ts
+++ b/src/utils/DepositUtils.ts
@@ -17,11 +17,11 @@ export enum InvalidFill {
   DepositIdInvalid = 0, // Deposit ID seems invalid for origin SpokePool
   DepositIdNotFound, // Deposit ID not found (bad RPC data?)
   FillMismatch, // Fill does not match deposit parameters for deposit ID.
-};
+}
 
 export type DepositSearchResult =
-  | { found: true; deposit: DepositWithBlock; }
-  | { found: false; code: InvalidFill; reason: string; };
+  | { found: true; deposit: DepositWithBlock }
+  | { found: false; code: InvalidFill; reason: string };
 
 /**
  * Attempts to resolve a deposit for a fill. If the fill's deposit Id is within the spoke pool client's search range,
@@ -52,7 +52,7 @@ export async function queryHistoricalDepositForFill(
 
   const { depositId } = fill;
   let { firstDepositIdForSpokePool: lowId, lastDepositIdForSpokePool: highId } = spokePoolClient;
-  if (depositId < lowId || depositId > highId)  {
+  if (depositId < lowId || depositId > highId) {
     return {
       found: false,
       code: InvalidFill.DepositIdInvalid,
@@ -70,7 +70,7 @@ export async function queryHistoricalDepositForFill(
     return {
       found: false,
       code: isDefined(deposit) ? InvalidFill.FillMismatch : InvalidFill.DepositIdNotFound,
-      reason: `Deposit ID ${depositId} not found in SpokePoolClient event buffer.`
+      reason: `Deposit ID ${depositId} not found in SpokePoolClient event buffer.`,
     };
   }
 

--- a/test/SpokePoolClient.ValidateFill.ts
+++ b/test/SpokePoolClient.ValidateFill.ts
@@ -7,7 +7,7 @@ import {
   InvalidFill,
   relayFilledAmount,
   validateFillForDeposit,
-  queryHistoricalDepositForFill
+  queryHistoricalDepositForFill,
 } from "../src/utils";
 import {
   expect,

--- a/test/SpokePoolClient.ValidateFill.ts
+++ b/test/SpokePoolClient.ValidateFill.ts
@@ -1,5 +1,14 @@
 import assert from "assert";
 import { RelayData } from "../src/interfaces";
+import { SpokePoolClient } from "../src/clients";
+import {
+  bnZero,
+  bnOne,
+  InvalidFill,
+  relayFilledAmount,
+  validateFillForDeposit,
+  queryHistoricalDepositForFill
+} from "../src/utils";
 import {
   expect,
   toBNWei,
@@ -27,18 +36,8 @@ import {
   winston,
   lastSpyLogIncludes,
 } from "./utils";
-
-import { SpokePoolClient } from "../src/clients";
-import { MockConfigStoreClient, MockHubPoolClient, MockSpokePoolClient } from "./mocks";
-import {
-  bnZero,
-  bnOne,
-  InvalidFill,
-  relayFilledAmount,
-  validateFillForDeposit,
-  queryHistoricalDepositForFill
-} from "../src/utils";
 import { CHAIN_ID_TEST_LIST, repaymentChainId } from "./constants";
+import { MockConfigStoreClient, MockHubPoolClient, MockSpokePoolClient } from "./mocks";
 
 let spokePool_1: Contract, erc20_1: Contract, spokePool_2: Contract, erc20_2: Contract, hubPool: Contract;
 let owner: SignerWithAddress, depositor: SignerWithAddress, relayer: SignerWithAddress;

--- a/test/SpokePoolClient.ValidateFill.ts
+++ b/test/SpokePoolClient.ValidateFill.ts
@@ -1,3 +1,4 @@
+import assert from "assert";
 import { RelayData } from "../src/interfaces";
 import {
   expect,
@@ -419,11 +420,10 @@ describe("SpokePoolClient: Fill Validation", function () {
 
     // Client has 0 deposits in memory so querying historical deposit sends fresh RPC requests.
     expect(spokePoolClient1.getDeposits().length).to.equal(0);
+
     const historicalDeposit = await queryHistoricalDepositForFill(spokePoolClient1, fill);
-    expect(historicalDeposit.found).is.true;
-    if (historicalDeposit.found) {
-      expect(historicalDeposit.deposit.depositId).to.deep.equal(deposit.depositId);
-    }
+    assert(historicalDeposit.found === true, "Test is broken"); // Help tsc to narrow the discriminated union.
+    expect(historicalDeposit.deposit.depositId).to.deep.equal(deposit.depositId);
   });
 
   it("Can fetch younger deposit matching fill", async function () {
@@ -445,11 +445,10 @@ describe("SpokePoolClient: Fill Validation", function () {
 
     // Client has 0 deposits in memory so querying historical deposit sends fresh RPC requests.
     expect(spokePoolClient1.getDeposits().length).to.equal(0);
+
     const historicalDeposit = await queryHistoricalDepositForFill(spokePoolClient1, fill);
-    expect(historicalDeposit.found).is.true;
-    if (historicalDeposit.found) {
-      expect(historicalDeposit.deposit.depositId).to.deep.equal(deposit.depositId);
-    }
+    assert(historicalDeposit.found === true, "Test is broken"); // Help tsc to narrow the discriminated union.
+    expect(historicalDeposit.deposit.depositId).to.deep.equal(deposit.depositId);
   });
 
   it("Loads fills from memory with deposit ID > spoke pool client's earliest deposit ID queried", async function () {
@@ -497,10 +496,9 @@ describe("SpokePoolClient: Fill Validation", function () {
     spokePoolClient1.firstDepositIdForSpokePool = deposit.depositId + 1;
     expect(fill.depositId < spokePoolClient1.firstDepositIdForSpokePool).is.true;
     const search = await queryHistoricalDepositForFill(spokePoolClient1, fill);
-    expect(search.found).is.false;
-    if (search.found === false) {
-      expect(search.code).to.equal(InvalidFill.DepositIdInvalid);
-    }
+
+    assert(search.found === false, "Test is broken"); // Help tsc to narrow the discriminated union.
+    expect(search.code).to.equal(InvalidFill.DepositIdInvalid);
     expect(lastSpyLogIncludes(spy, "Queried RPC for deposit")).is.not.true;
   });
 
@@ -524,10 +522,9 @@ describe("SpokePoolClient: Fill Validation", function () {
     await spokePoolClient1.update();
     expect(fill.depositId > spokePoolClient1.lastDepositIdForSpokePool).is.true;
     const search = await queryHistoricalDepositForFill(spokePoolClient1, fill);
-    expect(search.found).is.false;
-    if (search.found === false) {
-      expect(search.code).to.equal(InvalidFill.DepositIdInvalid);
-    }
+
+    assert(search.found === false, "Test is broken"); // Help tsc to narrow the discriminated union.
+    expect(search.code).to.equal(InvalidFill.DepositIdInvalid);
     expect(lastSpyLogIncludes(spy, "Queried RPC for deposit")).is.not.true;
   });
 
@@ -540,11 +537,7 @@ describe("SpokePoolClient: Fill Validation", function () {
     await Promise.all([spokePoolClient1.update(), spokePoolClient2.update()]);
 
     const search = await queryHistoricalDepositForFill(spokePoolClient1, fill);
-    expect(search.found).is.false;
-    if (search.found) {
-      // Helping tsc to narrow the type.
-      throw new Error("xxx test is broken; this should never happen");
-    }
+    assert(search.found === false, "Test is broken"); // Help tsc to narrow the discriminated union.
     expect(search.code).to.equal(InvalidFill.FillMismatch);
   });
 


### PR DESCRIPTION
This change provides additional information to the caller of queryHistoricalDepositForFill(). In the case that a fill is not found, a cause code is associated:
- 0: The deposit ID was invalid for the SpokePool (i.e. cannot exist).
- 1: The deposit ID was valid, but it wasn't found within scraped data (i.e. maybe the RPCs aren't serving it in eth_getLogs() requests).
- 2: The deposit ID was valid, but one or more fields in the corresponding deposit were mismatched (i.e. the fill was invalid).

This is most interesting for case (1), where there's a reasonable indication that the deposit should be held within the SpokePoolClient's deposit map, but isn't. This indirectly acts like a qualitative measure for RPC provider responses and will allow the upper layers to dynamically revert to more conservative behaviour.