### PR TITLE
chore: Temporarily revert "Handle disabled pool rebalance routes (#11…

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "bump-version:minor": "yarn version --minor --no-git-tag-version --no-commit-hooks && git commit -m 'chore: bump version' ./package.json --no-verify",
     "bump-version:patch": "yarn version --patch --no-git-tag-version --no-commit-hooks && git commit -m 'chore: bump version' ./package.json --no-verify",
     "typechain": "typechain --target ethers-v5 --out-dir src/utils/abi/typechain 'src/utils/abi/contracts/*.json' && eslint --fix src/utils/abi/typechain && yarn prettier --write \"src/utils/abi/typechain/**/*.ts\"",
-    "yalc:watch": "nodemon --watch src --ext ts,tsx,json,js,jsx --ignore src/utils/abi/ --exec 'yalc publish --push --changed'"
+    "yalc:watch": "nodemon --watch src --ext ts,tsx,json,js,jsx --exec 'yalc push'"
   },
   "lint-staged": {
     "*.ts": "yarn lint"

--- a/src/clients/BundleDataClient/utils/FillUtils.ts
+++ b/src/clients/BundleDataClient/utils/FillUtils.ts
@@ -37,21 +37,18 @@ export function getRefundInformationFromFill(
 
   // Now figure out the equivalent L2 token for the repayment token. If the inputToken doesn't have a
   // PoolRebalanceRoute, then the repayment chain would have been the originChainId after the getRepaymentChainId()
-  // call and we would have returned already, so the following call should always return a valid L1 token.
+  // call and we would have returned already, so the following call should always succeed.
   const l1TokenCounterpart = hubPoolClient.getL1TokenForL2TokenAtBlock(
     relayData.inputToken,
     relayData.originChainId,
     bundleEndBlockForMainnet
   );
 
-  assert(isDefined(l1TokenCounterpart), "getRefundInformationFromFill: l1TokenCounterpart is undefined");
-
   const repaymentToken = hubPoolClient.getL2TokenForL1TokenAtBlock(
     l1TokenCounterpart,
     chainToSendRefundTo,
     bundleEndBlockForMainnet
   );
-  assert(isDefined(repaymentToken), "getRefundInformationFromFill: repaymentToken is undefined");
 
   return {
     chainToSendRefundTo,
@@ -186,9 +183,6 @@ function _repaymentChainTokenIsValid(
     relayData.originChainId,
     bundleEndBlockForMainnet
   );
-  if (!l1TokenCounterpart) {
-    return false;
-  }
   if (
     !hubPoolClient.l2TokenEnabledForL1TokenAtBlock(
       l1TokenCounterpart,

--- a/src/clients/BundleDataClient/utils/PoolRebalanceUtils.ts
+++ b/src/clients/BundleDataClient/utils/PoolRebalanceUtils.ts
@@ -202,8 +202,6 @@ export function updateRunningBalanceForDeposit(
     deposit.originChainId,
     mainnetBundleEndBlock
   );
-  assert(isDefined(l1TokenCounterpart), "updateRunningBalanceForDeposit: l1TokenCounterpart is undefined");
-
   updateRunningBalance(runningBalances, deposit.originChainId, l1TokenCounterpart.toEvmAddress(), updateAmount);
 }
 

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -34,6 +34,7 @@ import {
   fetchTokenInfo,
   getCachedBlockForTimestamp,
   getCurrentTime,
+  getNetworkName,
   isDefined,
   mapAsync,
   paginatedEventQuery,
@@ -74,11 +75,17 @@ type HubPoolEvent =
   | "RootBundleExecuted"
   | "CrossChainContractsSet";
 
+type L1TokensToDestinationTokens = {
+  [l1Token: string]: { [destinationChainId: number]: Address };
+};
+
 export type LpFeeRequest = Pick<Deposit, "originChainId" | "inputToken" | "inputAmount" | "quoteTimestamp"> & {
   paymentChainId?: number;
 };
 
 export class HubPoolClient extends BaseAbstractClient {
+  // L1Token -> destinationChainId -> destinationToken
+  protected l1TokensToDestinationTokens: L1TokensToDestinationTokens = {};
   protected l1Tokens: L1TokenInfo[] = []; // L1Tokens and their associated info.
   // @dev `token` here is a 20-byte hex sting
   protected lpTokens: { [token: string]: LpToken } = {};
@@ -185,16 +192,24 @@ export class HubPoolClient extends BaseAbstractClient {
     l1Token: EvmAddress,
     destinationChainId: number,
     latestHubBlock = Number.MAX_SAFE_INTEGER
-  ): Address | undefined {
+  ): Address {
     if (!this.l1TokensToDestinationTokensWithBlock?.[l1Token.toEvmAddress()]?.[destinationChainId]) {
-      return undefined;
+      const chain = getNetworkName(destinationChainId);
+      const { symbol } = this.l1Tokens.find(({ address }) => address.eq(l1Token)) ?? { symbol: l1Token.toString() };
+      throw new Error(`Could not find SpokePool mapping for ${symbol} on ${chain} and L1 token ${l1Token}`);
     }
     // Find the last mapping published before the target block.
-    const l2Token: DestinationTokenWithBlock | undefined = this.l1TokensToDestinationTokensWithBlock[
-      l1Token.toEvmAddress()
-    ][destinationChainId].find((mapping: DestinationTokenWithBlock) => mapping.blockNumber <= latestHubBlock);
-
-    return !l2Token || l2Token.l2Token.isZeroAddress() ? undefined : l2Token.l2Token;
+    const l2Token: DestinationTokenWithBlock | undefined = sortEventsDescending(
+      this.l1TokensToDestinationTokensWithBlock[l1Token.toEvmAddress()][destinationChainId]
+    ).find((mapping: DestinationTokenWithBlock) => mapping.blockNumber <= latestHubBlock);
+    if (!l2Token) {
+      const chain = getNetworkName(destinationChainId);
+      const { symbol } = this.l1Tokens.find(({ address }) => address.eq(l1Token)) ?? { symbol: l1Token.toString() };
+      throw new Error(
+        `Could not find SpokePool mapping for ${symbol} on ${chain} at or before HubPool block ${latestHubBlock}!`
+      );
+    }
+    return l2Token.l2Token;
   }
 
   // Returns the latest L1 token to use for an L2 token as of the input hub block.
@@ -202,27 +217,32 @@ export class HubPoolClient extends BaseAbstractClient {
     l2Token: Address,
     destinationChainId: number,
     latestHubBlock = Number.MAX_SAFE_INTEGER
-  ): EvmAddress | undefined {
-    const l2Tokens = Object.keys(this.l1TokensToDestinationTokensWithBlock).flatMap((l1Token) => {
-      // Get the latest L2 token mapping for the given L1 token.
-      // @dev Since tokens on L2s (like Solana) can have 32 byte addresses, filter on the lower 20 bytes of the token only.
-      const sortedL2Tokens = sortEventsDescending(
-        (this.l1TokensToDestinationTokensWithBlock[l1Token][destinationChainId] ?? []).filter(
-          (dstTokenWithBlock) => dstTokenWithBlock.blockNumber <= latestHubBlock
-        )
+  ): EvmAddress {
+    const l2Tokens = Object.keys(this.l1TokensToDestinationTokensWithBlock)
+      .filter((l1Token) => this.l2TokenEnabledForL1Token(EvmAddress.from(l1Token), destinationChainId))
+      .map((l1Token) => {
+        // Return all matching L2 token mappings that are equal to or earlier than the target block.
+        // @dev Since tokens on L2s (like Solana) can have 32 byte addresses, filter on the lower 20 bytes of the token only.
+        return this.l1TokensToDestinationTokensWithBlock[l1Token][destinationChainId].filter(
+          (dstTokenWithBlock) =>
+            dstTokenWithBlock.l2Token.truncateToBytes20() === l2Token.truncateToBytes20() &&
+            dstTokenWithBlock.blockNumber <= latestHubBlock
+        );
+      })
+      .flat();
+    if (l2Tokens.length === 0) {
+      const chain = getNetworkName(destinationChainId);
+      throw new Error(
+        `Could not find HubPool mapping for ${l2Token} on ${chain} at or before HubPool block ${latestHubBlock}!`
       );
-      // If the latest L2 token mapping is equal to the target L2 token, return it.
-      return sortedL2Tokens.length > 0 && sortedL2Tokens[0].l2Token.truncateToBytes20() === l2Token.truncateToBytes20()
-        ? sortedL2Tokens[0]
-        : [];
-    });
-
-    return l2Tokens.length === 0 ? undefined : sortEventsDescending(l2Tokens)[0].l1Token;
+    }
+    // Find the last mapping published before the target block.
+    return sortEventsDescending(l2Tokens)[0].l1Token;
   }
 
   protected getL1TokenForDeposit(
     deposit: Pick<DepositWithBlock, "originChainId" | "inputToken" | "quoteBlockNumber">
-  ): EvmAddress | undefined {
+  ): EvmAddress {
     // L1-->L2 token mappings are set via PoolRebalanceRoutes which occur on mainnet,
     // so we use the latest token mapping. This way if a very old deposit is filled, the relayer can use the
     // latest L2 token mapping to find the L1 token counterpart.
@@ -230,7 +250,7 @@ export class HubPoolClient extends BaseAbstractClient {
   }
 
   l2TokenEnabledForL1Token(l1Token: EvmAddress, destinationChainId: number): boolean {
-    return this.l2TokenEnabledForL1TokenAtBlock(l1Token, destinationChainId, Number.MAX_SAFE_INTEGER);
+    return this.l1TokensToDestinationTokens?.[l1Token.toEvmAddress()]?.[destinationChainId] != undefined;
   }
 
   l2TokenEnabledForL1TokenAtBlock(l1Token: EvmAddress, destinationChainId: number, hubBlockNumber: number): boolean {
@@ -238,12 +258,21 @@ export class HubPoolClient extends BaseAbstractClient {
     const l2Token: DestinationTokenWithBlock | undefined = sortEventsDescending(
       this.l1TokensToDestinationTokensWithBlock?.[l1Token.toEvmAddress()]?.[destinationChainId] ?? []
     ).find((mapping: DestinationTokenWithBlock) => mapping.blockNumber <= hubBlockNumber);
-    return l2Token !== undefined && !l2Token.l2Token.isZeroAddress();
+    return l2Token !== undefined;
   }
 
   l2TokenHasPoolRebalanceRoute(l2Token: Address, l2ChainId: number, hubPoolBlock = this.latestHeightSearched): boolean {
-    const l1Token = this.getL1TokenForL2TokenAtBlock(l2Token, l2ChainId, hubPoolBlock);
-    return l1Token !== undefined;
+    return Object.values(this.l1TokensToDestinationTokensWithBlock).some((destinationTokenMapping) => {
+      return Object.entries(destinationTokenMapping).some(([_l2ChainId, setPoolRebalanceRouteEvents]) => {
+        return setPoolRebalanceRouteEvents.some((e) => {
+          return (
+            e.blockNumber <= hubPoolBlock &&
+            e.l2Token.truncateToBytes20() === l2Token.truncateToBytes20() &&
+            Number(_l2ChainId) === l2ChainId
+          );
+        });
+      });
+    });
   }
 
   /**
@@ -378,11 +407,9 @@ export class HubPoolClient extends BaseAbstractClient {
     const hubPoolTokens: { [k: string]: EvmAddress } = {};
     const getHubPoolToken = (deposit: LpFeeRequest, quoteBlockNumber: number): EvmAddress | undefined => {
       const tokenKey = `${deposit.originChainId}-${deposit.inputToken}`;
-      const l1Token = this.getL1TokenForDeposit({ ...deposit, quoteBlockNumber });
-      if (!l1Token) {
-        return undefined;
-      }
-      return (hubPoolTokens[tokenKey] ??= l1Token);
+      if (this.l2TokenHasPoolRebalanceRoute(deposit.inputToken, deposit.originChainId, quoteBlockNumber)) {
+        return (hubPoolTokens[tokenKey] ??= this.getL1TokenForDeposit({ ...deposit, quoteBlockNumber }));
+      } else return undefined;
     };
     const getHubPoolTokens = (): EvmAddress[] => dedupArray(Object.values(hubPoolTokens).filter(isDefined));
 
@@ -521,14 +548,14 @@ export class HubPoolClient extends BaseAbstractClient {
     // Resolve both SpokePool tokens back to their respective HubPool tokens and verify that they match.
     const l1TokenA = this.getL1TokenForL2TokenAtBlock(tokenA, chainIdA, hubPoolBlock);
     const l1TokenB = this.getL1TokenForL2TokenAtBlock(tokenB, chainIdB, hubPoolBlock);
-    if (!l1TokenA || !l1TokenB || !l1TokenA.eq(l1TokenB)) {
+    if (!l1TokenA.eq(l1TokenB)) {
       return false;
     }
 
     // Resolve both HubPool tokens back to a current SpokePool token and verify that they match.
     const _tokenA = this.getL2TokenForL1TokenAtBlock(l1TokenA, chainIdA, hubPoolBlock);
     const _tokenB = this.getL2TokenForL1TokenAtBlock(l1TokenB, chainIdB, hubPoolBlock);
-    return _tokenA !== undefined && _tokenB !== undefined && tokenA.eq(_tokenA) && tokenB.eq(_tokenB);
+    return tokenA.eq(_tokenA) && tokenB.eq(_tokenB);
   }
 
   getSpokeActivationBlockForChain(chainId: number): number {
@@ -968,22 +995,24 @@ export class HubPoolClient extends BaseAbstractClient {
           destinationToken = svmUsdc;
         }
 
-        const newRoute: DestinationTokenWithBlock = {
-          l1Token: EvmAddress.from(args.l1Token),
-          l2Token: destinationToken,
-          blockNumber: args.blockNumber,
-          txnIndex: args.txnIndex,
-          logIndex: args.logIndex,
-          txnRef: args.txnRef,
-        };
-        if (this.l1TokensToDestinationTokensWithBlock[args.l1Token]?.[args.destinationChainId]) {
-          // Events are most likely coming in descending orders already but just in case we sort them again.
-          this.l1TokensToDestinationTokensWithBlock[args.l1Token][args.destinationChainId] = sortEventsDescending([
-            ...this.l1TokensToDestinationTokensWithBlock[args.l1Token][args.destinationChainId],
-            newRoute,
-          ]);
-        } else {
-          assign(this.l1TokensToDestinationTokensWithBlock, [args.l1Token, args.destinationChainId], [newRoute]);
+        // If the destination token is set to the zero address in an event, then this means Across should no longer
+        // rebalance to this chain.
+        if (!destinationToken.isZeroAddress()) {
+          assign(this.l1TokensToDestinationTokens, [args.l1Token, args.destinationChainId], destinationToken);
+          assign(
+            this.l1TokensToDestinationTokensWithBlock,
+            [args.l1Token, args.destinationChainId],
+            [
+              {
+                l1Token: EvmAddress.from(args.l1Token),
+                l2Token: destinationToken,
+                blockNumber: args.blockNumber,
+                txnIndex: args.txnIndex,
+                logIndex: args.logIndex,
+                txnRef: args.txnRef,
+              },
+            ]
+          );
         }
       }
     }

--- a/src/clients/SpokePoolClient/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SpokePoolClient.ts
@@ -472,22 +472,18 @@ export abstract class SpokePoolClient extends BaseAbstractClient {
       )
     ) {
       return false;
+    } else {
+      const l1Token = this.hubPoolClient?.getL1TokenForL2TokenAtBlock(
+        deposit.inputToken,
+        deposit.originChainId,
+        deposit.quoteBlockNumber
+      );
+      return this.hubPoolClient.l2TokenEnabledForL1TokenAtBlock(
+        l1Token,
+        deposit.destinationChainId,
+        deposit.quoteBlockNumber
+      );
     }
-
-    const l1Token = this.hubPoolClient?.getL1TokenForL2TokenAtBlock(
-      deposit.inputToken,
-      deposit.originChainId,
-      deposit.quoteBlockNumber
-    );
-    if (!l1Token) {
-      return false;
-    }
-
-    return this.hubPoolClient.l2TokenEnabledForL1TokenAtBlock(
-      l1Token,
-      deposit.destinationChainId,
-      deposit.quoteBlockNumber
-    );
   }
 
   /**

--- a/src/clients/mocks/MockHubPoolClient.ts
+++ b/src/clients/mocks/MockHubPoolClient.ts
@@ -118,9 +118,9 @@ export class MockHubPoolClient extends HubPoolClient {
     delete this.spokePoolTokens[l1Token]?.[chainId];
   }
 
-  getL1TokenForL2TokenAtBlock(l2Token: Address, chainId: number, blockNumber: number): EvmAddress | undefined {
+  getL1TokenForL2TokenAtBlock(l2Token: Address, chainId: number, blockNumber: number): EvmAddress {
     const l1Token = Object.keys(this.spokePoolTokens).find(
-      (l1Token) => this.spokePoolTokens[l1Token]?.[chainId]?.eq(l2Token)
+      (l1Token) => this.spokePoolTokens[l1Token]?.[chainId].eq(l2Token)
     );
     if (isDefined(l1Token)) {
       return EvmAddress.from(l1Token);
@@ -129,7 +129,7 @@ export class MockHubPoolClient extends HubPoolClient {
     }
   }
 
-  getL2TokenForL1TokenAtBlock(l1Token: EvmAddress, chainId: number, blockNumber: number): Address | undefined {
+  getL2TokenForL1TokenAtBlock(l1Token: EvmAddress, chainId: number, blockNumber: number): Address {
     const l2Token = this.spokePoolTokens[l1Token.toEvmAddress()]?.[chainId];
     return l2Token ?? super.getL2TokenForL1TokenAtBlock(l1Token, chainId, blockNumber);
   }

--- a/test/HubPoolClient.DepositToDestinationToken.ts
+++ b/test/HubPoolClient.DepositToDestinationToken.ts
@@ -19,11 +19,11 @@ import {
   ethers,
   expect,
   getContractFactory,
+  randomAddress,
   zeroAddress,
 } from "./utils";
-import { createRandomBytes32 } from "@across-protocol/contracts/dist/test-utils";
 import { getDeployedAddress } from "@across-protocol/contracts";
-import { EvmAddress, SvmAddress, toAddressType } from "../src/utils/AddressUtils";
+import { Address, EvmAddress, SvmAddress, toAddressType } from "../src/utils/AddressUtils";
 
 let hubPool: Contract, lpTokenFactory: Contract, mockAdapter: Contract;
 let owner: SignerWithAddress;
@@ -73,83 +73,93 @@ describe("HubPoolClient: Deposit to Destination Token", function () {
     const randomDestinationTokenAddr = toAddressType(randomDestinationToken, CHAIN_IDs.MAINNET);
     const randomDestinationToken2Addr = toAddressType(randomDestinationToken2, CHAIN_IDs.MAINNET);
 
-    let l2Token = hubPoolClient.getL2TokenForL1TokenAtBlock(randomL1TokenAddr, destinationChainId, 0);
-    expect(l2Token).to.be.undefined;
+    expect(() => hubPoolClient.getL2TokenForL1TokenAtBlock(randomL1TokenAddr, destinationChainId, 0)).to.throw(
+      /Could not find SpokePool mapping/
+    );
 
     const e1 = hubPoolClient.setPoolRebalanceRoute(destinationChainId, randomL1Token, randomDestinationToken);
     await hubPoolClient.update();
 
     // If input hub pool block is before all events, should throw.
-    l2Token = hubPoolClient.getL2TokenForL1TokenAtBlock(randomL1TokenAddr, destinationChainId, 0);
-    expect(l2Token).to.be.undefined;
-
-    l2Token = hubPoolClient.getL2TokenForL1TokenAtBlock(randomL1TokenAddr, destinationChainId, e1.blockNumber);
-    expect(l2Token?.toNative()).to.be.equal(randomDestinationTokenAddr.toNative());
+    expect(() => hubPoolClient.getL2TokenForL1TokenAtBlock(randomL1TokenAddr, destinationChainId, 0)).to.throw(
+      /Could not find SpokePool mapping/
+    );
+    expect(
+      hubPoolClient
+        .getL2TokenForL1TokenAtBlock(randomL1TokenAddr, destinationChainId, e1.blockNumber)
+        .eq(randomDestinationTokenAddr)
+    ).to.be.true;
 
     // Now try changing the destination token. Client should correctly handle this.
     const e2 = hubPoolClient.setPoolRebalanceRoute(destinationChainId, randomL1Token, randomDestinationToken2);
     await hubPoolClient.update();
 
-    l2Token = hubPoolClient.getL2TokenForL1TokenAtBlock(randomL1TokenAddr, destinationChainId, e2.blockNumber);
-    expect(l2Token?.toNative()).to.be.equal(randomDestinationToken2Addr.toNative());
-
-    l2Token = hubPoolClient.getL2TokenForL1TokenAtBlock(randomL1TokenAddr, destinationChainId, e1.blockNumber);
-    expect(l2Token?.toNative()).to.be.equal(randomDestinationTokenAddr.toNative());
+    expect(
+      hubPoolClient
+        .getL2TokenForL1TokenAtBlock(randomL1TokenAddr, destinationChainId, e2.blockNumber)
+        .eq(randomDestinationToken2Addr)
+    ).to.be.true;
+    expect(
+      hubPoolClient
+        .getL2TokenForL1TokenAtBlock(randomL1TokenAddr, destinationChainId, e1.blockNumber)
+        .eq(randomDestinationTokenAddr)
+    ).to.be.true;
   });
   it("Gets L1 token counterpart", async function () {
-    let l1Token = hubPoolClient.getL1TokenForL2TokenAtBlock(
-      EvmAddress.from(randomDestinationToken),
-      destinationChainId,
-      0
-    );
-    expect(l1Token).to.be.undefined;
-
+    expect(() =>
+      hubPoolClient.getL1TokenForL2TokenAtBlock(EvmAddress.from(randomDestinationToken), destinationChainId, 0)
+    ).to.throw(/Could not find HubPool mapping/);
     const e1 = hubPoolClient.setPoolRebalanceRoute(destinationChainId, randomL1Token, randomDestinationToken);
     await hubPoolClient.update();
 
     // If input hub pool block is before all events, should throw.
-    l1Token = hubPoolClient.getL1TokenForL2TokenAtBlock(EvmAddress.from(randomDestinationToken), destinationChainId, 0);
-    expect(l1Token).to.be.undefined;
-
-    l1Token = hubPoolClient.getL1TokenForL2TokenAtBlock(
-      EvmAddress.from(randomDestinationToken),
-      destinationChainId,
-      e1.blockNumber
-    );
-    expect(l1Token?.toNative()).to.be.equal(EvmAddress.from(randomL1Token).toNative());
+    expect(() =>
+      hubPoolClient.getL1TokenForL2TokenAtBlock(EvmAddress.from(randomDestinationToken), destinationChainId, 0)
+    ).to.throw(/Could not find HubPool mapping/);
+    expect(
+      hubPoolClient
+        .getL1TokenForL2TokenAtBlock(EvmAddress.from(randomDestinationToken), destinationChainId, e1.blockNumber)
+        .toNative()
+    ).to.equal(EvmAddress.from(randomL1Token).toNative());
 
     // Now try changing the L1 token while keeping destination chain and L2 token the same.
     const e2 = hubPoolClient.setPoolRebalanceRoute(destinationChainId, randomOriginToken, randomDestinationToken);
     await hubPoolClient.update();
 
-    l1Token = hubPoolClient.getL1TokenForL2TokenAtBlock(
-      toAddressType(randomDestinationToken, destinationChainId),
-      destinationChainId,
-      e2.blockNumber
-    );
-    expect(l1Token?.toNative()).to.be.equal(EvmAddress.from(randomOriginToken).toNative());
-
-    l1Token = hubPoolClient.getL1TokenForL2TokenAtBlock(
-      toAddressType(randomDestinationToken, destinationChainId),
-      destinationChainId,
-      e1.blockNumber
-    );
-    expect(l1Token?.toNative()).to.be.equal(EvmAddress.from(randomL1Token).toNative());
+    expect(
+      hubPoolClient
+        .getL1TokenForL2TokenAtBlock(
+          toAddressType(randomDestinationToken, destinationChainId),
+          destinationChainId,
+          e2.blockNumber
+        )
+        .eq(EvmAddress.from(randomOriginToken))
+    ).to.be.true;
+    expect(
+      hubPoolClient
+        .getL1TokenForL2TokenAtBlock(
+          toAddressType(randomDestinationToken, destinationChainId),
+          destinationChainId,
+          e1.blockNumber
+        )
+        .eq(EvmAddress.from(randomL1Token))
+    ).to.be.true;
 
     // If L2 token mapping doesn't exist, throw.
-    l1Token = hubPoolClient.getL1TokenForL2TokenAtBlock(
-      toAddressType(randomL1Token, destinationChainId),
-      destinationChainId,
-      e2.blockNumber
-    );
-    expect(l1Token).to.be.undefined;
-
-    l1Token = hubPoolClient.getL1TokenForL2TokenAtBlock(
-      toAddressType(randomDestinationToken, originChainId),
-      originChainId,
-      e2.blockNumber
-    );
-    expect(l1Token).to.be.undefined;
+    expect(() =>
+      hubPoolClient.getL1TokenForL2TokenAtBlock(
+        toAddressType(randomL1Token, destinationChainId),
+        destinationChainId,
+        e2.blockNumber
+      )
+    ).to.throw(/Could not find HubPool mapping/);
+    expect(() =>
+      hubPoolClient.getL1TokenForL2TokenAtBlock(
+        toAddressType(randomDestinationToken, originChainId),
+        originChainId,
+        e2.blockNumber
+      )
+    ).to.throw(/Could not find HubPool mapping/);
   });
   it("Gets L1 token for deposit", async function () {
     const depositData = {
@@ -160,25 +170,27 @@ describe("HubPoolClient: Deposit to Destination Token", function () {
     const e0 = hubPoolClient.setPoolRebalanceRoute(originChainId, randomL1Token, randomOriginToken);
     await hubPoolClient.update();
     expect(
-      hubPoolClient.getL1TokenForDeposit({ ...depositData, quoteBlockNumber: e0.blockNumber })?.toNative()
+      hubPoolClient.getL1TokenForDeposit({ ...depositData, quoteBlockNumber: e0.blockNumber }).toNative()
     ).to.equal(randomL1Token);
 
     // quote block too early
-    let l1Token = hubPoolClient.getL1TokenForDeposit({ ...depositData, quoteBlockNumber: 0 });
-    expect(l1Token).to.be.undefined;
+    expect(() => hubPoolClient.getL1TokenForDeposit({ ...depositData, quoteBlockNumber: 0 })).to.throw(
+      /Could not find HubPool mapping/
+    );
 
     // no deposit with matching origin token
-    l1Token = hubPoolClient.getL1TokenForDeposit({
-      ...depositData,
-      inputToken: EvmAddress.from(randomL1Token),
-      quoteBlockNumber: e0.blockNumber,
-    });
-    expect(l1Token).to.be.undefined;
+    expect(() =>
+      hubPoolClient.getL1TokenForDeposit({
+        ...depositData,
+        inputToken: EvmAddress.from(randomL1Token),
+        quoteBlockNumber: e0.blockNumber,
+      })
+    ).to.throw(/Could not find HubPool mapping/);
 
     const e1 = hubPoolClient.setPoolRebalanceRoute(originChainId, randomOriginToken, randomOriginToken);
     await hubPoolClient.update();
     expect(
-      hubPoolClient.getL1TokenForDeposit({ ...depositData, quoteBlockNumber: e1.blockNumber })?.toNative()
+      hubPoolClient.getL1TokenForDeposit({ ...depositData, quoteBlockNumber: e1.blockNumber }).toNative()
     ).to.equal(randomOriginToken);
   });
   it("Gets L2 token for deposit", async function () {
@@ -193,36 +205,37 @@ describe("HubPoolClient: Deposit to Destination Token", function () {
     expect(
       hubPoolClient
         .getL2TokenForDeposit({ ...depositData, destinationChainId, quoteBlockNumber: e1.blockNumber })
-        ?.toString()
+        .toString()
     ).to.equal(randomDestinationToken);
 
     // origin chain token is set but none for destination chain yet, as of e0.
-    let l2Token = hubPoolClient.getL2TokenForDeposit({
-      ...depositData,
-      destinationChainId,
-      quoteBlockNumber: e0.blockNumber,
-    });
-    expect(l2Token).to.be.undefined;
+    expect(() =>
+      hubPoolClient
+        .getL2TokenForDeposit({ ...depositData, destinationChainId, quoteBlockNumber: e0.blockNumber })
+        .toString()
+    ).to.throw(/Could not find SpokePool mapping/);
 
     // quote block too early
-    l2Token = hubPoolClient.getL2TokenForDeposit({ ...depositData, destinationChainId, quoteBlockNumber: 0 });
-    expect(l2Token).to.be.undefined;
+    expect(() =>
+      hubPoolClient.getL2TokenForDeposit({ ...depositData, destinationChainId, quoteBlockNumber: 0 })
+    ).to.throw(/Could not find HubPool mapping/);
 
     // No deposit with matching token.
-    l2Token = hubPoolClient.getL2TokenForDeposit({
-      ...depositData,
-      destinationChainId,
-      inputToken: EvmAddress.from(randomL1Token),
-      quoteBlockNumber: e0.blockNumber,
-    });
-    expect(l2Token).to.be.undefined;
+    expect(() =>
+      hubPoolClient.getL2TokenForDeposit({
+        ...depositData,
+        destinationChainId,
+        inputToken: EvmAddress.from(randomL1Token),
+        quoteBlockNumber: e0.blockNumber,
+      })
+    ).to.throw(/Could not find HubPool mapping/);
 
     const e2 = hubPoolClient.setPoolRebalanceRoute(destinationChainId, randomL1Token, randomL1Token);
     await hubPoolClient.update();
     expect(
       hubPoolClient
         .getL2TokenForDeposit({ ...depositData, destinationChainId, quoteBlockNumber: e2.blockNumber })
-        ?.toString()
+        .toString()
     ).to.equal(randomL1Token);
   });
 
@@ -340,64 +353,19 @@ describe("HubPoolClient: Deposit to Destination Token", function () {
 
     // Verify that the L2 token mapping is correctly expanded to full SVM address
     expect(
-      hubPoolClient.getL2TokenForL1TokenAtBlock(EvmAddress.from(randomL1Token), svmChain, e1.blockNumber)?.toBytes32()
+      hubPoolClient.getL2TokenForL1TokenAtBlock(EvmAddress.from(randomL1Token), svmChain, e1.blockNumber).toBytes32()
     ).to.equal(SvmAddress.from(usdcTokenSol).toBytes32());
 
     // Verify that the L1 token mapping is also correct
     expect(
-      hubPoolClient.getL1TokenForL2TokenAtBlock(SvmAddress.from(usdcTokenSol), svmChain, e1.blockNumber)?.toNative()
+      hubPoolClient.getL1TokenForL2TokenAtBlock(SvmAddress.from(usdcTokenSol), svmChain, e1.blockNumber).toNative()
     ).to.equal(EvmAddress.from(randomL1Token).toNative());
 
     // Test changing the route with a different SVM address - this will fail
     // because only USDC is supported as an L2 on SVM
-    const newSvmAddress = SvmAddress.from(createRandomBytes32()).truncateToBytes20();
-    hubPoolClient.setPoolRebalanceRoute(svmChain, randomL1Token, newSvmAddress);
+    const newSvmAddress = new Address(Buffer.from(randomAddress(), "hex")).toBase58();
+    const newTruncatedAddress = SvmAddress.from(newSvmAddress).toEvmAddress();
+    hubPoolClient.setPoolRebalanceRoute(svmChain, randomL1Token, newTruncatedAddress);
     await assertPromiseError(hubPoolClient.update(), "SVM USDC address mismatch for chain");
-  });
-
-  it("correctly disables a rebalancing route", async function () {
-    const randomL1TokenAddr = EvmAddress.from(randomL1Token);
-
-    const randomDestinationTokenAddr = toAddressType(randomDestinationToken, CHAIN_IDs.MAINNET);
-
-    const e0 = hubPoolClient.setPoolRebalanceRoute(destinationChainId, randomL1Token, randomDestinationToken);
-    await hubPoolClient.update();
-
-    let l2Token = hubPoolClient.getL2TokenForL1TokenAtBlock(randomL1TokenAddr, destinationChainId, e0.blockNumber);
-    expect(l2Token?.toNative()).to.be.equal(randomDestinationTokenAddr.toNative());
-    let l1Token = hubPoolClient.getL1TokenForL2TokenAtBlock(
-      randomDestinationTokenAddr,
-      destinationChainId,
-      e0.blockNumber
-    );
-    expect(l1Token?.toNative()).to.be.equal(randomL1Token);
-
-    const e1 = hubPoolClient.setPoolRebalanceRoute(destinationChainId, randomL1Token, zeroAddress);
-    await hubPoolClient.update();
-
-    l2Token = hubPoolClient.getL2TokenForL1TokenAtBlock(randomL1TokenAddr, destinationChainId, e0.blockNumber);
-    expect(l2Token?.toNative()).to.be.equal(randomDestinationTokenAddr.toNative());
-    l1Token = hubPoolClient.getL1TokenForL2TokenAtBlock(randomDestinationTokenAddr, destinationChainId, e0.blockNumber);
-    expect(l1Token?.toNative()).to.be.equal(randomL1Token);
-
-    l2Token = hubPoolClient.getL2TokenForL1TokenAtBlock(randomL1TokenAddr, destinationChainId, e1.blockNumber);
-    expect(l2Token).to.be.undefined;
-    l1Token = hubPoolClient.getL1TokenForL2TokenAtBlock(randomDestinationTokenAddr, destinationChainId, e1.blockNumber);
-    expect(l1Token).to.be.undefined;
-
-    // setting a new route should override the disabled route
-    const e2 = hubPoolClient.setPoolRebalanceRoute(destinationChainId, randomL1Token, randomDestinationToken);
-    await hubPoolClient.update();
-
-    l2Token = hubPoolClient.getL2TokenForL1TokenAtBlock(randomL1TokenAddr, destinationChainId, e2.blockNumber);
-    expect(l2Token?.toNative()).to.be.equal(randomDestinationTokenAddr.toNative());
-    l1Token = hubPoolClient.getL1TokenForL2TokenAtBlock(randomDestinationTokenAddr, destinationChainId, e2.blockNumber);
-    expect(l1Token?.toNative()).to.be.equal(randomL1Token);
-
-    // check make sure historical routes are still valid
-    l2Token = hubPoolClient.getL2TokenForL1TokenAtBlock(randomL1TokenAddr, destinationChainId, e1.blockNumber);
-    expect(l2Token).to.be.undefined;
-    l1Token = hubPoolClient.getL1TokenForL2TokenAtBlock(randomDestinationTokenAddr, destinationChainId, e1.blockNumber);
-    expect(l1Token).to.be.undefined;
   });
 });

--- a/test/mocks/MockHubPoolClient.ts
+++ b/test/mocks/MockHubPoolClient.ts
@@ -30,7 +30,7 @@ export class MockHubPoolClient extends clients.mocks.MockHubPoolClient {
   }
   getL1TokenForDeposit(
     deposit: Pick<DepositWithBlock, "originChainId" | "inputToken" | "quoteBlockNumber">
-  ): EvmAddress | undefined {
+  ): EvmAddress {
     // L1-->L2 token mappings are set via PoolRebalanceRoutes which occur on mainnet,
     // so we use the latest token mapping. This way if a very old deposit is filled, the relayer can use the
     // latest L2 token mapping to find the L1 token counterpart.
@@ -47,11 +47,9 @@ export class MockHubPoolClient extends clients.mocks.MockHubPoolClient {
   getL2TokenForDeposit(
     deposit: Pick<DepositWithBlock, "originChainId" | "destinationChainId" | "inputToken" | "quoteBlockNumber">,
     l2ChainId = deposit.destinationChainId
-  ): string | undefined {
+  ): string {
     const l1Token = this.getL1TokenForDeposit(deposit);
     // Use the latest hub block number to find the L2 token counterpart.
-    return l1Token
-      ? this.getL2TokenForL1TokenAtBlock(l1Token, l2ChainId, deposit.quoteBlockNumber)?.toNative()
-      : undefined;
+    return this.getL2TokenForL1TokenAtBlock(l1Token, l2ChainId, deposit.quoteBlockNumber).toNative();
   }
 }


### PR DESCRIPTION
This reverts commit 4af064d4f4e8753b68427131de8c705c9b2d13d0.

The commit is backed out as a precaution to permit SDK to be bumped in the relayer without having to worry about this throwing up issues. Probability is low, but we'll bump when Faisal is available to monitor.