### PR TITLE
improve(utils): Support chunking fillStatusArray queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.22.16",
+  "version": "0.22.17",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/utils/ArrayUtils.ts
+++ b/src/utils/ArrayUtils.ts
@@ -9,6 +9,22 @@ export function dedupArray<T>(array: T[]): T[] {
 }
 
 /**
+ * Splits an arbitrary array into a series of chunks.
+ * @param array The array to chunk.
+ * @param chunkSize The maximum size of any chunk within the array.
+ * @returns A new array of chunked members.
+ */
+export function chunk<T>(array: T[], chunkSize: number): T[][] {
+  const chunks: T[][] = [];
+
+  for (let i = 0; i < array.length; i += chunkSize) {
+    chunks.push(array.slice(i, i + chunkSize));
+  }
+
+  return chunks;
+}
+
+/**
  * Returns the last index of an array that matches the given predicate.
  * @note Emulates Array.prototype.findLastIndex
  * @param array The array to search.

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -337,9 +337,11 @@ export async function fillStatusArray(
   const multicalls = await Promise.all(
     chunkedQueries.map((queries) => spokePool.callStatic.multicall(queries, { blockTag }))
   );
-  const status = multicalls.map((multicall: BytesLike[]) =>
-    multicall.map((result) => spokePool.interface.decodeFunctionResult(fillStatuses, result)[0])
-  ).flat();
+  const status = multicalls
+    .map((multicall: BytesLike[]) =>
+      multicall.map((result) => spokePool.interface.decodeFunctionResult(fillStatuses, result)[0])
+    )
+    .flat();
 
   const bnUnfilled = toBN(FillStatus.Unfilled);
   const bnFilled = toBN(FillStatus.Filled);

--- a/src/utils/SpokeUtils.ts
+++ b/src/utils/SpokeUtils.ts
@@ -3,6 +3,7 @@ import { BigNumber, BytesLike, Contract, PopulatedTransaction, providers, utils 
 import { CHAIN_IDs, ZERO_ADDRESS } from "../constants";
 import { FillStatus, RelayData, SlowFillRequest, V2RelayData, V3Deposit, V3Fill, V3RelayData } from "../interfaces";
 import { SpokePoolClient } from "../clients";
+import { chunk } from "./ArrayUtils";
 import { toBN } from "./BigNumberUtils";
 import { isDefined } from "./TypeGuards";
 import { isV2RelayData } from "./V3Utils";
@@ -323,14 +324,22 @@ export async function fillStatusArray(
 ): Promise<(FillStatus | undefined)[]> {
   const fillStatuses = "fillStatuses";
   const destinationChainId = await spokePool.chainId();
+
   const queries = relayData.map((relayData) => {
     const hash = getV3RelayHash(relayData, destinationChainId);
     return spokePool.interface.encodeFunctionData(fillStatuses, [hash]);
   });
-  const multicall = await spokePool.callStatic.multicall(queries, { blockTag });
-  const status = multicall.map(
-    (result: BytesLike) => spokePool.interface.decodeFunctionResult(fillStatuses, result)[0]
+
+  // Chunk the hashes into appropriate sizes to avoid death by rpc.
+  const chunkSize = 250;
+  const chunkedQueries = chunk(queries, chunkSize);
+
+  const multicalls = await Promise.all(
+    chunkedQueries.map((queries) => spokePool.callStatic.multicall(queries, { blockTag }))
   );
+  const status = multicalls.map((multicall: BytesLike[]) =>
+    multicall.map((result) => spokePool.interface.decodeFunctionResult(fillStatuses, result)[0])
+  ).flat();
 
   const bnUnfilled = toBN(FillStatus.Unfilled);
   const bnFilled = toBN(FillStatus.Filled);

--- a/test/ArrayUtils.ts
+++ b/test/ArrayUtils.ts
@@ -1,0 +1,16 @@
+import { chunk } from "../src/utils/ArrayUtils";
+import { expect } from "./utils";
+
+describe("ArrayUtils", () => {
+  describe("chunk", () => {
+    it("Applies the requested chunk size", () => {
+      const chunkSize = 10;
+      const array = Array.from({ length: 999 }, (_, idx) => idx);
+
+      const chunkedArray = chunk(array, chunkSize);
+      expect(chunkedArray.length).to.equal(Math.ceil(array.length / chunkSize));
+      expect(chunkedArray.at(-1)?.length).to.equal(9);
+    });
+  });
+
+});

--- a/test/ArrayUtils.ts
+++ b/test/ArrayUtils.ts
@@ -12,5 +12,4 @@ describe("ArrayUtils", () => {
       expect(chunkedArray.at(-1)?.length).to.equal(9);
     });
   });
-
 });


### PR DESCRIPTION
This allows the caller to be ignorant of the number of fill status requests they are sending.