### PR TITLE
Update publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # Note we set an `id` called `release`. We'll use that later...
       - name: Validate and extract release information
@@ -29,7 +29,7 @@ jobs:
       - run: yarn
 
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "20.19.2"
           always-auth: true


### PR DESCRIPTION
 - Updated actions/setup-node from @V3 to @v4
This is the only file in the repository that was still using the old version (v3). Updating it ensures consistency and up-to-date security across all workflows.
https://github.com/actions/setup-node/releases/tag/v4.4.0

  - Updates all instances to actions/checkout@v4
This is the last file requiring this update, all other files have been updated
Reference:
Latest version confirmation: https://github.com/actions/checkout/releases/tag/v4.2.2