### PR TITLE
feat(arweave): search by topics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/v/developer-docs/developers/across-sdk",
   "files": [

--- a/src/caching/Arweave/ArweaveClient.ts
+++ b/src/caching/Arweave/ArweaveClient.ts
@@ -102,6 +102,47 @@ export class ArweaveClient {
   }
 
   /**
+   * Retrieves a list of records from the Arweave network that have a specific tag.
+   * The records are expected to be a JSON string and are pre-filtered by the Across
+   * protocol tag, the content-type tag, and this client's address. Furthermore, the
+   * records are expected to be an array of the given type and will be discarded if
+   * they do not match the given validator.
+   * @param tag The tag to filter all the transactions by
+   * @param validator The validator to validate the retrieved values
+   * @returns The records if they exist, otherwise an empty array
+   */
+  async getByTopic<T>(tag: string, validator: Struct<T>): Promise<T[]> {
+    const transactions = await this.client.api.post<{
+      data: {
+        transactions: {
+          edges: {
+            node: {
+              id: string;
+            };
+          }[];
+        };
+      };
+    }>("/graphql", {
+      query: `
+        { 
+          transactions (
+            owners: ["${await this.getAddress()}"]
+            tags: [
+              { name: "App-Name", values: ["${ARWEAVE_TAG_APP_NAME}"] },
+              { name: "Content-Type", values: ["application/json"] },
+              ${tag ? `{ name: "Topic", values: ["${tag}"] } ` : ""}
+            ]
+          ) { edges { node { id } } } 
+        }`,
+    });
+    return (
+      await Promise.all(
+        transactions.data.data.transactions.edges.map((edge) => edge.node.id).map((txnId) => this.get(txnId, validator))
+      )
+    ).filter(isDefined);
+  }
+
+  /**
    * Retrieves the metadata of a transaction
    * @param transactionID The transaction ID of the record to retrieve
    * @returns The metadata of the transaction if it exists, otherwise null

--- a/test/arweaveClient.ts
+++ b/test/arweaveClient.ts
@@ -159,7 +159,7 @@ describe("ArweaveClient", () => {
     });
   });
 
-  it.only("should retrieve the data by the topic tag", async () => {
+  it("should retrieve the data by the topic tag", async () => {
     const value = { test: "value" };
     const topicTag = "test-topic-for-get-by-topic";
     const txID = await client.set(value, topicTag);
@@ -171,7 +171,12 @@ describe("ArweaveClient", () => {
 
     const data = await client.getByTopic(topicTag, object({ test: string() }));
 
-    expect(data).to.deep.equal([value]);
+    expect(data).to.deep.equal([
+      {
+        data: value,
+        hash: txID,
+      },
+    ]);
   });
 
   it("should gracefully handle out of funds errors", async () => {


### PR DESCRIPTION
Allows the Arweave client to resolve data by tags. This will be helpful for use in the relayer-v2 so that we don't submit duplicate data.