### PR TITLE
fix: Add `originChainId` to partial deposit queried from eth_getLogs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/v/developer-docs/developers/across-sdk",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.22.5",
+  "version": "0.22.6",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/v/developer-docs/developers/across-sdk",
   "files": [

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -1175,7 +1175,7 @@ export class SpokePoolClient extends BaseAbstractClient {
       quoteBlockNumber,
       outputToken:
         partialDeposit.outputToken === ZERO_ADDRESS
-          ? this.getDestinationTokenForDeposit(partialDeposit)
+          ? this.getDestinationTokenForDeposit({ ...partialDeposit, originChainId: this.chainId })
           : partialDeposit.outputToken,
     };
 

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -237,15 +237,14 @@ export class RelayFeeCalculator {
       throw new Error(`Could not find token information for ${inputToken}`);
     }
 
-    if (simulateZeroFill) {
-      amountToRelay = safeOutputAmount;
-      // Reduce the output amount to simulate a full fill with a lower value to estimate
-      // the fill cost accurately without risking a failure due to insufficient balance.
-      deposit = isV2Deposit(deposit)
-        ? { ...deposit, amount: amountToRelay }
-        : { ...deposit, outputAmount: amountToRelay };
-    }
-    const getGasCosts = this.queries.getGasCosts(deposit, amountToRelay, relayerAddress).catch((error) => {
+    // Reduce the output amount to simulate a full fill with a lower value to estimate
+    // the fill cost accurately without risking a failure due to insufficient balance.
+    const simulatedAmount = simulateZeroFill ? safeOutputAmount : toBN(amountToRelay);
+    deposit = isV2Deposit(deposit)
+      ? { ...deposit, amount: simulatedAmount }
+      : { ...deposit, outputAmount: simulatedAmount };
+
+    const getGasCosts = this.queries.getGasCosts(deposit, simulatedAmount, relayerAddress).catch((error) => {
       this.logger.error({
         at: "sdk-v2/gasFeePercent",
         message: "Error while fetching gas costs",


### PR DESCRIPTION
Missing `originChainId` needs to be appended to this partial event queried from eth_getLogs