### PR TITLE
fix(relay-execution-info): patch parsing of nested type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.22.20",
+  "version": "0.22.21",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -18,6 +18,7 @@ import {
   isV3Deposit,
   isV3SpeedUp,
   toBN,
+  isV3Fill,
 } from "../utils";
 import {
   paginatedEventQuery,
@@ -835,6 +836,15 @@ export class SpokePoolClient extends BaseAbstractClient {
           ? { ...(spreadEventWithBlockNumber(event) as V3FillWithBlock), destinationChainId: this.chainId }
           : { ...(spreadEventWithBlockNumber(event) as V2FillWithBlock) };
 
+        if (isV3Fill(fill) && Array.isArray(fill.relayExecutionInfo)) {
+          const correctedRelayExecutionInfo = {
+            updatedRecipient: fill.relayExecutionInfo[0],
+            updatedMessage: fill.relayExecutionInfo[1],
+            updatedOutputAmount: fill.relayExecutionInfo[2],
+            fillType: fill.relayExecutionInfo[3],
+          };
+          fill.relayExecutionInfo = correctedRelayExecutionInfo;
+        }
         assign(this.fills, [fill.originChainId], [fill]);
         assign(this.depositHashesToFills, [this.getDepositHash(fill)], [fill]);
       }


### PR DESCRIPTION
The `relayExecutionInfo` is not being parsed properly when a fill message is non-empty. The discrepancy was detected in [this arweave bundle](https://m5gtkkyrzrvyyd6ec554mbwiplhapbwt2jrmaqs33dycjd3puj2q.arweave.net/Z001KxHMa4wPxBd7xgbIes4HhtPSYsBCW9jwJI9vonU).

This patch performs a secondary check on `relayExecutionInfo` to manually update the event into a more stable version. A more comprehensive fix will follow.