### PR TITLE
refactor: Re-organise types around RelayData

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.20.4",
+  "version": "0.20.5",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/v/developer-docs/developers/across-sdk",
   "files": [

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -38,8 +38,8 @@ import {
   RootBundleRelayWithBlock,
   SpeedUp,
   TokensBridged,
-  v2DepositWithBlock,
-  v2SpeedUp,
+  V2DepositWithBlock,
+  V2SpeedUp,
 } from "../interfaces";
 import { SpokePool } from "../typechain";
 import { getNetworkName } from "../utils/NetworkUtils";
@@ -285,7 +285,7 @@ export class SpokePoolClient extends BaseAbstractClient {
       const v2SpeedUps = this.speedUps[depositor]?.[depositId]?.filter(isV2SpeedUp);
       const maxSpeedUp = v2SpeedUps?.reduce(
         (prev, current) => (prev.newRelayerFeePct.gt(current.newRelayerFeePct) ? prev : current),
-        { newRelayerFeePct: deposit.relayerFeePct } as v2SpeedUp
+        { newRelayerFeePct: deposit.relayerFeePct } as V2SpeedUp
       );
 
       // We assume that the depositor authorises SpeedUps in isolation of each other, which keeps the relayer
@@ -295,7 +295,7 @@ export class SpokePoolClient extends BaseAbstractClient {
       }
 
       // Return deposit with updated params from the speedup with the highest updated relayer fee pct.
-      const updatedDeposit: v2DepositWithBlock = {
+      const updatedDeposit: V2DepositWithBlock = {
         ...deposit,
         speedUpSignature: maxSpeedUp.depositorSignature,
         newRelayerFeePct: maxSpeedUp.newRelayerFeePct,

--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -9,12 +9,12 @@ import {
   FundsDepositedEvent,
   RealizedLpFee,
   SlowFillRequestWithBlock,
-  v2DepositWithBlock,
-  v2FillWithBlock,
-  v2SpeedUp,
-  v3DepositWithBlock,
-  v3FillWithBlock,
-  v3SpeedUp,
+  V2DepositWithBlock,
+  V2FillWithBlock,
+  V2SpeedUp,
+  V3DepositWithBlock,
+  V3FillWithBlock,
+  V3SpeedUp,
 } from "../../interfaces";
 import {
   bnZero,
@@ -151,7 +151,7 @@ export class MockSpokePoolClient extends SpokePoolClient {
     FundsDeposited: "uint256,uint256,uint256,int64,uint32,uint32,address,address,address,bytes",
   };
 
-  deposit(deposit: v2DepositWithBlock): Event {
+  deposit(deposit: V2DepositWithBlock): Event {
     assert(isV2Deposit(deposit));
     const event = "FundsDeposited";
 
@@ -189,7 +189,7 @@ export class MockSpokePoolClient extends SpokePoolClient {
     });
   }
 
-  depositV3(deposit: v3DepositWithBlock): Event {
+  depositV3(deposit: V3DepositWithBlock): Event {
     assert(isV3Deposit(deposit));
     const event = "V3FundsDeposited";
 
@@ -221,7 +221,7 @@ export class MockSpokePoolClient extends SpokePoolClient {
       outputAmount,
       quoteTimestamp,
       fillDeadline: deposit.fillDeadline ?? quoteTimestamp + 3600,
-      relayer: deposit.relayer ?? ZERO_ADDRESS,
+      relayer: deposit.exclusiveRelayer ?? ZERO_ADDRESS,
       exclusivityDeadline: deposit.exclusivityDeadline ?? quoteTimestamp + 600,
       message,
     };
@@ -236,7 +236,7 @@ export class MockSpokePoolClient extends SpokePoolClient {
     });
   }
 
-  fillRelay(fill: v2FillWithBlock): Event {
+  fillRelay(fill: V2FillWithBlock): Event {
     assert(isV2Fill(fill));
     const event = "FilledRelay";
 
@@ -286,7 +286,7 @@ export class MockSpokePoolClient extends SpokePoolClient {
     });
   }
 
-  fillV3Relay(fill: v3FillWithBlock): Event {
+  fillV3Relay(fill: V3FillWithBlock): Event {
     assert(isV3Fill(fill));
     const event = "FilledV3Relay";
 
@@ -337,7 +337,7 @@ export class MockSpokePoolClient extends SpokePoolClient {
     });
   }
 
-  speedUpDeposit(speedUp: v2SpeedUp): Event {
+  speedUpDeposit(speedUp: V2SpeedUp): Event {
     const event = "RequestedSpeedUpDeposit";
     const topics = [speedUp.depositId, speedUp.depositor];
     const args = { ...speedUp };
@@ -350,7 +350,7 @@ export class MockSpokePoolClient extends SpokePoolClient {
     });
   }
 
-  speedUpV3Deposit(speedUp: v3SpeedUp): Event {
+  speedUpV3Deposit(speedUp: V3SpeedUp): Event {
     const event = "RequestedSpeedUpV3Deposit";
     const topics = [speedUp.depositId, speedUp.depositor];
     const args = { ...speedUp };

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -153,22 +153,6 @@ export interface SlowFillRequest {
 
 export interface SlowFillRequestWithBlock extends SlowFillRequest, SortableEvent {}
 
-export interface SlowFill {
-  relayHash: string;
-  amount: BigNumber;
-  fillAmount: BigNumber;
-  totalFilledAmount: BigNumber;
-  originChainId: number;
-  relayerFeePct: BigNumber;
-  realizedLpFeePct: BigNumber;
-  payoutAdjustmentPct: BigNumber;
-  depositId: number;
-  destinationToken: string;
-  depositor: string;
-  recipient: string;
-  message: string;
-}
-
 export interface v2SlowFillLeaf {
   relayData: RelayData;
   payoutAdjustmentPct: string;

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -5,50 +5,61 @@ import { SpokePoolClient } from "../clients";
 
 export type { FilledRelayEvent, FilledV3RelayEvent, FundsDepositedEvent, V3FundsDepositedEvent };
 
-export interface DepositCommon {
-  depositId: number;
-  originChainId: number; // appended from chainID in the client.
-  destinationChainId: number;
+export interface RelayDataCommon {
+  originChainId: number;
   depositor: string;
   recipient: string;
-  quoteTimestamp: number;
+  depositId: number;
   message: string;
-  speedUpSignature?: string; // appended after initialization, if deposit was speedup (not part of Deposit event).
-  updatedRecipient?: string;
-  updatedMessage?: string;
-  realizedLpFeePct: BigNumber; // appended after initialization (not part of Deposit event).
 }
 
-export interface v2Deposit extends DepositCommon {
-  originToken: string;
+export interface V2RelayData extends RelayDataCommon {
+  destinationChainId: number;
+  destinationToken: string;
   amount: BigNumber;
   relayerFeePct: BigNumber;
-  destinationToken: string; // appended after initialization (not part of Deposit event).
-  newRelayerFeePct?: BigNumber; // appended after initialization, if deposit was speedup (not part of Deposit event).
+  realizedLpFeePct: BigNumber;
 }
 
-export interface v2DepositWithBlock extends v2Deposit, SortableEvent {
-  quoteBlockNumber: number;
-}
-
-export interface v3Deposit extends DepositCommon {
+export interface V3RelayData extends RelayDataCommon {
   inputToken: string;
   inputAmount: BigNumber;
   outputToken: string;
   outputAmount: BigNumber;
   fillDeadline: number;
-  relayer: string;
+  exclusiveRelayer: string;
   exclusivityDeadline: number;
-  updatedOutputAmount?: BigNumber; // appended after initialization if deposit was updated.
-  relayerFeePct?: BigNumber;
 }
 
-export interface v3DepositWithBlock extends v3Deposit, SortableEvent {
+// @todo: Extend with V2RelayData | V3RelayData.
+export type RelayData = V2RelayData;
+
+export interface V2Deposit extends V2RelayData {
+  originToken: string;
+  quoteTimestamp: number;
+  speedUpSignature?: string;
+  updatedRecipient?: string;
+  newRelayerFeePct?: BigNumber;
+  updatedMessage?: string;
+}
+
+export interface V2DepositWithBlock extends V2Deposit, SortableEvent {
   quoteBlockNumber: number;
 }
 
-export type Deposit = v2Deposit; // @todo: Extend with v2Deposit | v3Deposit.
-export type DepositWithBlock = v2DepositWithBlock; // @todo Extend with v2DepositWithBlock | v3DepositWithBlock.
+export interface V3Deposit extends V3RelayData {
+  destinationChainId: number;
+  quoteTimestamp: number;
+  updatedOutputAmount?: BigNumber;
+  relayerFeePct?: BigNumber;
+}
+
+export interface V3DepositWithBlock extends V3Deposit, SortableEvent {
+  quoteBlockNumber: number;
+}
+
+export type Deposit = V2Deposit; // @todo: Extend with V2Deposit | V3Deposit.
+export type DepositWithBlock = V2DepositWithBlock; // @todo Extend with V2DepositWithBlock | V3DepositWithBlock.
 
 export interface RelayExecutionInfoCommon {
   recipient: string;
@@ -73,48 +84,30 @@ export enum FillType {
   SlowFill,
 }
 
-export interface v3RelayExecutionEventInfo extends RelayExecutionInfoCommon {
+export interface V3RelayExecutionEventInfo extends RelayExecutionInfoCommon {
   outputAmount: BigNumber;
   fillType: FillType;
 }
 
-interface FillCommon {
-  depositId: number;
-  originChainId: number;
-  destinationChainId: number;
-  depositor: string;
-  recipient: string;
-  message: string;
+export interface V2Fill extends V2RelayData {
+  fillAmount: BigNumber;
+  totalFilledAmount: BigNumber;
   relayer: string;
   repaymentChainId: number;
-  realizedLpFeePct: BigNumber; // appended after initialization (not part of Fill event).
-}
-
-export interface v2Fill extends FillCommon {
-  destinationToken: string;
-  amount: BigNumber;
-  totalFilledAmount: BigNumber;
-  fillAmount: BigNumber;
-  relayerFeePct: BigNumber;
   updatableRelayData: RelayExecutionInfo;
 }
 
-export interface v3Fill extends FillCommon {
-  inputToken: string;
-  inputAmount: BigNumber;
-  outputToken: string;
-  outputAmount: BigNumber;
-  fillDeadline: number;
-  exclusivityDeadline: number;
-  exclusiveRelayer: string;
-  updatableRelayData: v3RelayExecutionEventInfo;
+export interface V3Fill extends V3RelayData {
+  relayer: string;
+  repaymentChainId: number;
+  updatableRelayData: V3RelayExecutionEventInfo;
 }
 
-export interface v2FillWithBlock extends v2Fill, SortableEvent {}
-export interface v3FillWithBlock extends v3Fill, SortableEvent {}
+export interface V2FillWithBlock extends V2Fill, SortableEvent {}
+export interface V3FillWithBlock extends V3Fill, SortableEvent {}
 
-export type Fill = v2Fill; // @todo: Extend with v2Fill | v3Fill.
-export type FillWithBlock = v2FillWithBlock; // @todo Extend with v2FillWithBlock | v3FillWithBlock.
+export type Fill = V2Fill; // @todo: Extend with V2Fill | V3Fill.
+export type FillWithBlock = V2FillWithBlock; // @todo Extend with V2FillWithBlock | V3FillWithBlock.
 
 export interface SpeedUpCommon {
   depositor: string;
@@ -125,47 +118,32 @@ export interface SpeedUpCommon {
   updatedMessage: string;
 }
 
-export interface v2SpeedUp extends SpeedUpCommon {
+export interface V2SpeedUp extends SpeedUpCommon {
   newRelayerFeePct: BigNumber;
 }
 
-export interface v3SpeedUp extends SpeedUpCommon {
+export interface V3SpeedUp extends SpeedUpCommon {
   updatedOutputAmount: BigNumber;
 }
 
-export type SpeedUp = v2SpeedUp; // @todo Extend with v2SpeedUp | v3SpeedUp.
+export type SpeedUp = V2SpeedUp; // @todo Extend with V2SpeedUp | V3SpeedUp.
 
-export interface SlowFillRequest {
-  depositId: number;
-  originChainId: number;
-  destinationChainId: number;
-  depositor: string;
-  recipient: string;
-  inputToken: string;
-  inputAmount: BigNumber;
-  outputToken: string;
-  outputAmount: BigNumber;
-  message: string;
-  fillDeadline: number;
-  exclusivityDeadline: number;
-  exclusiveRelayer: string;
-}
-
+export interface SlowFillRequest extends V3RelayData {}
 export interface SlowFillRequestWithBlock extends SlowFillRequest, SortableEvent {}
 
-export interface v2SlowFillLeaf {
+export interface V2SlowFillLeaf {
   relayData: RelayData;
   payoutAdjustmentPct: string;
 }
 
-export interface v3SlowFillLeaf {
-  relayData: v3RelayData;
+export interface V3SlowFillLeaf {
+  relayData: V3RelayData;
   chainId: number;
   updatedOutputAmount: BigNumber;
 }
 
-// @todo: Extend with v2SlowFillLeaf | v3SlowFillLeaf.
-export type SlowFillLeaf = v2SlowFillLeaf;
+// @todo: Extend with V2SlowFillLeaf | V3SlowFillLeaf.
+export type SlowFillLeaf = V2SlowFillLeaf;
 
 export interface RootBundleRelay {
   rootBundleId: number;
@@ -186,36 +164,6 @@ export interface RelayerRefundExecution {
 }
 
 export interface RelayerRefundExecutionWithBlock extends RelayerRefundExecution, SortableEvent {}
-
-export interface RelayDataCommon {
-  originChainId: number;
-  depositor: string;
-  recipient: string;
-  depositId: number;
-  message: string;
-}
-
-// Used in pool by spokePool to execute a slow relay.
-export interface v2RelayData extends RelayDataCommon {
-  destinationChainId: number;
-  destinationToken: string;
-  amount: BigNumber;
-  relayerFeePct: BigNumber;
-  realizedLpFeePct: BigNumber;
-}
-
-export interface v3RelayData extends RelayDataCommon {
-  inputToken: string;
-  inputAmount: BigNumber;
-  outputToken: string;
-  outputAmount: BigNumber;
-  fillDeadline: number;
-  exclusiveRelayer: string;
-  exclusivityDeadline: number;
-}
-
-// @todo: Extend with v2RelayData | v3RelayData.
-export type RelayData = v2RelayData;
 
 export interface UnfilledDeposit {
   deposit: Deposit;

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import { BigNumber, Contract, utils as ethersUtils } from "ethers";
-import { FillStatus, RelayData, v2RelayData, v3RelayData } from "../interfaces";
+import { FillStatus, RelayData, V2RelayData, V3RelayData } from "../interfaces";
 import { SpokePoolClient } from "../clients";
 import { bnZero } from "./BigNumberUtils";
 import { isDefined } from "./TypeGuards";
@@ -175,7 +175,7 @@ export function getRelayDataHash(relayData: RelayData, destinationChainId?: numb
     return getV2RelayHash(relayData);
   }
 
-  // v3RelayData does not include destinationChainId, so it must be supplied separately for v3 types.
+  // V3RelayData does not include destinationChainId, so it must be supplied separately for v3 types.
   assert(isDefined(destinationChainId));
   return getV3RelayHash(relayData, destinationChainId);
 }
@@ -183,10 +183,10 @@ export function getRelayDataHash(relayData: RelayData, destinationChainId?: numb
 /**
  * Compute the RelayData hash for a fill. This can be used to determine the fill amount.
  * @note Only compatible with Across v2 data types.
- * @param relayData v2RelayData information that is used to complete a fill.
+ * @param relayData V2RelayData information that is used to complete a fill.
  * @returns The corresponding RelayData hash.
  */
-function getV2RelayHash(relayData: v2RelayData): string {
+function getV2RelayHash(relayData: V2RelayData): string {
   return ethersUtils.keccak256(
     ethersUtils.defaultAbiCoder.encode(
       [
@@ -211,11 +211,11 @@ function getV2RelayHash(relayData: v2RelayData): string {
 /**
  * Compute the RelayData hash for a fill. This can be used to determine the fill status.
  * @note Only compatible with Across v3 data types.
- * @param relayData v3RelayData information that is used to complete a fill.
+ * @param relayData V3RelayData information that is used to complete a fill.
  * @param destinationChainId Supplementary destination chain ID required by V3 hashes.
  * @returns The corresponding RelayData hash.
  */
-function getV3RelayHash(relayData: v3RelayData, destinationChainId: number): string {
+function getV3RelayHash(relayData: V3RelayData, destinationChainId: number): string {
   return ethersUtils.keccak256(
     ethersUtils.defaultAbiCoder.encode(
       [
@@ -261,8 +261,8 @@ export async function relayFilledAmount(
   const fillStatus = await spokePool.fillStatuses(hash, { blockTag });
 
   // @note: If the deposit was updated then the fill amount may be _less_ than outputAmount.
-  // @todo: Remove v3RelayData type assertion once RelayData type is unionised.
-  return fillStatus === FillStatus.Filled ? (relayData as v3RelayData).outputAmount : bnZero;
+  // @todo: Remove V3RelayData type assertion once RelayData type is unionised.
+  return fillStatus === FillStatus.Filled ? (relayData as V3RelayData).outputAmount : bnZero;
 }
 
 /**

--- a/src/utils/V3Utils.ts
+++ b/src/utils/V3Utils.ts
@@ -1,24 +1,24 @@
 import {
   FillType,
-  v2Deposit,
-  v3Deposit,
-  v2Fill,
-  v2RelayData,
-  v2SlowFillLeaf,
-  v2SpeedUp,
-  v3Fill,
-  v3RelayData,
-  v3SlowFillLeaf,
-  v3SpeedUp,
+  V2Deposit,
+  V3Deposit,
+  V2Fill,
+  V2RelayData,
+  V2SlowFillLeaf,
+  V2SpeedUp,
+  V3Fill,
+  V3RelayData,
+  V3SlowFillLeaf,
+  V3SpeedUp,
 } from "../interfaces";
 import { BN } from "./BigNumberUtils";
 import { isDefined } from "./TypeGuards";
 
-type Deposit = v2Deposit | v3Deposit;
-type Fill = v2Fill | v3Fill;
-type SpeedUp = v2SpeedUp | v3SpeedUp;
-type RelayData = v2RelayData | v3RelayData;
-type SlowFillLeaf = v2SlowFillLeaf | v3SlowFillLeaf;
+type Deposit = V2Deposit | V3Deposit;
+type Fill = V2Fill | V3Fill;
+type SpeedUp = V2SpeedUp | V3SpeedUp;
+type RelayData = V2RelayData | V3RelayData;
+type SlowFillLeaf = V2SlowFillLeaf | V3SlowFillLeaf;
 
 // Lowest ConfigStore version where the V3 model is in effect. The version update to the following value should
 // take place atomically with the SpokePool upgrade to V3 so that the dataworker knows what kind of MerkleLeaves
@@ -31,48 +31,48 @@ export function isV3(version: number): boolean {
   return version >= 3;
 }
 
-export function isV2Deposit(deposit: Deposit): deposit is v2Deposit {
-  return isDefined((deposit as v2Deposit).originToken);
+export function isV2Deposit(deposit: Deposit): deposit is V2Deposit {
+  return isDefined((deposit as V2Deposit).originToken);
 }
 
-export function isV3Deposit(deposit: Deposit): deposit is v3Deposit {
-  return isDefined((deposit as v3Deposit).inputToken);
+export function isV3Deposit(deposit: Deposit): deposit is V3Deposit {
+  return isDefined((deposit as V3Deposit).inputToken);
 }
 
-export function isV2SpeedUp(speedUp: SpeedUp): speedUp is v2SpeedUp {
-  return isDefined((speedUp as v2SpeedUp).newRelayerFeePct);
+export function isV2SpeedUp(speedUp: SpeedUp): speedUp is V2SpeedUp {
+  return isDefined((speedUp as V2SpeedUp).newRelayerFeePct);
 }
 
-export function isV3SpeedUp(speedUp: SpeedUp): speedUp is v3SpeedUp {
-  return isDefined((speedUp as v3SpeedUp).updatedOutputAmount);
+export function isV3SpeedUp(speedUp: SpeedUp): speedUp is V3SpeedUp {
+  return isDefined((speedUp as V3SpeedUp).updatedOutputAmount);
 }
 
-export function isV2Fill(fill: Fill): fill is v2Fill {
-  return isDefined((fill as v2Fill).destinationToken);
+export function isV2Fill(fill: Fill): fill is V2Fill {
+  return isDefined((fill as V2Fill).destinationToken);
 }
 
-export function isV3Fill(fill: Fill): fill is v3Fill {
-  return isDefined((fill as v3Fill).inputToken);
+export function isV3Fill(fill: Fill): fill is V3Fill {
+  return isDefined((fill as V3Fill).inputToken);
 }
 
-export function isV2RelayData(relayData: RelayData): relayData is v2RelayData {
-  return isDefined((relayData as v2RelayData).destinationToken);
+export function isV2RelayData(relayData: RelayData): relayData is V2RelayData {
+  return isDefined((relayData as V2RelayData).destinationToken);
 }
 
-export function isV3RelayData(relayData: RelayData): relayData is v3RelayData {
-  return isDefined((relayData as v3RelayData).outputToken);
+export function isV3RelayData(relayData: RelayData): relayData is V3RelayData {
+  return isDefined((relayData as V3RelayData).outputToken);
 }
 
 export function isSlowFill(fill: Fill): boolean {
   return isV2Fill(fill) ? fill.updatableRelayData.isSlowRelay : fill.updatableRelayData.fillType === FillType.SlowFill;
 }
 
-export function isV2SlowFillLeaf(slowFillLeaf: SlowFillLeaf): slowFillLeaf is v2SlowFillLeaf {
-  return isDefined((slowFillLeaf as v2SlowFillLeaf).payoutAdjustmentPct) && isV2RelayData(slowFillLeaf.relayData);
+export function isV2SlowFillLeaf(slowFillLeaf: SlowFillLeaf): slowFillLeaf is V2SlowFillLeaf {
+  return isDefined((slowFillLeaf as V2SlowFillLeaf).payoutAdjustmentPct) && isV2RelayData(slowFillLeaf.relayData);
 }
 
-export function isV3SlowFillLeaf(slowFillLeaf: SlowFillLeaf): slowFillLeaf is v3SlowFillLeaf {
-  return isDefined((slowFillLeaf as v3SlowFillLeaf).updatedOutputAmount) && isV3RelayData(slowFillLeaf.relayData);
+export function isV3SlowFillLeaf(slowFillLeaf: SlowFillLeaf): slowFillLeaf is V3SlowFillLeaf {
+  return isDefined((slowFillLeaf as V3SlowFillLeaf).updatedOutputAmount) && isV3RelayData(slowFillLeaf.relayData);
 }
 
 export function getDepositInputToken(deposit: Deposit): string {


### PR DESCRIPTION
This PR makes two changes:
- Reorganise common type definitions around v*RelayData types.
- Rename type definitions v* -> V* to fit type style norms (proposed by
  James).

The former is done out of recognition that RelayData definitions
actually drive a lot of the activity in the bots, and this is even
moreso the case with v3. Anchoring types around RelayData definitions
shortens the set of definitions needed in the SpokePool interfaces file,
and also gives assurance that the bots can correctly derive a RelayData
object out of a Deposit, Fill, or even a SlowFillRequest.