### PR TITLE
refactor(utils): Defer to constants-v2 for chain definitions

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,13 @@
 import * as acxConstants from "@across-protocol/constants-v2";
 import { constants as ethersConstants, BigNumber, utils } from "ethers";
-export { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "@across-protocol/constants-v2";
+
+export {
+  CHAIN_IDs,
+  MAINNET_CHAIN_IDs,
+  PUBLIC_NETWORKS,
+  TESTNET_CHAIN_IDs,
+  TOKEN_SYMBOLS_MAP,
+} from "@across-protocol/constants-v2";
 
 export const { AddressZero: ZERO_ADDRESS } = ethersConstants;
 
@@ -59,36 +66,6 @@ export const TESTNET_CHAIN_IDS = [
   acxConstants.TESTNET_CHAIN_IDs.OPTIMISM_SEPOLIA,
   acxConstants.TESTNET_CHAIN_IDs.LINEA_GOERLI,
 ];
-
-export const PUBLIC_NETWORKS: { [chainId: number]: { name: string; etherscan: string } } = {
-  1: {
-    name: "mainnet",
-    etherscan: "https://etherscan.io",
-  },
-  5: { name: "goerli", etherscan: "https://goerli.etherscan.io" },
-  10: { name: "optimism", etherscan: "https://optimistic.etherscan.io" },
-  137: {
-    name: "polygon-matic",
-    etherscan: "https://polygonscan.com",
-  },
-  324: { name: "zksync", etherscan: "https://explorer.zksync.io" },
-  8453: { name: "base", etherscan: "https://basescan.org" },
-  42161: { name: "arbitrum", etherscan: "https://arbiscan.io" },
-  43114: { name: "avalanche", etherscan: "https://snowtrace.io" },
-  59140: { name: "linea-goerli", etherscan: "https://goerli.lineascan.build" },
-  59144: { name: "linea", etherscan: "https://lineascan.build" },
-  80002: { name: "polygon-amoy", etherscan: "https://www.oklink.com/amoy" },
-  84531: { name: "base-goerli", etherscan: "https://basescan.org" },
-  84532: { name: "base-sepolia", etherscan: "https://sepolia.basescan.org" },
-  421613: { name: "arbitrum-goerli", etherscan: "https://goerli.arbiscan.io" },
-  421614: { name: "arbitrum-sepolia", etherscan: "https://sepolia.arbiscan.io" },
-  534351: { name: "scroll-sepolia", etherscan: "https://sepolia.scrollscan.com" },
-  534352: { name: "scroll", etherscan: "https://scrollscan.com" },
-  11155111: { name: "sepolia", etherscan: "https://sepolia.etherscan.io" },
-  11155420: { name: "optimism-sepolia", etherscan: "https://sepolia-optimistic.etherscan.io" },
-};
-
-export const DEFAULT_BLOCKCHAIN_EXPLORER_DOMAIN = "https://etherscan.io";
 
 export const DEFAULT_CACHING_TTL = 60 * 60 * 24 * 7 * 2; // 2 Weeks
 export const DEFAULT_CACHING_SAFE_LAG = 60 * 60; // 1 hour

--- a/src/utils/BlockExplorerUtils.ts
+++ b/src/utils/BlockExplorerUtils.ts
@@ -16,10 +16,10 @@ export function blockExplorerLink(txHashOrAddress: string, chainId: number | str
 /**
  * Resolves a domain to an block explorer link for a given network.
  * @param networkId The network to link to.
- * @returns The block explorer link. If the networkId is not supported, the default block explorer mainnet link will be returned.
+ * @returns The block explorer link. If the networkId is not supported, undefined will be returned.
  */
 export function resolveBlockExplorerDomain(networkId: number): string | undefined {
-  return PUBLIC_NETWORKS[networkId]?.etherscan;
+  return PUBLIC_NETWORKS[networkId]?.blockExplorer;
 }
 
 /**

--- a/src/utils/NetworkUtils.ts
+++ b/src/utils/NetworkUtils.ts
@@ -1,5 +1,10 @@
 import { CHAIN_IDs, PRODUCTION_CHAIN_IDS, PUBLIC_NETWORKS, TESTNET_CHAIN_IDS } from "../constants";
 
+const hreNetworks: Record<number, string> = {
+  666: "Hardhat1",
+  1337: "Hardhat2",
+};
+
 /**
  * Resolves a network name from a network id.
  * @param networkId The network id to resolve the name for
@@ -7,17 +12,7 @@ import { CHAIN_IDs, PRODUCTION_CHAIN_IDS, PUBLIC_NETWORKS, TESTNET_CHAIN_IDS } f
  */
 export function getNetworkName(networkId: number | string): string {
   networkId = Number(networkId);
-  try {
-    const networkName = PUBLIC_NETWORKS[networkId].name;
-    return networkName.charAt(0).toUpperCase() + networkName.slice(1);
-  } catch (error) {
-    // Fallback network ID names.
-    const networkIdMap: Record<number, string> = {
-      666: "Hardhat1",
-      1337: "Hardhat2",
-    };
-    return networkIdMap[networkId] ?? "unknown";
-  }
+  return PUBLIC_NETWORKS[networkId]?.name ?? hreNetworks[networkId] ?? "unknown";
 }
 
 /**

--- a/src/utils/NetworkUtils.ts
+++ b/src/utils/NetworkUtils.ts
@@ -1,25 +1,4 @@
-import { PublicNetworks } from "@uma/common/dist/PublicNetworks";
-import { CHAIN_IDs, PRODUCTION_CHAIN_IDS, TESTNET_CHAIN_IDS } from "../constants";
-
-/**
- * A list of networks that provide more resolution about a chainid -> network name
- */
-const networkIdMap: Record<number, string> = {
-  666: "Hardhat1",
-  1337: "Hardhat2",
-  421613: "ArbitrumGoerli",
-  421614: "ArbitrumSepolia",
-  324: "ZkSync",
-  280: "ZkSync-Goerli",
-  300: "ZKSync-Sepolia",
-  8453: "Base",
-  84531: "BaseGoerli",
-  84532: "BaseSepolia",
-  59144: "Linea",
-  59140: "LineaGoerli",
-  11155111: "EthSepolia",
-  11155420: "OptimismSepolia",
-};
+import { CHAIN_IDs, PRODUCTION_CHAIN_IDS, PUBLIC_NETWORKS, TESTNET_CHAIN_IDS } from "../constants";
 
 /**
  * Resolves a network name from a network id.
@@ -27,13 +6,17 @@ const networkIdMap: Record<number, string> = {
  * @returns The network name for the network id. If the network id is not found, returns "unknown"
  */
 export function getNetworkName(networkId: number | string): string {
+  networkId = Number(networkId);
   try {
-    const networkName = PublicNetworks[Number(networkId)].name;
+    const networkName = PUBLIC_NETWORKS[networkId].name;
     return networkName.charAt(0).toUpperCase() + networkName.slice(1);
   } catch (error) {
-    // Convert networkId to a number in case it's a string, then lookup in the map
-    // Return "unknown" if the networkId does not exist in the map
-    return networkIdMap[Number(networkId)] || "unknown";
+    // Fallback network ID names.
+    const networkIdMap: Record<number, string> = {
+      666: "Hardhat1",
+      1337: "Hardhat2",
+    };
+    return networkIdMap[networkId] ?? "unknown";
   }
 }
 
@@ -43,10 +26,7 @@ export function getNetworkName(networkId: number | string): string {
  * @returns The native token symbol for the chain id. If the chain id is not found, returns "ETH"
  */
 export function getNativeTokenSymbol(chainId: number | string): string {
-  if (chainId.toString() === "137" || chainId.toString() === "80001") {
-    return "MATIC";
-  }
-  return "ETH";
+  return PUBLIC_NETWORKS[Number(chainId)]?.nativeToken ?? "ETH";
 }
 
 /**


### PR DESCRIPTION
This centalises our chain definitions and eliminates an annoying import workaround that was previously needed for PUBLIC_NETWORKS to be used in the FE.