### PR TITLE
fix: get l2 token address utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.22.6",
+  "version": "0.22.7",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/v/developer-docs/developers/across-sdk",
   "files": [

--- a/src/utils/TokenUtils.ts
+++ b/src/utils/TokenUtils.ts
@@ -15,9 +15,12 @@ export async function fetchTokenInfo(address: string, signerOrProvider: SignerOr
   return { address, symbol, decimals };
 }
 
-export const getL2TokenAddresses = (l1TokenAddress: string): { [chainId: number]: string } | undefined => {
+export const getL2TokenAddresses = (
+  l1TokenAddress: string,
+  l1ChainId = CHAIN_IDs.MAINNET
+): { [chainId: number]: string } | undefined => {
   return Object.values(TOKEN_SYMBOLS_MAP).find((details) => {
-    return details.addresses[CHAIN_IDs.MAINNET] === l1TokenAddress;
+    return details.addresses[l1ChainId] === l1TokenAddress;
   })?.addresses;
 };
 


### PR DESCRIPTION
Allow overriding l1 chain id when trying to get l2 token address.