### PR TITLE
refactor: Remove redundant SlowFill type

### DIFF
--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -153,22 +153,6 @@ export interface SlowFillRequest {
 
 export interface SlowFillRequestWithBlock extends SlowFillRequest, SortableEvent {}
 
-export interface SlowFill {
-  relayHash: string;
-  amount: BigNumber;
-  fillAmount: BigNumber;
-  totalFilledAmount: BigNumber;
-  originChainId: number;
-  relayerFeePct: BigNumber;
-  realizedLpFeePct: BigNumber;
-  payoutAdjustmentPct: BigNumber;
-  depositId: number;
-  destinationToken: string;
-  depositor: string;
-  recipient: string;
-  message: string;
-}
-
 export interface v2SlowFillLeaf {
   relayData: RelayData;
   payoutAdjustmentPct: string;


### PR DESCRIPTION
This isn't used in the SDK or relayer repositories.