### PR TITLE
improve(BlockUtils): Preset Linea block time to 3 seconds

### DIFF
--- a/src/utils/BlockUtils.ts
+++ b/src/utils/BlockUtils.ts
@@ -37,6 +37,7 @@ const blockTimes: { [chainId: number]: BlockTimeAverage } = {
   1: { average: 12.5, timestamp: now, blockRange: 1 },
   10: { average: 2, timestamp: now, blockRange: 1 },
   8453: { average: 2, timestamp: now, blockRange: 1 },
+  59144: { average: 3, timestamp: now, blockRange: 1 },
 };
 
 /**


### PR DESCRIPTION
This avoids getBlockNumber() and subsequent concurrent getBlockByNumber() queries to determine the average block time over the past 120 blocks, which is a prerequisite when setting SpokePoolClient search settings.