### PR TITLE
feat: Add helper method getV3RelayHashFromEvent

### DIFF
--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import { BigNumber, Contract, utils as ethersUtils } from "ethers";
-import { FillStatus, RelayData, V2RelayData, V3RelayData } from "../interfaces";
+import { FillStatus, RelayData, SlowFillRequest, V2RelayData, V3Deposit, V3Fill, V3RelayData } from "../interfaces";
 import { SpokePoolClient } from "../clients";
 import { bnZero } from "./BigNumberUtils";
 import { isDefined } from "./TypeGuards";
@@ -238,6 +238,24 @@ function getV3RelayHash(relayData: V3RelayData, destinationChainId: number): str
       [relayData, destinationChainId]
     )
   );
+}
+
+export function getV3RelayHashFromEvent(e: V3Deposit | V3Fill | SlowFillRequest): string {
+  const relayData: V3RelayData = {
+    depositor: e.depositor,
+    recipient: e.recipient,
+    exclusiveRelayer: e.exclusiveRelayer,
+    inputToken: e.inputToken,
+    outputToken: e.outputToken,
+    inputAmount: e.inputAmount,
+    outputAmount: e.outputAmount,
+    originChainId: e.originChainId,
+    depositId: e.depositId,
+    fillDeadline: e.fillDeadline,
+    exclusivityDeadline: e.exclusivityDeadline,
+    message: e.message,
+  };
+  return getV3RelayHash(relayData, e.destinationChainId);
 }
 
 /**


### PR DESCRIPTION
Will be useful in BundleDataClient to get relay hashes from raw V3 events from SpokePoolClient

See https://github.com/across-protocol/relayer-v2/pull/1155 in `Dataworker.BundleDataClient` for how I use this
