### PR TITLE
feat(SpokePoolClient): Improvements and corrections

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -757,7 +757,7 @@ export class SpokePoolClient extends BaseAbstractClient {
         let deposit: DepositWithBlock;
 
         if (this.isV3DepositEvent(event)) {
-          deposit = { ...(rawDeposit as V3DepositWithBlock) };
+          deposit = { ...(rawDeposit as V3DepositWithBlock), originChainId: this.chainId };
           if (deposit.outputToken === ZERO_ADDRESS) {
             deposit.outputToken = this.getDestinationTokenForDeposit(deposit);
           }
@@ -768,7 +768,6 @@ export class SpokePoolClient extends BaseAbstractClient {
 
         // Derive and append the common properties that are not part of the onchain event.
         const { quoteBlock: quoteBlockNumber, realizedLpFeePct } = dataForQuoteTime[index];
-        deposit.originChainId = this.chainId;
         deposit.realizedLpFeePct = realizedLpFeePct;
         deposit.quoteBlockNumber = quoteBlockNumber;
 

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -119,20 +119,24 @@ export class SpokePoolClient extends BaseAbstractClient {
   }
 
   public _queryableEventNames(): { [eventName: string]: EventFilter } {
-    return {
-      FundsDeposited: this.spokePool.filters.FundsDeposited(),
-      RequestedSpeedUpDeposit: this.spokePool.filters.RequestedSpeedUpDeposit(),
-      FilledRelay: this.spokePool.filters.FilledRelay(),
-      EnabledDepositRoute: this.spokePool.filters.EnabledDepositRoute(),
-      TokensBridged: this.spokePool.filters.TokensBridged(),
-      RelayedRootBundle: this.spokePool.filters.RelayedRootBundle(),
-      ExecutedRelayerRefundRoot: this.spokePool.filters.ExecutedRelayerRefundRoot(),
-      // These events will only work after bumping to the new contracts-v2 package.
-      // V3FundsDeposited: this.spokePool.filters.V3FundsDeposited(),
-      // RequestedSpeedUpV3Deposit: this.spokePool.filters.RequestedSpeedUpV3Deposit(),
-      // FilledV3Relay: this.spokePool.filters.FilledV3Relay(),
-      // ExecutedV3RelayerRefundRoot: this.spokePool.filters.ExecutedV3RelayerRefundRoot(),
-    };
+    const knownEventNames = [
+      "FundsDeposited",
+      "RequestedSpeedUpDeposit",
+      "FilledRelay",
+      "EnabledDepositRoute",
+      "TokensBridged",
+      "RelayedRootBundle",
+      "ExecutedRelayerRefundRoot",
+      "V3FundsDeposited",
+      "RequestedSpeedUpV3Deposit",
+      "FilledV3Relay",
+      "ExecutedV3RelayerRefundRoot",
+    ];
+    return Object.fromEntries(
+      this.spokePool.interface.fragments
+        .filter(({ name, type }) => type === "event" && knownEventNames.includes(name))
+        .map(({ name }) => [name, this.spokePool.filters[name]()])
+    );
   }
 
   /**
@@ -306,6 +310,9 @@ export class SpokePoolClient extends BaseAbstractClient {
 
     if (isV2Deposit(deposit)) {
       const v2SpeedUps = depositorSpeedUps.filter(isV2SpeedUp<V2SpeedUp, V3SpeedUp>);
+      if (v2SpeedUps.length === 0) {
+        return deposit;
+      }
       const maxSpeedUp = v2SpeedUps.reduce((prev, current) =>
         prev.newRelayerFeePct.gt(current.newRelayerFeePct) ? prev : current
       );
@@ -329,6 +336,9 @@ export class SpokePoolClient extends BaseAbstractClient {
     }
 
     const v3SpeedUps = depositorSpeedUps.filter(isV3SpeedUp<V3SpeedUp, V2SpeedUp>);
+    if (v3SpeedUps.length === 0) {
+      return deposit;
+    }
     const maxSpeedUp = v3SpeedUps.reduce((prev, current) =>
       prev.updatedOutputAmount.lt(current.updatedOutputAmount) ? prev : current
     );
@@ -758,6 +768,7 @@ export class SpokePoolClient extends BaseAbstractClient {
 
         // Derive and append the common properties that are not part of the onchain event.
         const { quoteBlock: quoteBlockNumber, realizedLpFeePct } = dataForQuoteTime[index];
+        deposit.originChainId = this.chainId;
         deposit.realizedLpFeePct = realizedLpFeePct;
         deposit.quoteBlockNumber = quoteBlockNumber;
 


### PR DESCRIPTION
 - Support dynamic population of _queryableEventNames(), subject a filter to avoid accidentally querying random events that we aren't actually interested in.
 - Ensure empty speedup arrays are not passed to Array.reduce().
 - Ensure to append originChainId on V3FundsDeposited events.

The Array.reduce() issue was originally identified by Nick.