### PR TITLE
fix: Revert last package version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.20.3",
+  "version": "0.20.2",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/v/developer-docs/developers/across-sdk",
   "files": [


### PR DESCRIPTION
The current version is v0.20.1; v0.20.2 hasn't been built yet.