### PR TITLE
Improve Arweave failover, read resilience, and topic caching

### DIFF
--- a/src/caching/Arweave/ArweaveClient.ts
+++ b/src/caching/Arweave/ArweaveClient.ts
@@ -4,7 +4,16 @@ import { JWKInterface } from "arweave/node/lib/wallet";
 import { Struct, create } from "superstruct";
 import winston from "winston";
 import { ARWEAVE_TAG_APP_NAME, ARWEAVE_TAG_APP_VERSION, DEFAULT_ARWEAVE_STORAGE_ADDRESS } from "../../constants";
-import { BigNumber, delay, fetchWithTimeout, isDefined, jsonReplacerWithBigNumbers, toBN } from "../../utils";
+import {
+  BigNumber,
+  delay,
+  fetchWithTimeout,
+  isDefined,
+  isHttpError,
+  jsonReplacerWithBigNumbers,
+  postWithTimeout,
+  toBN,
+} from "../../utils";
 
 export interface ArweaveGatewayConfig {
   host: string;
@@ -17,6 +26,32 @@ export const DEFAULT_ARWEAVE_GATEWAYS: ArweaveGatewayConfig[] = [{ host: "arweav
 interface Gateway {
   client: Arweave;
   url: string;
+}
+
+interface GraphQLTransactionsResponse {
+  data?: {
+    transactions?: {
+      edges?: { node: { id: string } }[];
+    };
+  };
+}
+
+type WritePhase = "createTransaction" | "sign" | "post";
+
+class ArweaveWriteError extends Error {
+  constructor(
+    message: string,
+    readonly phase: WritePhase,
+    readonly gateway: string,
+    readonly status?: number
+  ) {
+    super(message);
+    this.name = "ArweaveWriteError";
+  }
+}
+
+export function getArweaveTopicCacheKey(tag: string): string {
+  return `arweave-topic:${tag}`;
 }
 
 export class ArweaveClient {
@@ -69,16 +104,24 @@ export class ArweaveClient {
    * Tries gateways sequentially, returning the first successful response.
    * Used for write operations where we want exactly one successful submission.
    */
-  private async _failoverGateways<T>(label: string, fn: (gw: Gateway) => Promise<T>): Promise<T> {
+  private async _failoverGateways<T>(
+    label: string,
+    fn: (gw: Gateway, attempt: number) => Promise<T>,
+    shouldRetry: (error: unknown) => boolean = () => true
+  ): Promise<T> {
     const errors: Error[] = [];
-    for (const gw of this.gateways) {
+    for (const [index, gw] of this.gateways.entries()) {
       try {
-        return await this._retryRequest(() => fn(gw), 0);
+        return await this._retryRequest(() => fn(gw, index + 1), 0, shouldRetry);
       } catch (e) {
-        errors.push(e as Error);
+        const error = e instanceof Error ? e : new Error(String(e));
+        errors.push(error);
         this.logger.debug({
           at: "ArweaveClient:failoverGateways",
-          message: `Gateway ${gw.url} failed for ${label}, trying next: ${e}`,
+          message: `Gateway ${gw.url} failed for ${label}, trying next gateway`,
+          gateway: gw.url,
+          attempt: index + 1,
+          error: String(error),
         });
       }
     }
@@ -86,11 +129,15 @@ export class ArweaveClient {
     throw new Error(`All Arweave gateways failed for ${label}: ${details}`);
   }
 
-  private async _retryRequest<T>(request: () => Promise<T>, retryCount: number): Promise<T> {
+  private async _retryRequest<T>(
+    request: () => Promise<T>,
+    retryCount: number,
+    shouldRetry: (error: unknown) => boolean = () => true
+  ): Promise<T> {
     try {
       return await request();
     } catch (e) {
-      if (retryCount < this.retries) {
+      if (retryCount < this.retries && shouldRetry(e)) {
         // Implement a slightly aggressive exponential backoff to account for fierce parallelism.
         const baseDelay = this.retryDelaySeconds * Math.pow(2, retryCount);
         const delayS = baseDelay + baseDelay * Math.random();
@@ -107,6 +154,39 @@ export class ArweaveClient {
     }
   }
 
+  private _wrapWriteError(error: unknown, phase: WritePhase, gateway: string): ArweaveWriteError {
+    if (error instanceof ArweaveWriteError) {
+      return error;
+    }
+    if (isHttpError(error)) {
+      return new ArweaveWriteError(error.message, phase, gateway, error.status);
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return new ArweaveWriteError(message, phase, gateway);
+  }
+
+  private _isRetryableWriteError(error: unknown): boolean {
+    const status =
+      error instanceof ArweaveWriteError ? error.status : isHttpError(error) ? error.status : undefined;
+    if (status !== undefined) {
+      return status >= 500 || status === 408 || status === 429;
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    return !message.includes("You don't have enough tokens");
+  }
+
+  private _isNotFoundError(error: unknown): boolean {
+    if (isHttpError(error)) {
+      return error.status === 404;
+    }
+    if (error instanceof ArweaveWriteError) {
+      return error.status === 404;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return message.includes("HTTP 404") || message.includes("404: Not Found");
+  }
+
   /**
    * Stores an arbitrary record in the Arweave network. The record is stored as a JSON string and uses
    * JSON.stringify to convert the record to a string. The record has all of its big numbers converted
@@ -116,49 +196,65 @@ export class ArweaveClient {
    * @returns The transaction ID of the stored value
    */
   async set(value: Record<string, unknown>, topicTag?: string | undefined): Promise<string | undefined> {
-    // Get a template client to use for creating a transaction. Since clients are equal up to the gateway URL,
-    // it does not matter which gateway is used, so we just choose the first one.
-    const templateClient = this.gateways[0].client;
-    const transaction = await templateClient.createTransaction(
-      { data: JSON.stringify(value, jsonReplacerWithBigNumbers) },
-      this.arweaveJWT
-    );
+    const payload = JSON.stringify(value, jsonReplacerWithBigNumbers);
 
-    // Add tags to the transaction
-    transaction.addTag("Content-Type", "application/json");
-    transaction.addTag("App-Name", ARWEAVE_TAG_APP_NAME);
-    transaction.addTag("App-Version", ARWEAVE_TAG_APP_VERSION.toString());
-    if (isDefined(topicTag)) {
-      transaction.addTag("Topic", topicTag);
-    }
+    try {
+      return await this._failoverGateways(
+        "set",
+        async ({ client, url }, attempt) => {
+          let transaction;
+          try {
+            transaction = await client.createTransaction({ data: payload }, this.arweaveJWT);
+          } catch (error) {
+            throw this._wrapWriteError(error, "createTransaction", url);
+          }
 
-    // Sign the transaction
-    await templateClient.transactions.sign(transaction, this.arweaveJWT);
-    // Send the transaction
+          transaction.addTag("Content-Type", "application/json");
+          transaction.addTag("App-Name", ARWEAVE_TAG_APP_NAME);
+          transaction.addTag("App-Version", ARWEAVE_TAG_APP_VERSION.toString());
+          if (isDefined(topicTag)) {
+            transaction.addTag("Topic", topicTag);
+          }
 
-    return await this._failoverGateways("set", async ({ client }) => {
-      const result = await client.transactions.post(transaction);
+          try {
+            await client.transactions.sign(transaction, this.arweaveJWT);
+          } catch (error) {
+            throw this._wrapWriteError(error, "sign", url);
+          }
 
-      // Ensure that the result is successful
-      if (result.status !== 200) {
-        const message = result?.data?.error?.msg ?? "Unknown error";
-        this.logger.error({
-          at: "ArweaveClient:set",
-          message,
-          result,
-          txn: transaction.id,
-          address: await this.getAddress(),
-          balance: (await this.getBalance()).toString(),
-        });
-        throw new Error(message);
-      }
+          let result;
+          try {
+            result = await client.transactions.post(transaction);
+          } catch (error) {
+            throw this._wrapWriteError(error, "post", url);
+          }
 
-      this.logger.debug({
+          if (result.status !== 200) {
+            const message = result?.data?.error?.msg ?? result.statusText ?? `HTTP ${result.status}`;
+            throw new ArweaveWriteError(message, "post", url, result.status);
+          }
+
+          this.logger.debug({
+            at: "ArweaveClient:set",
+            message: `Arweave transaction posted with ${transaction.id}`,
+            gateway: url,
+            attempt,
+            phase: "post",
+            txn: transaction.id,
+          });
+          return transaction.id;
+        },
+        (error) => this._isRetryableWriteError(error)
+      );
+    } catch (error) {
+      this.logger.error({
         at: "ArweaveClient:set",
-        message: `Arweave transaction posted with ${transaction.id}`,
+        message: "Failed to persist data to Arweave after exhausting all gateways",
+        topicTag,
+        error: String(error),
       });
-      return transaction.id;
-    });
+      throw error;
+    }
   }
 
   /**
@@ -218,17 +314,11 @@ export class ArweaveClient {
       ) { edges { node { id } } }
     }`;
 
-    const response = await this._raceGateways("getByTopic", async ({ client }) => {
-      const response = await client.api.post<{
-        data: { transactions: { edges: { node: { id: string } }[] } };
-      }>("/graphql", { query });
-      if (!response.ok) {
-        throw new Error(`Arweave GraphQL request failed with status ${response.status}`);
-      }
-      return response;
+    const response = await this._raceGateways("getByTopic", async ({ url }) => {
+      return await postWithTimeout<GraphQLTransactionsResponse>(`${url}/graphql`, { query }, {}, {}, 20_000);
     });
 
-    const entries = response?.data?.data?.transactions?.edges ?? [];
+    const entries = response?.data?.transactions?.edges ?? [];
     this.logger.debug({
       at: "ArweaveClient:getByTopic",
       message: `Retrieved ${entries.length} matching transactions from Arweave`,
@@ -239,6 +329,7 @@ export class ArweaveClient {
         appVersion: ARWEAVE_TAG_APP_VERSION,
       },
     });
+    const failures: { hash: string; error: unknown }[] = [];
     const results = await Promise.all(
       entries.map(async (edge) => {
         try {
@@ -250,14 +341,35 @@ export class ArweaveClient {
               }
             : null;
         } catch (e) {
-          this.logger.warn({
-            at: "ArweaveClient:getByTopic",
-            message: `Bad request for Arweave topic ${edge.node.id}: ${e}`,
-          });
+          failures.push({ hash: edge.node.id, error: e });
           return null;
         }
       })
     );
+    const notFoundFailures = failures.filter(({ error }) => this._isNotFoundError(error));
+    const unexpectedFailures = failures.filter(({ error }) => !this._isNotFoundError(error));
+
+    if (notFoundFailures.length > 0) {
+      this.logger.debug({
+        at: "ArweaveClient:getByTopic",
+        message: `Skipped ${notFoundFailures.length} Arweave topic entries that were not yet available`,
+        tag,
+        transactions: notFoundFailures.map(({ hash }) => hash),
+      });
+    }
+
+    if (unexpectedFailures.length > 0) {
+      this.logger.warn({
+        at: "ArweaveClient:getByTopic",
+        message: `Failed to fetch ${unexpectedFailures.length} Arweave topic entries`,
+        tag,
+        failures: unexpectedFailures.map(({ hash, error }) => ({
+          hash,
+          error: String(error),
+        })),
+      });
+    }
+
     return results.filter(isDefined);
   }
 

--- a/src/caching/Arweave/ArweaveClient.ts
+++ b/src/caching/Arweave/ArweaveClient.ts
@@ -50,10 +50,6 @@ class ArweaveWriteError extends Error {
   }
 }
 
-export function getArweaveTopicCacheKey(tag: string): string {
-  return `arweave-topic:${tag}`;
-}
-
 export class ArweaveClient {
   private gateways: Gateway[];
 

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -44,6 +44,7 @@ import {
   convertRelayDataParamsToBytes32,
   convertFillParamsToBytes32,
   chainIsTvm,
+  getArweaveTopicCacheKey,
   jsonReplacerWithBigNumbers,
 } from "../../utils";
 import winston from "winston";
@@ -61,8 +62,6 @@ import {
 import { isEVMSpokePoolClient, isSVMSpokePoolClient } from "../SpokePoolClient";
 import { SpokePoolManager } from "../SpokePoolClient/SpokePoolClientManager";
 import { DEFAULT_CACHING_TTL } from "../../constants";
-import { getArweaveTopicCacheKey } from "../../caching";
-
 type DataCache = Record<string, Promise<LoadDataReturnValue>>;
 
 // V3 dictionary helper functions

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
 import _ from "lodash";
+import { create } from "superstruct";
 import {
   SlowFillRequestWithBlock,
   SpokePoolClientsByChain,
@@ -16,6 +17,7 @@ import {
   FillWithBlock,
   Deposit,
   DepositWithBlock,
+  CachingMechanismInterface,
 } from "../../interfaces";
 import { SpokePoolClient } from "..";
 import { findFillEvent as findEvmFillEvent } from "../../arch/evm";
@@ -42,10 +44,12 @@ import {
   convertRelayDataParamsToBytes32,
   convertFillParamsToBytes32,
   chainIsTvm,
+  jsonReplacerWithBigNumbers,
 } from "../../utils";
 import winston from "winston";
 import {
   BundleDataSS,
+  BundleData as PersistedArweaveBundleData,
   getRefundInformationFromFill,
   isChainDisabledAtBlock,
   isChainPaused,
@@ -56,6 +60,8 @@ import {
 } from "./utils";
 import { isEVMSpokePoolClient, isSVMSpokePoolClient } from "../SpokePoolClient";
 import { SpokePoolManager } from "../SpokePoolClient/SpokePoolClientManager";
+import { DEFAULT_CACHING_TTL } from "../../constants";
+import { getArweaveTopicCacheKey } from "../../caching";
 
 type DataCache = Record<string, Promise<LoadDataReturnValue>>;
 
@@ -164,7 +170,8 @@ export class BundleDataClient {
     readonly clients: Clients,
     spokePoolClients: { [chainId: number]: SpokePoolClient },
     readonly chainIdListForBundleEvaluationBlockNumbers: number[],
-    readonly blockRangeEndBlockBuffer: { [chainId: number]: number } = {}
+    readonly blockRangeEndBlockBuffer: { [chainId: number]: number } = {},
+    readonly arweaveTopicCache?: CachingMechanismInterface
   ) {
     this.spokePoolClientManager = new SpokePoolManager(logger, spokePoolClients);
   }
@@ -204,6 +211,50 @@ export class BundleDataClient {
     return `bundles-${BundleDataClient.getArweaveClientKey(blockRangesForChains)}`;
   }
 
+  private async getPersistedArweaveTopicFromCache(tag: string): Promise<PersistedArweaveBundleData | undefined> {
+    if (!isDefined(this.arweaveTopicCache)) {
+      return undefined;
+    }
+
+    try {
+      const cachedPayload = await this.arweaveTopicCache.get<string>(getArweaveTopicCacheKey(tag));
+      if (!isDefined(cachedPayload)) {
+        return undefined;
+      }
+
+      return create(JSON.parse(cachedPayload), BundleDataSS);
+    } catch (error) {
+      this.logger.debug({
+        at: "BundleDataClient#getPersistedArweaveTopicFromCache",
+        message: "Failed to restore persisted bundle data from topic cache, falling back to Arweave",
+        tag,
+        error: String(error),
+      });
+      return undefined;
+    }
+  }
+
+  private async backfillPersistedArweaveTopicCache(tag: string, data: PersistedArweaveBundleData): Promise<void> {
+    if (!isDefined(this.arweaveTopicCache)) {
+      return;
+    }
+
+    try {
+      await this.arweaveTopicCache.set(
+        getArweaveTopicCacheKey(tag),
+        JSON.stringify(data, jsonReplacerWithBigNumbers),
+        DEFAULT_CACHING_TTL
+      );
+    } catch (error) {
+      this.logger.debug({
+        at: "BundleDataClient#backfillPersistedArweaveTopicCache",
+        message: "Failed to backfill persisted bundle data into topic cache",
+        tag,
+        error: String(error),
+      });
+    }
+  }
+
   private async loadPersistedDataFromArweave(
     blockRangesForChains: number[][]
   ): Promise<LoadDataReturnValue | undefined> {
@@ -211,14 +262,25 @@ export class BundleDataClient {
       return undefined;
     }
     const start = performance.now();
-    const persistedData = await this.clients.arweaveClient.getByTopic(
-      this.getArweaveBundleDataClientKey(blockRangesForChains),
-      BundleDataSS
-    );
-    // If there is no data or the data is empty, return undefined because we couldn't
-    // pull info from the Arweave persistence layer.
-    if (!isDefined(persistedData) || persistedData.length < 1) {
-      return undefined;
+    const tag = this.getArweaveBundleDataClientKey(blockRangesForChains);
+    let data = await this.getPersistedArweaveTopicFromCache(tag);
+
+    if (!isDefined(data)) {
+      const persistedData = await this.clients.arweaveClient.getByTopic(tag, BundleDataSS);
+      // If there is no data or the data is empty, return undefined because we couldn't
+      // pull info from the Arweave persistence layer.
+      if (!isDefined(persistedData) || persistedData.length < 1) {
+        return undefined;
+      }
+      data = persistedData[0].data;
+      await this.backfillPersistedArweaveTopicCache(tag, data);
+    } else {
+      this.logger.debug({
+        at: "BundleDataClient#loadPersistedDataFromArweave",
+        message: "Loaded persisted bundle data from topic cache",
+        blockRanges: JSON.stringify(blockRangesForChains),
+        tag,
+      });
     }
 
     // A converter function to account for the fact that our SuperStruct schema does not support numeric
@@ -302,8 +364,6 @@ export class BundleDataClient {
       );
     };
 
-    const data = persistedData[0].data;
-
     // This section processes and transforms bundle data loaded from Arweave storage into the correct format:
     // 1. Each field (bundleFillsV3, expiredDepositsToRefundV3, etc.) contains nested records keyed by chainId and token
     // 2. The chainId keys are converted from strings to numbers using convertTypedStringRecordIntoNumericRecord
@@ -365,7 +425,10 @@ export class BundleDataClient {
     const arweaveKey = this.getArweaveBundleDataClientKey(blockRangesForChains);
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     if (!this.arweaveDataCache[arweaveKey]) {
-      this.arweaveDataCache[arweaveKey] = this.loadPersistedDataFromArweave(blockRangesForChains);
+      this.arweaveDataCache[arweaveKey] = this.loadPersistedDataFromArweave(blockRangesForChains).catch((error) => {
+        delete this.arweaveDataCache[arweaveKey];
+        throw error;
+      });
     }
     const arweaveData = _.cloneDeep(await this.arweaveDataCache[arweaveKey]);
     return arweaveData!;
@@ -384,7 +447,17 @@ export class BundleDataClient {
     if (!this.loadDataCache[key]) {
       let arweaveData;
       if (attemptArweaveLoad) {
-        arweaveData = await this.loadArweaveData(blockRangesForChains);
+        try {
+          arweaveData = await this.loadArweaveData(blockRangesForChains);
+        } catch (error) {
+          this.logger.warn({
+            at: "BundleDataClient#loadData",
+            message: "Failed to load bundle data from Arweave, falling back to on-chain reconstruction",
+            blockRanges: JSON.stringify(blockRangesForChains),
+            error: String(error),
+          });
+          arweaveData = undefined;
+        }
       } else {
         arweaveData = undefined;
       }

--- a/src/utils/CachingUtils.ts
+++ b/src/utils/CachingUtils.ts
@@ -54,3 +54,7 @@ export function getDepositKey(bridgeEvent: Deposit | Fill | SlowFillRequest): st
   const relayHash = getRelayEventKey(bridgeEvent);
   return `deposit_${bridgeEvent.originChainId}_${bridgeEvent.depositId.toString()}_${relayHash}`;
 }
+
+export function getArweaveTopicCacheKey(tag: string): string {
+  return `arweave-topic:${tag}`;
+}

--- a/test/BundleDataClient.cache.ts
+++ b/test/BundleDataClient.cache.ts
@@ -1,0 +1,92 @@
+import sinon from "sinon";
+import { expect, createSpyLogger } from "./utils";
+import { BundleDataClient } from "../src/clients/BundleDataClient";
+import { MemoryCacheClient } from "../src/caching";
+import { getArweaveTopicCacheKey } from "../src/caching/Arweave/ArweaveClient";
+
+describe("BundleDataClient Arweave cache behavior", () => {
+  const blockRanges = [[100, 123]];
+  const tag = `bundles-${BundleDataClient.getArweaveClientKey(blockRanges)}`;
+  const emptyPersistedBundle = {
+    bundleDepositsV3: {},
+    expiredDepositsToRefundV3: {},
+    bundleFillsV3: {},
+    unexecutableSlowFills: {},
+    bundleSlowFillsV3: {},
+  };
+  const emptyLoadDataResult = {
+    bundleDepositsV3: {},
+    expiredDepositsToRefundV3: {},
+    bundleFillsV3: {},
+    unexecutableSlowFills: {},
+    bundleSlowFillsV3: {},
+  };
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("should load persisted bundle data from the topic cache before querying Arweave", async () => {
+    const { spyLogger } = createSpyLogger();
+    const cache = new MemoryCacheClient();
+    const arweaveClient = { getByTopic: sinon.stub().rejects(new Error("should not query Arweave")) };
+    const bundleDataClient = new BundleDataClient(spyLogger, { arweaveClient } as any, {}, [], {}, cache);
+
+    await cache.set(getArweaveTopicCacheKey(tag), JSON.stringify(emptyPersistedBundle));
+
+    const result = await (bundleDataClient as any).loadPersistedDataFromArweave(blockRanges);
+
+    expect(result).to.deep.equal(emptyLoadDataResult);
+    expect(arweaveClient.getByTopic.called).to.be.false;
+  });
+
+  it("should backfill the topic cache after a successful Arweave read", async () => {
+    const { spyLogger } = createSpyLogger();
+    const cache = new MemoryCacheClient();
+    const arweaveClient = {
+      getByTopic: sinon.stub().resolves([{ data: emptyPersistedBundle, hash: "tx-1" }]),
+    };
+    const bundleDataClient = new BundleDataClient(spyLogger, { arweaveClient } as any, {}, [], {}, cache);
+
+    const result = await (bundleDataClient as any).loadPersistedDataFromArweave(blockRanges);
+    const cachedPayload = await cache.get<string>(getArweaveTopicCacheKey(tag));
+
+    expect(result).to.deep.equal(emptyLoadDataResult);
+    expect(JSON.parse(cachedPayload!)).to.deep.equal(emptyPersistedBundle);
+  });
+
+  it("should ignore malformed cached payloads and refresh from Arweave", async () => {
+    const { spyLogger } = createSpyLogger();
+    const cache = new MemoryCacheClient();
+    const arweaveClient = {
+      getByTopic: sinon.stub().resolves([{ data: emptyPersistedBundle, hash: "tx-2" }]),
+    };
+    const bundleDataClient = new BundleDataClient(spyLogger, { arweaveClient } as any, {}, [], {}, cache);
+
+    await cache.set(getArweaveTopicCacheKey(tag), '{"bundleDepositsV3":');
+
+    const result = await (bundleDataClient as any).loadPersistedDataFromArweave(blockRanges);
+
+    expect(result).to.deep.equal(emptyLoadDataResult);
+    expect(arweaveClient.getByTopic.calledOnce).to.be.true;
+  });
+
+  it("should fall back to on-chain reconstruction when the Arweave load throws", async () => {
+    const { spyLogger } = createSpyLogger();
+    const bundleDataClient = new BundleDataClient(spyLogger, {} as any, {}, [], {});
+    const expected = {
+      bundleDepositsV3: { 1: {} },
+      expiredDepositsToRefundV3: {},
+      bundleFillsV3: {},
+      unexecutableSlowFills: {},
+      bundleSlowFillsV3: {},
+    };
+
+    sinon.stub(bundleDataClient as any, "loadArweaveData").rejects(new Error("gateway timeout"));
+    sinon.stub(bundleDataClient as any, "loadDataFromScratch").resolves(expected);
+
+    const result = await bundleDataClient.loadData(blockRanges, {} as any, true);
+
+    expect(result).to.deep.equal(expected);
+  });
+});

--- a/test/BundleDataClient.cache.ts
+++ b/test/BundleDataClient.cache.ts
@@ -2,7 +2,7 @@ import sinon from "sinon";
 import { expect, createSpyLogger } from "./utils";
 import { BundleDataClient } from "../src/clients/BundleDataClient";
 import { MemoryCacheClient } from "../src/caching";
-import { getArweaveTopicCacheKey } from "../src/caching/Arweave/ArweaveClient";
+import { getArweaveTopicCacheKey } from "../src/utils";
 
 describe("BundleDataClient Arweave cache behavior", () => {
   const blockRanges = [[100, 123]];

--- a/test/arweaveClient.ts
+++ b/test/arweaveClient.ts
@@ -4,10 +4,12 @@ import { JWKInterface } from "arweave/node/lib/wallet";
 import { expect } from "chai";
 import { object, string } from "superstruct";
 import winston from "winston";
+import sinon from "sinon";
 import { ArweaveClient, ArweaveGatewayConfig } from "../src/caching";
 import { ARWEAVE_TAG_APP_NAME } from "../src/constants";
-import { fetchWithTimeout, toBN } from "../src/utils";
+import { HttpError, fetchWithTimeout, toBN } from "../src/utils";
 import { assertPromiseError } from "./utils";
+import { createSpyLogger } from "./utils";
 
 const INITIAL_FUNDING_AMNT = "5000000000";
 const LOCAL_ARWEAVE_GATEWAY: ArweaveGatewayConfig = {
@@ -56,6 +58,10 @@ describe("ArweaveClient", () => {
       }),
       [LOCAL_ARWEAVE_GATEWAY]
     );
+  });
+
+  afterEach(() => {
+    sinon.restore();
   });
 
   it(`should have ${INITIAL_FUNDING_AMNT} initial AR in the address`, async () => {
@@ -191,6 +197,139 @@ describe("ArweaveClient", () => {
       [LOCAL_ARWEAVE_GATEWAY]
     );
     await assertPromiseError(client.set({ test: "value" }), "You don't have enough tokens");
+  });
+
+  it("should fail over writes when the first gateway fails during transaction creation", async () => {
+    const { spyLogger } = createSpyLogger();
+    const client = new ArweaveClient(jwk, spyLogger, [LOCAL_ARWEAVE_GATEWAY, LOCAL_ARWEAVE_GATEWAY]);
+    const transaction = {
+      id: "tx-success",
+      addTag: sinon.stub(),
+    };
+    const createFirst = sinon.stub().rejects(new Error("Could not getPrice"));
+    const createSecond = sinon.stub().resolves(transaction);
+    const signSecond = sinon.stub().resolves();
+    const postSecond = sinon.stub().resolves({ status: 200 });
+
+    (client as any).gateways = [
+      {
+        url: "https://gateway-a",
+        client: {
+          createTransaction: createFirst,
+          transactions: { sign: sinon.stub(), post: sinon.stub() },
+        },
+      },
+      {
+        url: "https://gateway-b",
+        client: {
+          createTransaction: createSecond,
+          transactions: { sign: signSecond, post: postSecond },
+        },
+      },
+    ];
+
+    const result = await client.set({ test: "value" }, "topic-a");
+
+    expect(result).to.equal("tx-success");
+    expect(createFirst.called).to.be.true;
+    expect(createSecond.calledOnce).to.be.true;
+    expect(signSecond.calledOnce).to.be.true;
+    expect(postSecond.calledOnce).to.be.true;
+  });
+
+  it("should avoid error logs when a later gateway successfully posts the write", async () => {
+    const { spy, spyLogger } = createSpyLogger();
+    const client = new ArweaveClient(jwk, spyLogger, [LOCAL_ARWEAVE_GATEWAY, LOCAL_ARWEAVE_GATEWAY]);
+    const createTransaction = sinon.stub().resolves({
+      id: "tx-failover-success",
+      addTag: sinon.stub(),
+    });
+    const sign = sinon.stub().resolves();
+    const postFirst = sinon.stub().resolves({ status: 502, statusText: "Bad Gateway" });
+    const postSecond = sinon.stub().resolves({ status: 200 });
+
+    (client as any).gateways = [
+      {
+        url: "https://gateway-a",
+        client: {
+          createTransaction,
+          transactions: { sign, post: postFirst },
+        },
+      },
+      {
+        url: "https://gateway-b",
+        client: {
+          createTransaction,
+          transactions: { sign, post: postSecond },
+        },
+      },
+    ];
+
+    await client.set({ test: "value" }, "topic-b");
+
+    const errorLogs = spy.getCalls().filter((call) => call.lastArg.level === "error");
+    const successLog = spy
+      .getCalls()
+      .find((call) => call.lastArg.at === "ArweaveClient:set" && call.lastArg.gateway === "https://gateway-b");
+
+    expect(errorLogs).to.have.lengthOf(0);
+    expect(successLog?.lastArg.phase).to.equal("post");
+    expect(successLog?.lastArg.attempt).to.equal(2);
+  });
+
+  it("should emit one terminal error log when all gateways fail to write", async () => {
+    const { spy, spyLogger } = createSpyLogger();
+    const client = new ArweaveClient(jwk, spyLogger, [LOCAL_ARWEAVE_GATEWAY, LOCAL_ARWEAVE_GATEWAY]);
+
+    (client as any).gateways = [
+      {
+        url: "https://gateway-a",
+        client: {
+          createTransaction: sinon.stub().rejects(new Error("bad anchor")),
+          transactions: { sign: sinon.stub(), post: sinon.stub() },
+        },
+      },
+      {
+        url: "https://gateway-b",
+        client: {
+          createTransaction: sinon.stub().rejects(new Error("bad anchor")),
+          transactions: { sign: sinon.stub(), post: sinon.stub() },
+        },
+      },
+    ];
+
+    await assertPromiseError(client.set({ test: "value" }, "topic-c"), "All Arweave gateways failed for set");
+
+    const errorLogs = spy.getCalls().filter((call) => call.lastArg.level === "error");
+    expect(errorLogs).to.have.lengthOf(1);
+    expect(errorLogs[0].lastArg.at).to.equal("ArweaveClient:set");
+  });
+
+  it("should log 404 topic fetch failures at debug instead of warn", async () => {
+    const { spy, spyLogger } = createSpyLogger();
+    const client = new ArweaveClient(jwk, spyLogger, [LOCAL_ARWEAVE_GATEWAY]);
+    sinon
+      .stub(globalThis, "fetch")
+      .resolves(
+        new Response(JSON.stringify({ data: { transactions: { edges: [{ node: { id: "missing-tx" } }] } } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      );
+    sinon.stub(client, "get").rejects(new HttpError(404, "HTTP 404: Not Found"));
+
+    const result = await client.getByTopic("topic-404", object({ test: string() }));
+
+    const debugLogs = spy
+      .getCalls()
+      .filter((call) => call.lastArg.level === "debug" && call.lastArg.at === "ArweaveClient:getByTopic");
+    const warnLogs = spy
+      .getCalls()
+      .filter((call) => call.lastArg.level === "warn" && call.lastArg.at === "ArweaveClient:getByTopic");
+
+    expect(result).to.deep.equal([]);
+    expect(debugLogs.some((call) => call.lastArg.transactions?.includes("missing-tx"))).to.be.true;
+    expect(warnLogs).to.have.lengthOf(0);
   });
 
   after(async () => {


### PR DESCRIPTION
## Summary
- make Arweave writes fail over across the full `createTransaction -> sign -> post` lifecycle
- reduce write alert noise so only terminal failures log at `error`
- make bundle loading fall back to on-chain reconstruction when Arweave reads fail
- replace the GraphQL topic lookup transport with repo-owned HTTP logic and add topic-cache hooks for bundle payloads
- add targeted tests for write failover/logging and bundle topic-cache behavior

## Verification
- direct runtime smoke test against the modified SDK source passed
- the normal `yarn test` / Hardhat path is currently blocked in this environment by a pre-existing TypeScript config mismatch: `tsconfig.json` sets `"ignoreDeprecations": "6.0"` while the installed TypeScript is `5.9.2`

## Notes
- this PR adds the SDK-side support used by the paired relayer PR that seeds Redis topic cache entries from the Arweave writer