### PR TITLE
improve(FlowUtils): Avoid hashing obvious fill mismatches

### DIFF
--- a/src/utils/FlowUtils.ts
+++ b/src/utils/FlowUtils.ts
@@ -31,6 +31,11 @@ export const V3_DEPOSIT_COMPARISON_KEYS = [
 ] as const;
 
 export function filledSameDeposit(fillA: Fill, fillB: Fill): boolean {
+  // Don't bother hashing obvious mismatches.
+  if (fillA.depositId !== fillB.depositId) {
+    return false;
+  }
+
   if (isV2Fill(fillA) && isV2Fill(fillB)) {
     return getV2RelayHash(fillA) === getV2RelayHash(fillB);
   } else if (isV3Fill(fillA) && isV3Fill(fillB)) {


### PR DESCRIPTION
Hashing can be expensive when it's run in a tight loop (i.e. when iterating over a complete array). Identified by Nick when investigating performance issues.