### PR TITLE
fix: add polling interval to outer provider

### DIFF
--- a/src/providers/retryProvider.ts
+++ b/src/providers/retryProvider.ts
@@ -53,6 +53,8 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
       });
     });
 
+    this.pollingInterval = 1000;
+
     if (this.nodeQuorumThreshold < 1 || !Number.isInteger(this.nodeQuorumThreshold)) {
       throw new Error(
         `nodeQuorum,Threshold cannot be < 1 and must be an integer. Currently set to ${this.nodeQuorumThreshold}`


### PR DESCRIPTION
We realized that the polling for transactions is managed by the outer provider rather than the inner one. So this adds the 1s poll frequency to the outer provider.

A faster poll frequency is probably still ideal in the inner ones to keep track of other information used internally (like block number) that changes quickly on L2s.