### PR TITLE
fix: Derive v2 relay hashes locally

### DIFF
--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -1,6 +1,5 @@
 import assert from "assert";
-import { getRelayHash } from "@across-protocol/contracts-v2/dist/test-utils";
-import { BigNumber, Contract } from "ethers";
+import { BigNumber, Contract, utils as ethersUtils } from "ethers";
 import { RelayData } from "../interfaces";
 import { SpokePoolClient } from "../clients";
 import { getNetworkName } from "./NetworkUtils";
@@ -172,18 +171,25 @@ export function relayFilledAmount(
   relayData: RelayData,
   blockTag?: number | "latest"
 ): Promise<BigNumber> {
-  const hash = getRelayHash(
-    relayData.depositor,
-    relayData.recipient,
-    relayData.depositId,
-    relayData.originChainId,
-    relayData.destinationChainId,
-    relayData.destinationToken,
-    relayData.amount,
-    relayData.realizedLpFeePct,
-    relayData.relayerFeePct,
-    relayData.message
-  ).relayHash;
+  const hash = ethersUtils.keccak256(
+    ethersUtils.defaultAbiCoder.encode(
+      [
+        "tuple(" +
+          "address depositor," +
+          "address recipient," +
+          "address destinationToken," +
+          "uint256 amount," +
+          "uint256 originChainId," +
+          "uint256 destinationChainId," +
+          "int64 realizedLpFeePct," +
+          "int64 relayerFeePct," +
+          "uint32 depositId," +
+          "bytes message" +
+          ")",
+      ],
+      [relayData]
+    )
+  );
 
   return spokePool.relayFills(hash, { blockTag });
 }

--- a/test/SpokePoolClient.fills.ts
+++ b/test/SpokePoolClient.fills.ts
@@ -174,7 +174,7 @@ describe("SpokePoolClient: Fills", function () {
     await hre.network.provider.send("evm_mine");
 
     // Now search for the fill _after_ it was filled and expect an exception.
-   const srcChain = getNetworkName(deposit.originChainId);
+    const srcChain = getNetworkName(deposit.originChainId);
     await assertPromiseError(
       findFillBlock(spokePool, deposit as RelayData, lateBlockNumber),
       `${srcChain} deposit ${deposit.depositId} filled on `


### PR DESCRIPTION
When testing the WIP v3 changes I found that the relayer-v2 repo is subtly broken when running with a `yarn link`-ed sdk-v2. The breaking change was isolated to the import of code from contracts-v2/dist.