### PR TITLE
improve: Make deposit realizedLpFeePct mandatory

### DIFF
--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -7,6 +7,7 @@ import {
   DepositWithBlock,
   FillType,
   FundsDepositedEvent,
+  RealizedLpFee,
   SlowFillRequestWithBlock,
   v2DepositWithBlock,
   v2FillWithBlock,
@@ -36,7 +37,7 @@ type Block = providers.Block;
 // user to bypass on-chain queries and inject ethers Event objects directly.
 export class MockSpokePoolClient extends SpokePoolClient {
   public eventManager: EventManager;
-  private realizedLpFeePct: BigNumber | undefined = bnZero;
+  private realizedLpFeePct: BigNumber = bnZero;
   private realizedLpFeePctOverride = false;
   private destinationTokenForChainOverride: Record<number, string> = {};
   // Allow tester to set the numberOfDeposits() returned by SpokePool at a block height.
@@ -50,7 +51,7 @@ export class MockSpokePoolClient extends SpokePoolClient {
     this.eventManager = getEventManager(chainId, this.eventSignatures, deploymentBlock);
   }
 
-  setDefaultRealizedLpFeePct(fee: BigNumber | undefined): void {
+  setDefaultRealizedLpFeePct(fee: BigNumber): void {
     this.realizedLpFeePct = fee;
     this.realizedLpFeePctOverride = true;
   }
@@ -67,7 +68,7 @@ export class MockSpokePoolClient extends SpokePoolClient {
       : await super.computeRealizedLpFeePct(depositEvent);
   }
 
-  async batchComputeRealizedLpFeePct(depositEvents: FundsDepositedEvent[]) {
+  async batchComputeRealizedLpFeePct(depositEvents: FundsDepositedEvent[]): Promise<RealizedLpFee[]> {
     const { realizedLpFeePct, realizedLpFeePctOverride } = this;
     return realizedLpFeePctOverride
       ? depositEvents.map(({ blockNumber: quoteBlock }) => {

--- a/src/interfaces/HubPool.ts
+++ b/src/interfaces/HubPool.ts
@@ -32,7 +32,7 @@ export interface ProposedRootBundle extends SortableEvent {
 
 export type RealizedLpFee = {
   quoteBlock: number;
-  realizedLpFeePct?: BigNumber;
+  realizedLpFeePct: BigNumber;
 };
 
 export type ProposedRootBundleStringified = Omit<ProposedRootBundle, "bundleEvaluationBlockNumbers"> & {

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -16,14 +16,13 @@ export interface DepositCommon {
   speedUpSignature?: string; // appended after initialization, if deposit was speedup (not part of Deposit event).
   updatedRecipient?: string;
   updatedMessage?: string;
-  realizedLpFeePct?: BigNumber; // appended after initialization (not part of Deposit event).
+  realizedLpFeePct: BigNumber; // appended after initialization (not part of Deposit event).
 }
 
 export interface v2Deposit extends DepositCommon {
   originToken: string;
   amount: BigNumber;
   relayerFeePct: BigNumber;
-  realizedLpFeePct?: BigNumber; // appended after initialization (not part of Deposit event).
   destinationToken: string; // appended after initialization (not part of Deposit event).
   newRelayerFeePct?: BigNumber; // appended after initialization, if deposit was speedup (not part of Deposit event).
 }


### PR DESCRIPTION
Now that the UBA-related functionality has been removed, the realizedLpFeePct member of the Deposit-family objects can be made mandatory. This eases the process of introducing v3.