### PR TITLE
feat: Add spoke pool client functions to support BundleDataClient unit tests in relayer-v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/v/developer-docs/developers/across-sdk",
   "files": [

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -510,6 +510,14 @@ export class SpokePoolClient extends BaseAbstractClient {
     return sortEventsAscending(fills.filter((_fill) => filledSameDeposit(_fill, matchingFill)));
   }
 
+  public async getMaxFillDeadlineInRange(startBlock: number, endBlock: number): Promise<number> {
+    const fillDeadlineBuffers = await Promise.all([
+      this.spokePool.fillDeadlineBuffer({ blockTag: startBlock }),
+      this.spokePool.fillDeadlineBuffer({ blockTag: endBlock }),
+    ]);
+    return Math.max(fillDeadlineBuffers[0].toNumber(), fillDeadlineBuffers[1].toNumber());
+  }
+
   /**
    * Performs an update to refresh the state of this client. This will query the SpokePool contract for new events
    * and store them in memory. This method is the primary method for updating the state of this client.

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -511,11 +511,11 @@ export class SpokePoolClient extends BaseAbstractClient {
   }
 
   public async getMaxFillDeadlineInRange(startBlock: number, endBlock: number): Promise<number> {
-    const fillDeadlineBuffers = await Promise.all([
+    const fillDeadlineBuffers: number[] = await Promise.all([
       this.spokePool.fillDeadlineBuffer({ blockTag: startBlock }),
       this.spokePool.fillDeadlineBuffer({ blockTag: endBlock }),
     ]);
-    return Math.max(fillDeadlineBuffers[0].toNumber(), fillDeadlineBuffers[1].toNumber());
+    return Math.max(fillDeadlineBuffers[0], fillDeadlineBuffers[1]);
   }
 
   /**

--- a/src/utils/V3Utils.ts
+++ b/src/utils/V3Utils.ts
@@ -28,7 +28,7 @@ type SlowFillLeaf = v2SlowFillLeaf | v3SlowFillLeaf;
 export const V3_MIN_CONFIG_STORE_VERSION = 3;
 
 export function isV3(version: number): boolean {
-  return version >= 3;
+  return version >= V3_MIN_CONFIG_STORE_VERSION;
 }
 
 export function isV2Deposit(deposit: Deposit): deposit is v2Deposit {


### PR DESCRIPTION
Adds functions we can override in a downstream MockSpokePoolClient to make unit tests more precise
