### PR TITLE
hotfix(spreadEvent): fix recurrence step

### DIFF
--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -22,7 +22,7 @@ export function spreadEvent(args: Result = {} as Result): any {
       case "object":
         if (Array.isArray(args[key])) {
           returnedObject[key] =
-            Object.keys(args[key].filter((key: string) => isNaN(+key))).length > 0
+            Object.keys(args[key]).filter((key: string) => isNaN(+key)).length > 0
               ? spreadEvent(args[key]) // Record/array hybrid...
               : args[key]; // Just an array
         } else {

--- a/test/relayFeeCalculator.test.ts
+++ b/test/relayFeeCalculator.test.ts
@@ -464,7 +464,7 @@ describe("RelayFeeCalculator: Composable Bridging", function () {
       ...spreadFill.relayExecutionInfo,
       updatedOutputAmount: spreadFill.relayExecutionInfo.updatedOutputAmount.toString(),
     }).to.deep.eq({
-      updatedRecipient: "0x3Aa5ebB10DC797CAC828524e59A333d0A371443c",
+      updatedRecipient: testContract.address,
       updatedMessage: "0xabcdef",
       updatedOutputAmount: "1",
       fillType: 0,


### PR DESCRIPTION
There is a bug in the spreadEvent function right before the recurrence. Previously, we were getting the keys of 
```
args[key].filter((key: string) => isNaN(+key)
```
which would first filter the array of non-numeric keys. Whereas we should have gotten the keys of `args[key]` and filtered on the keys.