### PR TITLE
fix: Revert SpokePoolClient update timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk-v2",
   "author": "UMA Team",
-  "version": "0.23.3",
+  "version": "0.23.4",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [


### PR DESCRIPTION
Due to unintentional collateral damage in the relayer tests, which I had incorrectly attributed to a `yarn link` issue.