### PR TITLE
feat: update FillsToRefund type to account for V3

### DIFF
--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -250,7 +250,7 @@ export interface Refund {
 export type FillsToRefund = {
   [repaymentChainId: number]: {
     [l2TokenAddress: string]: {
-      fills: Fill[];
+      fills: Fill[] | v3Fill[];
       refunds?: Refund;
       totalRefundAmount: BigNumber;
       realizedLpFees: BigNumber;


### PR DESCRIPTION
I'd  like to re-use this dictionary in the BundleDataClient for V3
