### PR TITLE
fix(SpokePoolClient): Import assert

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -1,3 +1,4 @@
+import assert from "assert";
 import { BigNumber, Contract, Event, EventFilter } from "ethers";
 import winston from "winston";
 import { isError, isEthersError } from "../typeguards";


### PR DESCRIPTION
Not sure how this was previously able to pass any tests. Perhaps because no caller currently specifies the timeout, so the assert() is never called.