### PR TITLE
improve(hubpool): expose executedRootBundle 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.20.2",
+  "version": "0.20.3",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/v/developer-docs/developers/across-sdk",
   "files": [

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -144,6 +144,10 @@ export class HubPoolClient extends BaseAbstractClient {
     return this.disputedRootBundles;
   }
 
+  getExecutedRootBundles(): ExecutedRootBundle[] {
+    return this.executedRootBundles;
+  }
+
   getSpokePoolForBlock(chain: number, block: number = Number.MAX_SAFE_INTEGER): string {
     if (!this.crossChainContracts[chain]) {
       throw new Error(`No cross chain contracts set for ${chain}`);


### PR DESCRIPTION
We need this as part of the new relayer finalizer for L1 -> L2 finalizations. We can use the `executedRootBundle` in the search for transaction receipts that contain outbound multi-chain transactions that require finalizations.