### PR TITLE
improve: arweave structure version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.23.3",
+  "version": "0.23.4",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,7 +28,7 @@ export const TRANSFER_THRESHOLD_MAX_CONFIG_STORE_VERSION = 1;
 export const ARWEAVE_TAG_APP_NAME = "across-protocol";
 
 // A hardcoded version number used, by default, to tag all Arweave records.
-export const ARWEAVE_TAG_APP_VERSION = 1;
+export const ARWEAVE_TAG_APP_VERSION = 2;
 
 /**
  * A default list of chain Ids that the protocol supports. This is outlined


### PR DESCRIPTION
We had a change to our deposit that will break previous bundle data.