### PR TITLE
fix: Revert to type0 gas pricing on Plasma

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.65",
+  "version": "4.3.66",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "files": [

--- a/src/gasPriceOracle/oracle.ts
+++ b/src/gasPriceOracle/oracle.ts
@@ -108,7 +108,7 @@ function _getEthersGasPriceEstimate(
     [CHAIN_IDs.ARBITRUM]: arbitrum.eip1559,
     [CHAIN_IDs.BSC]: ethereum.legacy,
     [CHAIN_IDs.MAINNET]: ethereum.eip1559,
-    [CHAIN_IDs.PLASMA]: ethereum.eip1559,
+    // [CHAIN_IDs.PLASMA]: ethereum.eip1559, @todo: Pending RPC support
     [CHAIN_IDs.POLYGON]: polygon.gasStation,
     [CHAIN_IDs.SCROLL]: ethereum.legacy,
     [CHAIN_IDs.ZK_SYNC]: ethereum.legacy,


### PR DESCRIPTION
Alchemy is error on eth_maxPriorityFeePerGas. Revert to type0 for the
time being.