### PR TITLE
improve: include options for multiple arweave gateways

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.143",
+  "version": "4.3.144",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.143-alpha.0",
+  "version": "4.3.143-alpha.1",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.143-alpha.2",
+  "version": "4.3.143-alpha.3",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.142",
+  "version": "4.3.143-alpha.0",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.143-alpha.1",
+  "version": "4.3.143-alpha.2",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.143-alpha.3",
+  "version": "4.3.143",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/src/caching/Arweave/ArweaveClient.ts
+++ b/src/caching/Arweave/ArweaveClient.ts
@@ -6,37 +6,107 @@ import winston from "winston";
 import { ARWEAVE_TAG_APP_NAME, ARWEAVE_TAG_APP_VERSION, DEFAULT_ARWEAVE_STORAGE_ADDRESS } from "../../constants";
 import { BigNumber, delay, fetchWithTimeout, isDefined, jsonReplacerWithBigNumbers, toBN } from "../../utils";
 
+export interface ArweaveGatewayConfig {
+  host: string;
+  protocol?: string;
+  port?: number;
+}
+
+export const DEFAULT_ARWEAVE_GATEWAYS: ArweaveGatewayConfig[] = [
+  { host: "arweave.net" },
+  { host: "ar-io.net" },
+];
+
+interface Gateway {
+  client: Arweave;
+  url: string;
+}
+
 export class ArweaveClient {
-  private client: Arweave;
-  private gatewayUrl: string;
+  private gateways: Gateway[];
 
   public constructor(
     private arweaveJWT: JWKInterface,
     private logger: winston.Logger,
-    public gatewayURL = "arweave.net",
-    public protocol = "https",
-    port = 443,
+    gateways: ArweaveGatewayConfig[] = DEFAULT_ARWEAVE_GATEWAYS,
     private readonly retries = 2,
     private readonly retryDelaySeconds = 1
   ) {
-    this.gatewayUrl = `${protocol}://${gatewayURL}:${port}`;
-    this.client = new Arweave({
-      host: gatewayURL,
-      port,
-      protocol,
-      timeout: 20000,
-      logging: false,
-    });
-    this.logger.debug({
-      at: "ArweaveClient:constructor",
-      message: "Arweave client initialized",
-      gateway: this.gatewayUrl,
-    });
+    if (gateways.length === 0) {
+      throw new Error("At least one gateway must be provided");
+    }
     if (this.retries < 0) {
       throw new Error(`retries cannot be < 0 and must be an integer. Currently set to ${this.retries}`);
     }
     if (this.retryDelaySeconds < 0) {
       throw new Error(`delay cannot be < 0. Currently set to ${this.retryDelaySeconds}`);
+    }
+    this.gateways = gateways.map(({ host, protocol = "https", port = 443 }) => ({
+      client: new Arweave({ host, port, protocol, timeout: 20000, logging: false }),
+      url: `${protocol}://${host}:${port}`,
+    }));
+    this.logger.debug({
+      at: "ArweaveClient:constructor",
+      message: "Arweave client initialized",
+      gateways: this.gateways.map((g) => g.url),
+    });
+  }
+
+  /**
+   * Races a request across all gateways, returning the first successful response.
+   * If all gateways fail, throws an error with details from each gateway.
+   */
+  private async _raceGateways<T>(label: string, fn: (gw: Gateway) => Promise<T>): Promise<T> {
+    try {
+      return await Promise.any(this.gateways.map((gw) => this._retryRequest(() => fn(gw), 0)));
+    } catch (e) {
+      if (e instanceof AggregateError) {
+        const details = this.gateways.map((gw, i) => `${gw.url}: ${e.errors[i]}`).join("; ");
+        throw new Error(`All Arweave gateways failed for ${label}: ${details}`);
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Tries gateways sequentially, returning the first successful response.
+   * Used for write operations where we want exactly one successful submission.
+   */
+  private async _failoverGateways<T>(label: string, fn: (gw: Gateway) => Promise<T>): Promise<T> {
+    const errors: Error[] = [];
+    for (const gw of this.gateways) {
+      try {
+        return await this._retryRequest(() => fn(gw), 0);
+      } catch (e) {
+        errors.push(e as Error);
+        this.logger.debug({
+          at: "ArweaveClient:failoverGateways",
+          message: `Gateway ${gw.url} failed for ${label}, trying next: ${e}`,
+        });
+      }
+    }
+    const details = this.gateways.map((gw, i) => `${gw.url}: ${errors[i]}`).join("; ");
+    throw new Error(`All Arweave gateways failed for ${label}: ${details}`);
+  }
+
+  private async _retryRequest<T>(request: () => Promise<T>, retryCount: number): Promise<T> {
+    try {
+      return await request();
+    } catch (e) {
+      if (retryCount < this.retries) {
+        // Implement a slightly aggressive exponential backoff to account for fierce parallelism.
+        const baseDelay = this.retryDelaySeconds * Math.pow(2, retryCount);
+        const delayS = baseDelay + baseDelay * Math.random();
+        this.logger.debug({
+          at: "ArweaveClient:retryRequest",
+          message: `Arweave request failed, retrying after waiting ${delayS} seconds: ${e}`,
+          retryCount,
+        });
+        await delay(delayS);
+        return this._retryRequest(request, retryCount + 1);
+      } else {
+        throw e;
+      }
     }
   }
 
@@ -47,46 +117,47 @@ export class ArweaveClient {
    * @param value The value to store
    * @param topicTag An optional topic tag to add to the transaction
    * @returns The transaction ID of the stored value
-   * @
    */
   async set(value: Record<string, unknown>, topicTag?: string | undefined): Promise<string | undefined> {
-    const transaction = await this.client.createTransaction(
-      { data: JSON.stringify(value, jsonReplacerWithBigNumbers) },
-      this.arweaveJWT
-    );
+    return this._failoverGateways("set", async ({ client }) => {
+      const transaction = await client.createTransaction(
+        { data: JSON.stringify(value, jsonReplacerWithBigNumbers) },
+        this.arweaveJWT
+      );
 
-    // Add tags to the transaction
-    transaction.addTag("Content-Type", "application/json");
-    transaction.addTag("App-Name", ARWEAVE_TAG_APP_NAME);
-    transaction.addTag("App-Version", ARWEAVE_TAG_APP_VERSION.toString());
-    if (isDefined(topicTag)) {
-      transaction.addTag("Topic", topicTag);
-    }
+      // Add tags to the transaction
+      transaction.addTag("Content-Type", "application/json");
+      transaction.addTag("App-Name", ARWEAVE_TAG_APP_NAME);
+      transaction.addTag("App-Version", ARWEAVE_TAG_APP_VERSION.toString());
+      if (isDefined(topicTag)) {
+        transaction.addTag("Topic", topicTag);
+      }
 
-    // Sign the transaction
-    await this.client.transactions.sign(transaction, this.arweaveJWT);
-    // Send the transaction
-    const result = await this.client.transactions.post(transaction);
+      // Sign the transaction
+      await client.transactions.sign(transaction, this.arweaveJWT);
+      // Send the transaction
+      const result = await client.transactions.post(transaction);
 
-    // Ensure that the result is successful
-    if (result.status !== 200) {
-      const message = result?.data?.error?.msg ?? "Unknown error";
-      this.logger.error({
-        at: "ArweaveClient:set",
-        message,
-        result,
-        txn: transaction.id,
-        address: await this.getAddress(),
-        balance: (await this.getBalance()).toString(),
-      });
-      throw new Error(message);
-    } else {
+      // Ensure that the result is successful
+      if (result.status !== 200) {
+        const message = result?.data?.error?.msg ?? "Unknown error";
+        this.logger.error({
+          at: "ArweaveClient:set",
+          message,
+          result,
+          txn: transaction.id,
+          address: await this.getAddress(),
+          balance: (await this.getBalance()).toString(),
+        });
+        throw new Error(message);
+      }
+
       this.logger.debug({
         at: "ArweaveClient:set",
         message: `Arweave transaction posted with ${transaction.id}`,
       });
-    }
-    return transaction.id;
+      return transaction.id;
+    });
   }
 
   /**
@@ -97,15 +168,12 @@ export class ArweaveClient {
    * @returns The record if it exists, otherwise null
    */
   async get<T>(transactionID: string, validator: Struct<T>): Promise<T | null> {
-    // Resolve the URL of the transaction
-    const transactionUrl = `${this.gatewayUrl}/${transactionID}`;
-    // We should query in via Axios directly to the gateway URL. The reasoning behind this is
+    // We query via fetchWithTimeout directly to the gateway URL. The reasoning behind this is
     // that the Arweave SDK's `getData` method is too slow and does not provide a way to set a timeout.
     // Therefore, something that could take milliseconds to complete could take tens of minutes.
-    const request = async () => {
-      return await fetchWithTimeout(transactionUrl, {}, {}, 20_000);
-    };
-    const data = await this._retryRequest(request, 0);
+    const data = await this._raceGateways("get", async ({ url }) => {
+      return fetchWithTimeout(`${url}/${transactionID}`, {}, {}, 20_000);
+    });
     try {
       // We should validate the data and perform any logical coercion here.
       return create(data, validator);
@@ -149,15 +217,15 @@ export class ArweaveClient {
       ) { edges { node { id } } }
     }`;
 
-    const response = await this._retryRequest(async () => {
-      const response = await this.client.api.post<{
+    const response = await this._raceGateways("getByTopic", async ({ client }) => {
+      const response = await client.api.post<{
         data: { transactions: { edges: { node: { id: string } }[] } };
       }>("/graphql", { query });
       if (!response.ok) {
         throw new Error(`Arweave GraphQL request failed with status ${response.status}`);
       }
       return response;
-    }, 0);
+    });
 
     const entries = response?.data?.data?.transactions?.edges ?? [];
     this.logger.debug({
@@ -198,7 +266,9 @@ export class ArweaveClient {
    * @returns The metadata of the transaction if it exists, otherwise null
    */
   async getMetadata(transactionID: string): Promise<Record<string, string> | null> {
-    const transaction = await this.client.transactions.get(transactionID);
+    const transaction = await this._raceGateways("getMetadata", async ({ client }) => {
+      return client.transactions.get(transactionID);
+    });
     if (!isDefined(transaction)) {
       return null;
     }
@@ -216,32 +286,12 @@ export class ArweaveClient {
   }
 
   /**
-   * Returns the address of the signer of the JWT
+   * Returns the address of the signer of the JWT. This is a local crypto
+   * operation and does not require a network call.
    * @returns The address of the signer in this client
    */
   getAddress(): Promise<string> {
-    return this.client.wallets.jwkToAddress(this.arweaveJWT);
-  }
-
-  private async _retryRequest<T>(request: () => Promise<T>, retryCount: number): Promise<T> {
-    try {
-      return await request();
-    } catch (e) {
-      if (retryCount < this.retries) {
-        // Implement a slightly aggressive exponential backoff to account for fierce parallelism.
-        const baseDelay = this.retryDelaySeconds * Math.pow(2, retryCount); // ms; attempt = [0, 1, 2, ...]
-        const delayS = baseDelay + baseDelay * Math.random();
-        this.logger.debug({
-          at: "ArweaveClient:retryRequest",
-          message: `Arweave request failed, retrying after waiting ${delayS} seconds: ${e}`,
-          retryCount,
-        });
-        await delay(delayS);
-        return this._retryRequest(request, retryCount + 1);
-      } else {
-        throw e;
-      }
-    }
+    return this.gateways[0].client.wallets.jwkToAddress(this.arweaveJWT);
   }
 
   /**
@@ -250,9 +300,9 @@ export class ArweaveClient {
    */
   async getBalance(): Promise<BigNumber> {
     const address = await this.getAddress();
-    const request = async () => {
-      const balanceInFloat = await this.client.wallets.getBalance(address);
-      // @dev The reason we add in the BN.from into this retry loop is because the client.getBalance call
+    return this._raceGateways("getBalance", async ({ client }) => {
+      const balanceInFloat = await client.wallets.getBalance(address);
+      // @dev The reason we add in the BN.from here is because the client.getBalance call
       // does not correctly throw an error if the request fails, instead it will return the error string as the
       // balanceInFloat.
       // Sometimes the balance is returned in scientific notation, so we need to
@@ -264,7 +314,6 @@ export class ArweaveClient {
       } else {
         return BigNumber.from(balanceInFloat);
       }
-    };
-    return await this._retryRequest(request, 0);
+    });
   }
 }

--- a/src/caching/Arweave/ArweaveClient.ts
+++ b/src/caching/Arweave/ArweaveClient.ts
@@ -12,10 +12,7 @@ export interface ArweaveGatewayConfig {
   port?: number;
 }
 
-export const DEFAULT_ARWEAVE_GATEWAYS: ArweaveGatewayConfig[] = [
-  { host: "arweave.net" },
-  { host: "ar-io.net" },
-];
+export const DEFAULT_ARWEAVE_GATEWAYS: ArweaveGatewayConfig[] = [{ host: "arweave.net" }, { host: "ar-io.net" }];
 
 interface Gateway {
   client: Arweave;
@@ -119,7 +116,7 @@ export class ArweaveClient {
    * @returns The transaction ID of the stored value
    */
   async set(value: Record<string, unknown>, topicTag?: string | undefined): Promise<string | undefined> {
-    return this._failoverGateways("set", async ({ client }) => {
+    return await this._failoverGateways("set", async ({ client }) => {
       const transaction = await client.createTransaction(
         { data: JSON.stringify(value, jsonReplacerWithBigNumbers) },
         this.arweaveJWT
@@ -172,7 +169,7 @@ export class ArweaveClient {
     // that the Arweave SDK's `getData` method is too slow and does not provide a way to set a timeout.
     // Therefore, something that could take milliseconds to complete could take tens of minutes.
     const data = await this._raceGateways("get", async ({ url }) => {
-      return fetchWithTimeout(`${url}/${transactionID}`, {}, {}, 20_000);
+      return await fetchWithTimeout(`${url}/${transactionID}`, {}, {}, 20_000);
     });
     try {
       // We should validate the data and perform any logical coercion here.
@@ -267,7 +264,7 @@ export class ArweaveClient {
    */
   async getMetadata(transactionID: string): Promise<Record<string, string> | null> {
     const transaction = await this._raceGateways("getMetadata", async ({ client }) => {
-      return client.transactions.get(transactionID);
+      return await client.transactions.get(transactionID);
     });
     if (!isDefined(transaction)) {
       return null;

--- a/src/caching/Arweave/ArweaveClient.ts
+++ b/src/caching/Arweave/ArweaveClient.ts
@@ -116,23 +116,27 @@ export class ArweaveClient {
    * @returns The transaction ID of the stored value
    */
   async set(value: Record<string, unknown>, topicTag?: string | undefined): Promise<string | undefined> {
+    // Get a template client to use for creating a transaction. Since clients are equal up to the gateway URL,
+    // it does not matter which gateway is used, so we just choose the first one.
+    const templateClient = this.gateways[0].client;
+    const transaction = await templateClient.createTransaction(
+      { data: JSON.stringify(value, jsonReplacerWithBigNumbers) },
+      this.arweaveJWT
+    );
+
+    // Add tags to the transaction
+    transaction.addTag("Content-Type", "application/json");
+    transaction.addTag("App-Name", ARWEAVE_TAG_APP_NAME);
+    transaction.addTag("App-Version", ARWEAVE_TAG_APP_VERSION.toString());
+    if (isDefined(topicTag)) {
+      transaction.addTag("Topic", topicTag);
+    }
+
+    // Sign the transaction
+    await templateClient.transactions.sign(transaction, this.arweaveJWT);
+    // Send the transaction
+
     return await this._failoverGateways("set", async ({ client }) => {
-      const transaction = await client.createTransaction(
-        { data: JSON.stringify(value, jsonReplacerWithBigNumbers) },
-        this.arweaveJWT
-      );
-
-      // Add tags to the transaction
-      transaction.addTag("Content-Type", "application/json");
-      transaction.addTag("App-Name", ARWEAVE_TAG_APP_NAME);
-      transaction.addTag("App-Version", ARWEAVE_TAG_APP_VERSION.toString());
-      if (isDefined(topicTag)) {
-        transaction.addTag("Topic", topicTag);
-      }
-
-      // Sign the transaction
-      await client.transactions.sign(transaction, this.arweaveJWT);
-      // Send the transaction
       const result = await client.transactions.post(transaction);
 
       // Ensure that the result is successful

--- a/test/arweaveClient.ts
+++ b/test/arweaveClient.ts
@@ -4,23 +4,23 @@ import { JWKInterface } from "arweave/node/lib/wallet";
 import { expect } from "chai";
 import { object, string } from "superstruct";
 import winston from "winston";
-import { ArweaveClient } from "../src/caching";
+import { ArweaveClient, ArweaveGatewayConfig } from "../src/caching";
 import { ARWEAVE_TAG_APP_NAME } from "../src/constants";
 import { fetchWithTimeout, toBN } from "../src/utils";
 import { assertPromiseError } from "./utils";
 
 const INITIAL_FUNDING_AMNT = "5000000000";
-const LOCAL_ARWEAVE_NODE = {
+const LOCAL_ARWEAVE_GATEWAY: ArweaveGatewayConfig = {
   protocol: "http",
   host: "localhost",
   port: 1984,
 };
-const LOCAL_ARWEAVE_URL = `${LOCAL_ARWEAVE_NODE.protocol}://${LOCAL_ARWEAVE_NODE.host}:${LOCAL_ARWEAVE_NODE.port}`;
+const LOCAL_ARWEAVE_URL = `${LOCAL_ARWEAVE_GATEWAY.protocol}://${LOCAL_ARWEAVE_GATEWAY.host}:${LOCAL_ARWEAVE_GATEWAY.port}`;
 
 const mineBlock = () => fetchWithTimeout(`${LOCAL_ARWEAVE_URL}/mine`, {}, {}, undefined, "text");
 
 describe("ArweaveClient", () => {
-  const arLocal = new ArLocal(LOCAL_ARWEAVE_NODE.port, true);
+  const arLocal = new ArLocal(LOCAL_ARWEAVE_GATEWAY.port as number, true);
 
   let jwk: JWKInterface;
   let client: ArweaveClient;
@@ -54,9 +54,7 @@ describe("ArweaveClient", () => {
           }),
         ],
       }),
-      LOCAL_ARWEAVE_NODE.host,
-      LOCAL_ARWEAVE_NODE.protocol,
-      LOCAL_ARWEAVE_NODE.port
+      [LOCAL_ARWEAVE_GATEWAY]
     );
   });
 
@@ -190,9 +188,7 @@ describe("ArweaveClient", () => {
         defaultMeta: { service: "arweave-client" },
         transports: [new winston.transports.Console()],
       }),
-      LOCAL_ARWEAVE_NODE.host,
-      LOCAL_ARWEAVE_NODE.protocol,
-      LOCAL_ARWEAVE_NODE.port
+      [LOCAL_ARWEAVE_GATEWAY]
     );
     await assertPromiseError(client.set({ test: "value" }), "You don't have enough tokens");
   });


### PR DESCRIPTION
Adds extra functions which wrap the retry logic:
- _raceGateways is for getting data and will concurrently query all available gateways with retries, until either all fail or one returns a 200.
- _failoverGateways is for setting data and will iterate through all available gateways with retries until either all fail or one gateway set succeeds.