### PR TITLE
fix(logger): use proper slack transport inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.22.11",
+  "version": "0.22.12",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/v/developer-docs/developers/across-sdk",
   "files": [

--- a/src/caching/Arweave/ArweaveClient.ts
+++ b/src/caching/Arweave/ArweaveClient.ts
@@ -23,7 +23,11 @@ export class ArweaveClient {
       timeout: 20000,
       logging: false,
     });
-    this.logger.info("Arweave client initialized");
+    this.logger.debug({
+      at: "ArweaveClient:constructor",
+      message: "Arweave client initialized",
+      gateway: `${protocol}://${gatewayURL}:${port}`,
+    });
   }
 
   /**
@@ -95,7 +99,10 @@ export class ArweaveClient {
     }
     // If the validator does not match the retrieved value, return null and log a warning
     if (!is(data, validator)) {
-      this.logger.warn("Retrieved value from Arweave does not match the expected type");
+      this.logger.warn({
+        at: "ArweaveClient:get",
+        message: "Retrieved value from Arweave does not match the expected type",
+      });
       return null;
     }
     return data;


### PR DESCRIPTION
We should be passing the expected inputs to the logger as defined here: https://github.com/UMAprotocol/protocol/blob/2f300fd7f24367aed758baa0367241d7fed2d599/packages/logger/src/logger/SlackTransport.ts#L5-L23