### PR TITLE
fix(arweave): resolve BN parse error for large Arweave balances

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/v/developer-docs/developers/across-sdk",
   "files": [


### PR DESCRIPTION
Large enough Arweave balances (5B+ Arweave balances) are returned to the client in scientific notation (i.e. `5e+24`). This PR handles the sci notation output.