### PR TITLE
chore: Bump Node version to 20.19.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 20.19.2
       - run: yarn install
       - run: yarn build
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 20.19.2
       - run: yarn install
       - run: yarn lint-check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v3
         with:
-          node-version: "20.x"
+          node-version: "20.19.2"
           always-auth: true
           registry-url: "https://registry.npmjs.org"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
           solana_version: ${{ steps.extract-versions.outputs.solana_version }}
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 20.19.2
       - run: yarn install
       - run: yarn test
         env:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "src"
   ],
   "engines": {
-    "node": ">=20.18.0"
+    "node": ">=20.19.2"
   },
   "scripts": {
     "build-bigint-buffer": "node scripts/build-bigint-buffer.js",


### PR DESCRIPTION
Bump Node version so it is the same as in relayer repo