### PR TITLE
feat: Define V3RelayerRefundExecution

### DIFF
--- a/src/interfaces/HubPool.ts
+++ b/src/interfaces/HubPool.ts
@@ -11,7 +11,7 @@ export interface PoolRebalanceLeaf {
   l1Tokens: string[];
 }
 
-export interface RelayerRefundLeaf {
+export interface RelayerRefundLeafCommon {
   amountToReturn: BigNumber;
   chainId: number;
   refundAmounts: BigNumber[];
@@ -19,6 +19,14 @@ export interface RelayerRefundLeaf {
   l2TokenAddress: string;
   refundAddresses: string[];
 }
+
+export interface V2RelayerRefundLeaf extends RelayerRefundLeafCommon {}
+export interface V3RelayerRefundLeaf extends RelayerRefundLeafCommon {
+  fillsRefundedRoot: string;
+  fillsRefundedHash: string;
+}
+
+export type RelayerRefundLeaf = V2RelayerRefundLeaf;
 
 export interface ProposedRootBundle extends SortableEvent {
   challengePeriodEndTimestamp: number;

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -2,6 +2,7 @@ import { BigNumber } from "ethers";
 import { SortableEvent } from "./Common";
 import { FilledRelayEvent, FilledV3RelayEvent, FundsDepositedEvent, V3FundsDepositedEvent } from "../typechain";
 import { SpokePoolClient } from "../clients";
+import { RelayerRefundLeaf } from "./HubPool";
 
 export type { FilledRelayEvent, FilledV3RelayEvent, FundsDepositedEvent, V3FundsDepositedEvent };
 
@@ -153,17 +154,22 @@ export interface RootBundleRelay {
 
 export interface RootBundleRelayWithBlock extends RootBundleRelay, SortableEvent {}
 
-export interface RelayerRefundExecution {
-  amountToReturn: BigNumber;
-  chainId: number;
-  refundAmounts: BigNumber[];
+export interface V2RelayerRefundExecution extends RelayerRefundLeaf {
   rootBundleId: number;
-  leafId: number;
-  l2TokenAddress: string;
-  refundAddresses: string[];
 }
 
-export interface RelayerRefundExecutionWithBlock extends RelayerRefundExecution, SortableEvent {}
+export interface V3RelayerRefundExecution extends V2RelayerRefundExecution {
+  fillsRefundedRoot: string;
+  fillsRefundedIpfsHash: string;
+}
+
+export interface V2RelayerRefundExecutionWithBlock extends V2RelayerRefundExecution, SortableEvent {}
+export interface V3RelayerRefundExecutionWithBlock extends V3RelayerRefundExecution, SortableEvent {}
+
+// @todo: Extend with V2RelayerRefundExecution | V3RelayerRefundExecution.
+export type RelayerRefundExecution = V2RelayerRefundExecution;
+// @todo Extend with V2RelayerRefundLeafWithBlock | V3RelayerRefundLeafWithBlock.
+export type RelayerRefundExecutionWithBlock = V2RelayerRefundExecutionWithBlock;
 
 export interface UnfilledDeposit {
   deposit: Deposit;

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -2,7 +2,7 @@ import { BigNumber } from "ethers";
 import { SortableEvent } from "./Common";
 import { FilledRelayEvent, FilledV3RelayEvent, FundsDepositedEvent, V3FundsDepositedEvent } from "../typechain";
 import { SpokePoolClient } from "../clients";
-import { RelayerRefundLeaf } from "./HubPool";
+import { V2RelayerRefundLeaf, V3RelayerRefundLeaf } from "./HubPool";
 
 export type { FilledRelayEvent, FilledV3RelayEvent, FundsDepositedEvent, V3FundsDepositedEvent };
 
@@ -154,13 +154,12 @@ export interface RootBundleRelay {
 
 export interface RootBundleRelayWithBlock extends RootBundleRelay, SortableEvent {}
 
-export interface V2RelayerRefundExecution extends RelayerRefundLeaf {
+export interface V2RelayerRefundExecution extends V2RelayerRefundLeaf {
   rootBundleId: number;
 }
 
-export interface V3RelayerRefundExecution extends V2RelayerRefundExecution {
-  fillsRefundedRoot: string;
-  fillsRefundedIpfsHash: string;
+export interface V3RelayerRefundExecution extends V3RelayerRefundLeaf {
+  rootBundleId: number;
 }
 
 export interface V2RelayerRefundExecutionWithBlock extends V2RelayerRefundExecution, SortableEvent {}

--- a/src/utils/V3Utils.ts
+++ b/src/utils/V3Utils.ts
@@ -4,10 +4,14 @@ import {
   V3Deposit,
   V2Fill,
   V2RelayData,
+  V2RelayerRefundExecution,
+  V2RelayerRefundLeaf,
   V2SlowFillLeaf,
   V2SpeedUp,
   V3Fill,
   V3RelayData,
+  V3RelayerRefundExecution,
+  V3RelayerRefundLeaf,
   V3SlowFillLeaf,
   V3SpeedUp,
 } from "../interfaces";
@@ -19,6 +23,8 @@ type Fill = V2Fill | V3Fill;
 type SpeedUp = V2SpeedUp | V3SpeedUp;
 type RelayData = V2RelayData | V3RelayData;
 type SlowFillLeaf = V2SlowFillLeaf | V3SlowFillLeaf;
+type RelayerRefundExecution = V2RelayerRefundExecution | V3RelayerRefundExecution;
+type RelayerRefundLeaf = V2RelayerRefundLeaf | V3RelayerRefundLeaf;
 
 // Lowest ConfigStore version where the V3 model is in effect. The version update to the following value should
 // take place atomically with the SpokePool upgrade to V3 so that the dataworker knows what kind of MerkleLeaves
@@ -73,6 +79,14 @@ export function isV2SlowFillLeaf(slowFillLeaf: SlowFillLeaf): slowFillLeaf is V2
 
 export function isV3SlowFillLeaf(slowFillLeaf: SlowFillLeaf): slowFillLeaf is V3SlowFillLeaf {
   return isDefined((slowFillLeaf as V3SlowFillLeaf).updatedOutputAmount) && isV3RelayData(slowFillLeaf.relayData);
+}
+
+export function isV3RelayerRefundLeaf(leaf: RelayerRefundLeaf): leaf is V3RelayerRefundLeaf {
+  return isDefined((leaf as V3RelayerRefundLeaf).fillsRefundedRoot);
+}
+
+export function isV3RelayerRefundExecution(refund: RelayerRefundExecution): refund is V3RelayerRefundExecution {
+  return isDefined((refund as V3RelayerRefundExecution).fillsRefundedRoot);
 }
 
 export function getDepositInputToken(deposit: Deposit): string {


### PR DESCRIPTION
This change introduces V3 defintions for RelayerRefundExecution, but also recognises that the existing RelayerRefundExecution SpokePool definition has significant overlap with the HubPool RelayerRefundLeaf type, so it now inherits most of the definition from the HubPool.