### PR TITLE
improve(sdk): bump optimism sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@across-protocol/across-token": "^1.0.0",
     "@across-protocol/constants-v2": "^1.0.12",
     "@across-protocol/contracts-v2": "2.5.0-beta.7",
-    "@eth-optimism/sdk": "^3.1.8",
+    "@eth-optimism/sdk": "^3.2.2",
     "@pinata/sdk": "^2.1.0",
     "@types/mocha": "^10.0.1",
     "@uma/sdk": "^0.34.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -530,10 +530,10 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.49.0.tgz#86f79756004a97fa4df866835093f1df3d03c333"
   integrity sha512-1S8uAY/MTJqVx0SC4epBq+N2yhuwtNwLbJYNZyhL2pO1ZVKn5HFXav5T41Ryzy9K9V7ZId2JB2oy/W4aCd9/2w==
 
-"@eth-optimism/contracts-bedrock@0.16.2":
-  version "0.16.2"
-  resolved "https://registry.yarnpkg.com/@eth-optimism/contracts-bedrock/-/contracts-bedrock-0.16.2.tgz#065ad561c3c8b942e4e0dd3d0ea6ed7e00a0f8f0"
-  integrity sha512-a2+f7soDbrd6jV74U02EpyMwQt2iZeDZ4c2ZwgkObcxXUZLZQ2ELt/VRFBf8TIL3wYcBOGpUa1aXAE2oHQ7oRA==
+"@eth-optimism/contracts-bedrock@0.17.1":
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/contracts-bedrock/-/contracts-bedrock-0.17.1.tgz#729b1dc53ec23d02ea9e68181f994955129f7415"
+  integrity sha512-Hc5peN5PM8kzl9dzqSD5jv6ED3QliO1DF0dXLRJxfrXR7/rmEeyuAYESUwUM0gdJZjkwRYiS5m230BI6bQmnlw==
 
 "@eth-optimism/contracts@0.6.0":
   version "0.6.0"
@@ -608,17 +608,18 @@
     ethers "^5.5.4"
     lodash "^4.17.21"
 
-"@eth-optimism/sdk@^3.1.8":
-  version "3.1.8"
-  resolved "https://registry.yarnpkg.com/@eth-optimism/sdk/-/sdk-3.1.8.tgz#af68d1d58e0d71539363a273a50815233b54c83a"
-  integrity sha512-hvv7f3xE5JWIRN1lSiBUeRXdr2Ue+Ircgl612Gi/WvW1M3KGWQzCO0GYl858yheM8ROZOboOjSyKRy+ObubJkw==
+"@eth-optimism/sdk@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/sdk/-/sdk-3.2.2.tgz#732c2d6fde96a25303b3c5b39b3b3ed1f913d9aa"
+  integrity sha512-P8YXAlh2lun0KZlwrw4FqmK4kNIoOOzI816XXhfkW3nMVADGRAru3TKSM74MgmEuyGiHrA9EoPRq1WLqUX4B0w==
   dependencies:
     "@eth-optimism/contracts" "0.6.0"
-    "@eth-optimism/contracts-bedrock" "0.16.2"
+    "@eth-optimism/contracts-bedrock" "0.17.1"
     "@eth-optimism/core-utils" "0.13.1"
     lodash "^4.17.21"
     merkletreejs "^0.3.11"
     rlp "^2.2.7"
+    semver "^7.6.0"
 
 "@ethereum-waffle/chai@4.0.10":
   version "4.0.10"
@@ -13073,6 +13074,13 @@ semver@^7.0.0, semver@^7.1.2, semver@^7.3.4, semver@^7.3.5, semver@^7.5.3, semve
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.6.0:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
+  integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
This PR bumps the `@eth-optimism/sdk-v2` so that our CircleCI build works every time.

--
Reasoning: we want to have this PR added to our codebase (https://github.com/ethereum-optimism/optimism/pull/9805)

Currently, the CircleCI occasionally fails due to an issue with the `@eth-optimism/sdk` pre-install scripts. By upgrading the optimism package to include the PR listed above, the hope is that we can mitigate these occasional failed builds.

I have been working closely with @evaldofelipe to diagnose/triage this issue.