### PR TITLE
feat: Utility for identifying Arbitrum chains

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
   },
   "dependencies": {
     "@across-protocol/across-token": "^1.0.0",
-    "@across-protocol/constants-v2": "^1.0.8",
+    "@across-protocol/constants-v2": "^1.0.9",
     "@across-protocol/contracts-v2": "^2.4.7",
     "@eth-optimism/sdk": "^3.1.8",
     "@pinata/sdk": "^2.1.0",

--- a/src/utils/NetworkUtils.ts
+++ b/src/utils/NetworkUtils.ts
@@ -1,5 +1,5 @@
 import { PublicNetworks } from "@uma/common";
-import { PRODUCTION_CHAIN_IDS, TESTNET_CHAIN_IDS } from "../constants";
+import { CHAIN_IDs, PRODUCTION_CHAIN_IDS, TESTNET_CHAIN_IDS } from "../constants";
 
 /**
  * A list of networks that provide more resolution about a chainid -> network name
@@ -68,5 +68,14 @@ export function chainIsTestnet(chainId: number): boolean {
  * @returns True if chainId is an OP stack, otherwise false.
  */
 export function chainIsOPStack(chainId: number): boolean {
-  return [10, 8453, 69, 420, 84531].includes(chainId);
+  return [CHAIN_IDs.OPTIMISM, CHAIN_IDs.BASE, CHAIN_IDs.OPTIMISM_GOERLI, CHAIN_IDs.BASE_GOERLI].includes(chainId);
+}
+
+/**
+ * Determines whether a chain ID is an Arbitrum implementation.
+ * @param chainId Chain ID to evaluate.
+ * @returns True if chainId is an Arbitrum chain, otherwise false.
+ */
+export function chainIsArbitrum(chainId: number): boolean {
+  return [CHAIN_IDs.ARBITRUM, CHAIN_IDs.ARBITRUM_GOERLI].includes(chainId);
 }

--- a/src/utils/NetworkUtils.ts
+++ b/src/utils/NetworkUtils.ts
@@ -68,7 +68,14 @@ export function chainIsTestnet(chainId: number): boolean {
  * @returns True if chainId is an OP stack, otherwise false.
  */
 export function chainIsOPStack(chainId: number): boolean {
-  return [CHAIN_IDs.OPTIMISM, CHAIN_IDs.BASE, CHAIN_IDs.OPTIMISM_GOERLI, CHAIN_IDs.BASE_GOERLI].includes(chainId);
+  return [
+    CHAIN_IDs.OPTIMISM,
+    CHAIN_IDs.BASE,
+    CHAIN_IDs.OPTIMISM_GOERLI,
+    CHAIN_IDs.BASE_GOERLI,
+    CHAIN_IDs.OPTIMISM_SEPOLIA,
+    CHAIN_IDs.BASE_SEPOLIA,
+  ].includes(chainId);
 }
 
 /**

--- a/src/utils/NetworkUtils.ts
+++ b/src/utils/NetworkUtils.ts
@@ -77,5 +77,5 @@ export function chainIsOPStack(chainId: number): boolean {
  * @returns True if chainId is an Arbitrum chain, otherwise false.
  */
 export function chainIsArbitrum(chainId: number): boolean {
-  return [CHAIN_IDs.ARBITRUM, CHAIN_IDs.ARBITRUM_GOERLI].includes(chainId);
+  return [CHAIN_IDs.ARBITRUM, CHAIN_IDs.ARBITRUM_GOERLI, CHAIN_IDs.ARBITRUM_SEPOLIA].includes(chainId);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,10 +21,10 @@
   resolved "https://registry.yarnpkg.com/@across-protocol/constants-v2/-/constants-v2-1.0.4.tgz#df31c81038982a25de2b1b8f7604875f3de1186c"
   integrity sha512-Nzl8Z1rZFvcpuKQu7CmBVfvgB13/NoulcsRVYBSkG90imS/e6mugxzqD9UrUb+WOL0ODMCANCAoDw54ZBBzNiQ==
 
-"@across-protocol/constants-v2@^1.0.8":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@across-protocol/constants-v2/-/constants-v2-1.0.8.tgz#0f4dc9fbcf7b99dd895a06bb6070b5d3c8e1188d"
-  integrity sha512-7rygtlYseWNI/5ocIT9SXYu6L86oQbKTtFNAOw5MqD53bbsREzRy5dU0wkUHJzvHiNIQ+iawKnzprqshHHeRKw==
+"@across-protocol/constants-v2@^1.0.9":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@across-protocol/constants-v2/-/constants-v2-1.0.9.tgz#bf1b8daa9fc57de29f7561bee288fa3406324787"
+  integrity sha512-Zc+EzT6Cbbxp1tL1lJTl9QCy8RoOySAmetQeMSfMdm6yE7HpLw05wvxUEx0qGNImwGg2ioaceefnm+Gg1MLgIQ==
 
 "@across-protocol/contracts-v2@^2.4.7":
   version "2.4.7"


### PR DESCRIPTION
A use for this has been identified in the relayer repository, but it's
also likely to be needed for Orbit chains.

While here, update the OP stack chain IDs as well, since we now have new 
test chains.