### PR TITLE
feat(relayFeeCalculator): Support estimating v3 fills

### DIFF
--- a/src/relayFeeCalculator/chain-queries/baseQuery.ts
+++ b/src/relayFeeCalculator/chain-queries/baseQuery.ts
@@ -65,7 +65,7 @@ export default abstract class QueryBase implements QueryInterface {
    * @param relayerAddress Relayer address to simulate with.
    * @returns The gas estimate for this function call (multplied with the optional buffer).
    */
-  async getGasCosts(
+  getGasCosts(
     deposit: Deposit,
     fillAmount: BigNumberish,
     relayAddress = DEFAULT_SIMULATED_RELAYER_ADDRESS

--- a/src/relayFeeCalculator/chain-queries/baseQuery.ts
+++ b/src/relayFeeCalculator/chain-queries/baseQuery.ts
@@ -68,9 +68,9 @@ export default abstract class QueryBase implements QueryInterface {
   getGasCosts(
     deposit: Deposit,
     fillAmount: BigNumberish,
-    relayAddress = DEFAULT_SIMULATED_RELAYER_ADDRESS
+    relayer = DEFAULT_SIMULATED_RELAYER_ADDRESS
   ): Promise<TransactionCostEstimate> {
-    const relayer = relayAddress ?? this.simulatedRelayerAddress;
+    relayer ??= this.simulatedRelayerAddress;
     return isV2Deposit(deposit)
       ? this.getV2GasCosts(deposit, fillAmount, relayer)
       : this.getV3GasCosts(deposit, relayer);

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -13,7 +13,7 @@ import { getNetworkName } from "./NetworkUtils";
  * @param repaymentChainId Optional repaymentChainId (defaults to destinationChainId).
  * @returns An Ethers UnsignedTransaction instance.
  */
-export async function populateV3Relay(
+export function populateV3Relay(
   spokePool: Contract,
   deposit: V3Deposit,
   repaymentChainId = deposit.destinationChainId


### PR DESCRIPTION
This is a simple change to permit estimating v3 fills. This is used by the relayer, but also the FE. It'll be necessary for simulating messages with fills to recipients who only support handleV3AcrossMessage(), and the relayer also needs it prior to v3 going live.