### PR TITLE
feat: Add oldest time searched to SpokePoolClient

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -583,7 +583,7 @@ export class SpokePoolClient extends BaseAbstractClient {
     const [numberOfDeposits, currentTime, oldestTime, ...events] = await Promise.all([
       this.spokePool.numberOfDeposits({ blockTag: searchConfig.toBlock }),
       this.spokePool.getCurrentTime({ blockTag: searchConfig.toBlock }),
-      this.spokePool.getCurrentTime({ blockTag: searchConfig.fromBlock }),
+      this.spokePool.getCurrentTime({ blockTag: Math.max(searchConfig.fromBlock, this.deploymentBlock) }),
       ...eventSearchConfigs.map((config) => paginatedEventQuery(this.spokePool, config.filter, config.searchConfig)),
     ]);
     this.log("debug", `Time to query new events from RPC for ${this.chainId}: ${Date.now() - timerStart} ms`);
@@ -964,6 +964,14 @@ export class SpokePoolClient extends BaseAbstractClient {
   public getFillDeadlineBuffer(): number {
     return this.fillDeadlineBuffer;
   }
+
+  // public getExpiredDeposits(fromTimestamp: number, toTimestamp: number): v3Deposit[] {
+  //   return Object.values(this.depositHashes).filter((deposit) => {
+  //     if (isV3Deposit(deposit) && deposit.fillDeadline >= fromTimestamp && deposit.fillDeadline <= toTimestamp) {
+  //       return true;
+  //     } else return false;
+  //   })
+  // }
 
   /**
    * Finds a deposit for a given deposit ID, destination chain ID and depositor address. This method will search for

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -575,7 +575,7 @@ export class SpokePoolClient extends BaseAbstractClient {
     });
 
     const timerStart = Date.now();
-    const [numberOfDeposits, currentTime, oldestTime ...events] = await Promise.all([
+    const [numberOfDeposits, currentTime, oldestTime, ...events] = await Promise.all([
       this.spokePool.numberOfDeposits({ blockTag: searchConfig.toBlock }),
       this.spokePool.getCurrentTime({ blockTag: searchConfig.toBlock }),
       this.spokePool.getCurrentTime({ blockTag: Math.max(searchConfig.fromBlock, this.deploymentBlock) }),

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -577,9 +577,11 @@ export class SpokePoolClient extends BaseAbstractClient {
     });
 
     const timerStart = Date.now();
-    // TODO: Once the SpokePools are updated and have the `fillDeadlineBuffer()` method, load it dynamically here.
-    const fillDeadlineBuffer = 2 * 60 * 60; // 2 hours. We're assuming this is hardcoded to the same value that the
-    // V3 spoke pools will be instantiated with.
+    // fillDeadlineBuffer is a constant/immutable in the contract so we don't have an easy to track its updates.
+    // Therefore, dynamically reading it from the SpokePool will not always be accurate if the value changes
+    // drastically mid-bundle. A conservative way to deal with it is to hardcode the following value to a value
+    // that is conservatively greater than the fillDeadlineBuffer would ever be set to in the contracts.
+    const fillDeadlineBuffer = 10 * 60 * 60;
     const [numberOfDeposits, currentTime, oldestTime, ...events] = await Promise.all([
       this.spokePool.numberOfDeposits({ blockTag: searchConfig.toBlock }),
       this.spokePool.getCurrentTime({ blockTag: searchConfig.toBlock }),

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -965,14 +965,6 @@ export class SpokePoolClient extends BaseAbstractClient {
     return this.fillDeadlineBuffer;
   }
 
-  // public getExpiredDeposits(fromTimestamp: number, toTimestamp: number): v3Deposit[] {
-  //   return Object.values(this.depositHashes).filter((deposit) => {
-  //     if (isV3Deposit(deposit) && deposit.fillDeadline >= fromTimestamp && deposit.fillDeadline <= toTimestamp) {
-  //       return true;
-  //     } else return false;
-  //   })
-  // }
-
   /**
    * Finds a deposit for a given deposit ID, destination chain ID and depositor address. This method will search for
    * the deposit in the SpokePool contract and return it if found. If the deposit is not found, this method will

--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -119,6 +119,8 @@ export class MockSpokePoolClient extends SpokePoolClient {
       firstDepositId: 0,
       latestDepositId,
       currentTime,
+      oldestTime: 0,
+      fillDeadlineBuffer: 0,
       events,
       blocks,
       searchEndBlock: this.eventSearchConfig.toBlock || latestBlockSearched,

--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -120,7 +120,6 @@ export class MockSpokePoolClient extends SpokePoolClient {
       latestDepositId,
       currentTime,
       oldestTime: 0,
-      fillDeadlineBuffer: 0,
       events,
       blocks,
       searchEndBlock: this.eventSearchConfig.toBlock || latestBlockSearched,

--- a/test/SpokePoolClient.fills.ts
+++ b/test/SpokePoolClient.fills.ts
@@ -174,7 +174,7 @@ describe("SpokePoolClient: Fills", function () {
     await hre.network.provider.send("evm_mine");
 
     // Now search for the fill _after_ it was filled and expect an exception.
-   const srcChain = getNetworkName(deposit.originChainId);
+    const srcChain = getNetworkName(deposit.originChainId);
     await assertPromiseError(
       findFillBlock(spokePool, deposit as RelayData, lateBlockNumber),
       `${srcChain} deposit ${deposit.depositId} filled on `


### PR DESCRIPTION
These will be useful for the dataworker functions (beginning to be implemented in https://github.com/across-protocol/relayer-v2/pull/1155 ) that have to deal with expired deposits. We need to be able to know when a deposit is expired (comparing its fill deadline TIMESTAMP with a bundle BLOCK NUMBER), and also whether our spoke pool clients have enough of a lookback to fetch expired deposits for a bundle
