### PR TITLE
chore(clients): Export SpokePoolUpdate type

### DIFF
--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -5,5 +5,5 @@ export {
   ConfigStoreUpdate,
 } from "./AcrossConfigStoreClient";
 export { HubPoolClient, LpFeeRequest } from "./HubPoolClient";
-export { SpokePoolClient } from "./SpokePoolClient";
+export { SpokePoolClient, SpokePoolUpdate } from "./SpokePoolClient";
 export * as mocks from "./mocks";


### PR DESCRIPTION
This is needed in relayer-v2 where the SpokePoolClient will be overridden.