### PR TITLE
fix: Include message in relay hash

### DIFF
--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -172,7 +172,8 @@ export function relayFilledAmount(
     relayData.destinationToken,
     relayData.amount,
     relayData.realizedLpFeePct,
-    relayData.relayerFeePct
+    relayData.relayerFeePct,
+    relayData.message
   ).relayHash;
 
   return spokePool.relayFills(hash, { blockTag });


### PR DESCRIPTION
This was an omission in the previous commit. getRelayHash() permits amount, realizedLpFeePct, relayerFeePct or message to be undefined.