### PR TITLE
improve: Add Polygon to list of OFT enabled chains

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.59",
+  "version": "4.3.60",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/utils/NetworkUtils.ts
+++ b/src/utils/NetworkUtils.ts
@@ -155,7 +155,7 @@ export function chainIsCCTPEnabled(chainId: number): boolean {
 export function chainIsOFTEnabled(chainId: number): boolean {
   // Add chainIds to oftEnabled as they are supported by the protocol.
   // This is backwards vs. CCTP logic because Across support for OFTs is limited vs. OFT deployments.
-  const oftEnabled = [CHAIN_IDs.ARBITRUM];
+  const oftEnabled = [CHAIN_IDs.ARBITRUM, CHAIN_IDs.POLYGON];
   return oftEnabled.includes(chainId) && PRODUCTION_NETWORKS[chainId]?.oftEid !== OFT_NO_EID;
 }
 


### PR DESCRIPTION
Used by inventory client in `repaymentChainCanBeQuicklyRebalanced` when determining repayment chain selection
