### PR TITLE
improve(arweave): include app version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.22.19",
+  "version": "0.22.20",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/caching/Arweave/ArweaveClient.ts
+++ b/src/caching/Arweave/ArweaveClient.ts
@@ -4,7 +4,7 @@ import { ethers } from "ethers";
 import winston from "winston";
 import { isDefined, jsonReplacerWithBigNumbers, parseWinston, toBN } from "../../utils";
 import { Struct, is } from "superstruct";
-import { ARWEAVE_TAG_APP_NAME } from "../../constants";
+import { ARWEAVE_TAG_APP_NAME, ARWEAVE_TAG_APP_VERSION } from "../../constants";
 
 export class ArweaveClient {
   private client: Arweave;
@@ -48,6 +48,7 @@ export class ArweaveClient {
     // Add tags to the transaction
     transaction.addTag("Content-Type", "application/json");
     transaction.addTag("App-Name", ARWEAVE_TAG_APP_NAME);
+    transaction.addTag("App-Version", ARWEAVE_TAG_APP_VERSION.toString());
     if (isDefined(topicTag)) {
       transaction.addTag("Topic", topicTag);
     }
@@ -137,6 +138,7 @@ export class ArweaveClient {
             tags: [
               { name: "App-Name", values: ["${ARWEAVE_TAG_APP_NAME}"] },
               { name: "Content-Type", values: ["application/json"] },
+              { name: "App-Version", values: ["${ARWEAVE_TAG_APP_VERSION}"] },
               ${tag ? `{ name: "Topic", values: ["${tag}"] } ` : ""}
             ]
           ) { edges { node { id } } } 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,6 +20,9 @@ export const TRANSFER_THRESHOLD_MAX_CONFIG_STORE_VERSION = 1;
 // A hardcoded identifier used, by default, to tag all Arweave records.
 export const ARWEAVE_TAG_APP_NAME = "across-protocol";
 
+// A hardcoded version number used, by default, to tag all Arweave records.
+export const ARWEAVE_TAG_APP_VERSION = 1;
+
 /**
  * A default list of chain Ids that the protocol supports. This is outlined
  * in the UMIP (https://github.com/UMAprotocol/UMIPs/pull/590) and is used


### PR DESCRIPTION
We should be tagging Arweave by version in addition to other attributes. This change introduces a tag version & a graphql filter to the `getByTopic` function.