### PR TITLE
improve(HubPoolClient): Permit selectively overriding search config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.22.10",
+  "version": "0.22.11",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/v/developer-docs/developers/across-sdk",
   "files": [

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -796,7 +796,6 @@ export class HubPoolClient extends BaseAbstractClient {
       at: "HubPoolClient",
       message: "Updating HubPool client",
       searchConfig: eventSearchConfigs.map(({ eventName, searchConfig }) => ({ eventName, searchConfig })),
-      eventNames,
     });
     const timerStart = Date.now();
     const [currentTime, pendingRootBundleProposal, ...events] = await Promise.all([

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -771,17 +771,38 @@ export class HubPoolClient extends BaseAbstractClient {
       return { success: false };
     }
 
+    const eventSearchConfigs = eventNames.map((eventName) => {
+      if (!Object.keys(hubPoolEvents).includes(eventName)) {
+        throw new Error(`HubPoolClient: Cannot query unrecognised HubPool event name: ${eventName}`);
+      }
+
+      const _searchConfig = { ...searchConfig }; // shallow copy
+
+      // By default, an event's query range is controlled by the `searchConfig` passed in during
+      // instantiation. However, certain events generally must be queried back to HubPool genesis.
+      const overrideEvents = ["CrossChainContractsSet", "L1TokenEnabledForLiquidityProvision", "SetPoolRebalanceRoute"];
+      if (overrideEvents.includes(eventName) && !this.isUpdated) {
+        _searchConfig.fromBlock = this.deploymentBlock;
+      }
+
+      return {
+        eventName,
+        filter: hubPoolEvents[eventName],
+        searchConfig: _searchConfig,
+      };
+    });
+
     this.logger.debug({
       at: "HubPoolClient",
       message: "Updating HubPool client",
-      searchConfig,
+      searchConfig: eventSearchConfigs.map(({ eventName, searchConfig }) => ({ eventName, searchConfig })),
       eventNames,
     });
     const timerStart = Date.now();
     const [currentTime, pendingRootBundleProposal, ...events] = await Promise.all([
       this.hubPool.getCurrentTime({ blockTag: searchConfig.toBlock }),
       this.hubPool.rootBundleProposal({ blockTag: searchConfig.toBlock }),
-      ...eventNames.map((eventName) => paginatedEventQuery(this.hubPool, hubPoolEvents[eventName], searchConfig)),
+      ...eventSearchConfigs.map((config) => paginatedEventQuery(this.hubPool, config.filter, config.searchConfig)),
     ]);
     this.logger.debug({
       at: "HubPoolClient#_update",


### PR DESCRIPTION
This follows the pattern established in the SpokePoolClient, where `EnabledDepositRoute` overriddes `searchConfig.fromBlock` on the first update.

This will be used in the relayer to reduce the lookback for events related to root bundles, since there's no need to query those all the way back to HubPool genesis.