### PR TITLE
refactor: Upstream SpokePoolClient early quoteTimestamp detection

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -628,7 +628,9 @@ export class SpokePoolClient extends BaseAbstractClient {
   }
 
   _isEarlyDeposit(depositEvent: FundsDepositedEvent, currentTime: number): boolean {
-    return depositEvent.args.quoteTimestamp > currentTime;
+    const hubPoolTime = this.hubPoolClient?.currentTime ?? currentTime;
+    const { quoteTimestamp } = depositEvent.args;
+    return quoteTimestamp > Math.min(hubPoolTime, currentTime);
   }
 
   /**


### PR DESCRIPTION
This is relocated from the relayer-v2 SpokePoolClient implementation. It's preferable to centralise the logic here in advance of its eventual removal of early deposit detection.

The the proposer will still need to be conscious of future quoteTimestamps to avoid computing fees on early deposits. Alternatively, an UMIP change could be made to permit the proposer to clamp the quoteTimestamp at the toBlock in the relevant proposal.