### PR TITLE
ci(DX): :construction_worker: confirm that SDK builds before merging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,5 @@
 name: CI
 on: [push]
-env:
-  NODE_OPTIONS: "--max_old_space_size=4096"
 jobs:
   build:
     name: Builds
@@ -13,6 +11,4 @@ jobs:
           node-version: 16
       - run: yarn install
       - run: yarn build
-        env:
-          NODE_URL_1: ${{ secrets.NODE_URL_1 }}
 


### PR DESCRIPTION
We should be testing that the SDK builds properly via `yarn build`. This done when a new version is created, but we should have the check at the PR level.