### PR TITLE
improve(arweave): handle out of gas error

### DIFF
--- a/src/caching/Arweave/ArweaveClient.ts
+++ b/src/caching/Arweave/ArweaveClient.ts
@@ -52,20 +52,24 @@ export class ArweaveClient {
     await this.client.transactions.sign(transaction, this.arweaveJWT);
     // Send the transaction
     const result = await this.client.transactions.post(transaction);
-    this.logger.debug({
-      at: "ArweaveClient:set",
-      message: `Arweave transaction posted with ${transaction.id}`,
-    });
+
     // Ensure that the result is successful
     if (result.status !== 200) {
+      const message = result?.data?.error?.msg ?? "Unknown error";
       this.logger.error({
         at: "ArweaveClient:set",
-        message: `Arweave transaction failed with ${transaction.id}`,
+        message,
         result,
+        txn: transaction.id,
         address: await this.getAddress(),
         balance: (await this.getBalance()).toString(),
       });
-      throw new Error("Server failed to receive arweave transaction");
+      throw new Error(message);
+    } else {
+      this.logger.debug({
+        at: "ArweaveClient:set",
+        message: `Arweave transaction posted with ${transaction.id}`,
+      });
     }
     return transaction.id;
   }

--- a/test/arweaveClient.ts
+++ b/test/arweaveClient.ts
@@ -156,7 +156,7 @@ describe("ArweaveClient", () => {
     });
   });
 
-  it.only("should gracefully handle out of funds errors", async () => {
+  it("should gracefully handle out of funds errors", async () => {
     const jwk = await Arweave.init({}).wallets.generate();
     // Create a new Arweave client
     const client = new ArweaveClient(

--- a/test/arweaveClient.ts
+++ b/test/arweaveClient.ts
@@ -7,6 +7,7 @@ import { ArweaveClient } from "../src/caching";
 import { parseWinston, toBN } from "../src/utils";
 import { object, string } from "superstruct";
 import { ARWEAVE_TAG_APP_NAME } from "../src/constants";
+import { assertPromiseError } from "./utils";
 
 const INITIAL_FUNDING_AMNT = "5000000000";
 const LOCAL_ARWEAVE_NODE = {
@@ -153,5 +154,24 @@ describe("ArweaveClient", () => {
       appName: ARWEAVE_TAG_APP_NAME,
       topic: topicTag,
     });
+  });
+
+  it.only("should gracefully handle out of funds errors", async () => {
+    const jwk = await Arweave.init({}).wallets.generate();
+    // Create a new Arweave client
+    const client = new ArweaveClient(
+      jwk,
+      // Define default winston logger
+      winston.createLogger({
+        level: "info",
+        format: winston.format.json(),
+        defaultMeta: { service: "arweave-client" },
+        transports: [new winston.transports.Console()],
+      }),
+      LOCAL_ARWEAVE_NODE.host,
+      LOCAL_ARWEAVE_NODE.protocol,
+      LOCAL_ARWEAVE_NODE.port
+    );
+    await assertPromiseError(client.set({ test: "value" }), "You don't have enough tokens");
   });
 });


### PR DESCRIPTION
We should explicitly handle the path where we are out of gas. This should unwind the stack to the calling function.