### PR TITLE
improve: Ignore dotfiles in ABI test

### DIFF
--- a/test/abi.ts
+++ b/test/abi.ts
@@ -5,11 +5,15 @@ import { assertPromiseError, assertPromisePasses } from "./utils";
 describe("ABI Utils", () => {
   describe("getABI", () => {
     it("All files are valid JSON", async () => {
-      const abiFiles = await fs.readdir(getABIDir(), { encoding: "utf8" });
+      let abiFiles = await fs.readdir(getABIDir(), { encoding: "utf8" });
 
-      // Strip any trailing '.json', since readdir() returns the
-      // full filename but callers should only supply the ABI name.
-      for (const abiFile of abiFiles.map((abi) => abi.slice(0, abi.lastIndexOf(".json")))) {
+      // Filter out any dotfiles, because editors sometimes save them in the local working directory. Also, strip any
+      // trailing '.json', since readdir() returns the full filename, but callers should only supply the ABI name.
+      abiFiles = abiFiles
+        .filter((fileName) => !fileName.startsWith("."))
+        .map((fileName) => fileName.slice(0, fileName.lastIndexOf(".json")));
+
+      for (const abiFile of abiFiles) {
         await assertPromisePasses(getABI(abiFile));
       }
     });


### PR DESCRIPTION
This test suddenly started failing after I'd merged in the latest ABI update. I identified the issue to be that my editor has saved a swap file in the same directory, and the test was incorrectly trying to use it.