### PR TITLE
improve(findFillBlock): Source destinationChainId from SpokePool

### DIFF
--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -205,7 +205,7 @@ export async function findFillBlock(
   const { provider } = spokePool;
   highBlockNumber ??= await provider.getBlockNumber();
   assert(highBlockNumber > lowBlockNumber, `Block numbers out of range (${lowBlockNumber} > ${highBlockNumber})`);
-  const { chainId: destinationChainId } = await spokePool.provider.getNetwork();
+  const { chainId: destinationChainId } = await provider.getNetwork();
 
   // Make sure the relay is 100% completed within the block range supplied by the caller.
   const [initialFillAmount, finalFillAmount] = await Promise.all([

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -205,6 +205,7 @@ export async function findFillBlock(
   const { provider } = spokePool;
   highBlockNumber ??= await provider.getBlockNumber();
   assert(highBlockNumber > lowBlockNumber, `Block numbers out of range (${lowBlockNumber} > ${highBlockNumber})`);
+  const { chainId: destinationChainId } = await spokePool.provider.getNetwork();
 
   // Make sure the relay is 100% completed within the block range supplied by the caller.
   const [initialFillAmount, finalFillAmount] = await Promise.all([
@@ -219,7 +220,7 @@ export async function findFillBlock(
 
   // Was filled earlier than the specified lowBlock.. This is an error by the caller.
   if (initialFillAmount.eq(relayData.amount)) {
-    const { depositId, originChainId, destinationChainId } = relayData;
+    const { depositId, originChainId } = relayData;
     const [srcChain, dstChain] = [getNetworkName(originChainId), getNetworkName(destinationChainId)];
     throw new Error(`${srcChain} deposit ${depositId} filled on ${dstChain} before block ${lowBlockNumber}`);
   }

--- a/test/SpokePoolClient.fills.ts
+++ b/test/SpokePoolClient.fills.ts
@@ -174,10 +174,10 @@ describe("SpokePoolClient: Fills", function () {
     await hre.network.provider.send("evm_mine");
 
     // Now search for the fill _after_ it was filled and expect an exception.
-    const [srcChain, dstChain] = [getNetworkName(deposit.originChainId), getNetworkName(deposit.destinationChainId)];
+   const srcChain = getNetworkName(deposit.originChainId);
     await assertPromiseError(
       findFillBlock(spokePool, deposit as RelayData, lateBlockNumber),
-      `${srcChain} deposit ${deposit.depositId} filled on ${dstChain} before block`
+      `${srcChain} deposit ${deposit.depositId} filled on `
     );
 
     // Should assert if highBlock <= lowBlock.


### PR DESCRIPTION
This is transparently compatible with v3 RelayData, which does not directly include the destinationChainId.