### PR TITLE
fix(arweave): harden write failover and logging

### DIFF
--- a/src/caching/Arweave/ArweaveClient.ts
+++ b/src/caching/Arweave/ArweaveClient.ts
@@ -29,6 +29,7 @@ interface Gateway {
 }
 
 type WritePhase = "createTransaction" | "sign" | "post";
+type ArweavePostResponse = Awaited<ReturnType<Arweave["transactions"]["post"]>>;
 
 class ArweaveWriteError extends Error {
   constructor(
@@ -183,7 +184,7 @@ export class ArweaveClient {
           signedTransaction = createdTransaction;
         }
 
-        let result;
+        let result: ArweavePostResponse;
         try {
           result = await client.transactions.post(signedTransaction);
         } catch (error) {

--- a/src/caching/Arweave/ArweaveClient.ts
+++ b/src/caching/Arweave/ArweaveClient.ts
@@ -4,7 +4,15 @@ import { JWKInterface } from "arweave/node/lib/wallet";
 import { Struct, create } from "superstruct";
 import winston from "winston";
 import { ARWEAVE_TAG_APP_NAME, ARWEAVE_TAG_APP_VERSION, DEFAULT_ARWEAVE_STORAGE_ADDRESS } from "../../constants";
-import { BigNumber, delay, fetchWithTimeout, isDefined, jsonReplacerWithBigNumbers, toBN } from "../../utils";
+import {
+  BigNumber,
+  delay,
+  fetchWithTimeout,
+  isDefined,
+  isHttpError,
+  jsonReplacerWithBigNumbers,
+  toBN,
+} from "../../utils";
 
 export interface ArweaveGatewayConfig {
   host: string;
@@ -17,6 +25,20 @@ export const DEFAULT_ARWEAVE_GATEWAYS: ArweaveGatewayConfig[] = [{ host: "arweav
 interface Gateway {
   client: Arweave;
   url: string;
+}
+
+type WritePhase = "createTransaction" | "sign" | "post";
+
+class ArweaveWriteError extends Error {
+  constructor(
+    message: string,
+    readonly phase: WritePhase,
+    readonly gateway: string,
+    readonly status?: number
+  ) {
+    super(message);
+    this.name = "ArweaveWriteError";
+  }
 }
 
 export class ArweaveClient {
@@ -69,16 +91,24 @@ export class ArweaveClient {
    * Tries gateways sequentially, returning the first successful response.
    * Used for write operations where we want exactly one successful submission.
    */
-  private async _failoverGateways<T>(label: string, fn: (gw: Gateway) => Promise<T>): Promise<T> {
+  private async _failoverGateways<T>(
+    label: string,
+    fn: (gw: Gateway, attempt: number) => Promise<T>,
+    shouldRetry: (error: unknown) => boolean = () => true
+  ): Promise<T> {
     const errors: Error[] = [];
-    for (const gw of this.gateways) {
+    for (const [index, gw] of this.gateways.entries()) {
       try {
-        return await this._retryRequest(() => fn(gw), 0);
+        return await this._retryRequest(() => fn(gw, index + 1), 0, shouldRetry);
       } catch (e) {
-        errors.push(e as Error);
+        const error = e instanceof Error ? e : new Error(String(e));
+        errors.push(error);
         this.logger.debug({
           at: "ArweaveClient:failoverGateways",
-          message: `Gateway ${gw.url} failed for ${label}, trying next: ${e}`,
+          message: `Gateway ${gw.url} failed for ${label}, trying next gateway`,
+          gateway: gw.url,
+          attempt: index + 1,
+          error: String(error),
         });
       }
     }
@@ -86,11 +116,15 @@ export class ArweaveClient {
     throw new Error(`All Arweave gateways failed for ${label}: ${details}`);
   }
 
-  private async _retryRequest<T>(request: () => Promise<T>, retryCount: number): Promise<T> {
+  private async _retryRequest<T>(
+    request: () => Promise<T>,
+    retryCount: number,
+    shouldRetry: (error: unknown) => boolean = () => true
+  ): Promise<T> {
     try {
       return await request();
     } catch (e) {
-      if (retryCount < this.retries) {
+      if (retryCount < this.retries && shouldRetry(e)) {
         // Implement a slightly aggressive exponential backoff to account for fierce parallelism.
         const baseDelay = this.retryDelaySeconds * Math.pow(2, retryCount);
         const delayS = baseDelay + baseDelay * Math.random();
@@ -107,6 +141,28 @@ export class ArweaveClient {
     }
   }
 
+  private _wrapWriteError(error: unknown, phase: WritePhase, gateway: string): ArweaveWriteError {
+    if (error instanceof ArweaveWriteError) {
+      return error;
+    }
+    if (isHttpError(error)) {
+      return new ArweaveWriteError(error.message, phase, gateway, error.status);
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return new ArweaveWriteError(message, phase, gateway);
+  }
+
+  private _isRetryableWriteError(error: unknown): boolean {
+    const status =
+      error instanceof ArweaveWriteError ? error.status : isHttpError(error) ? error.status : undefined;
+    if (status !== undefined) {
+      return status >= 500 || status === 408 || status === 429;
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    return !message.includes("You don't have enough tokens");
+  }
+
   /**
    * Stores an arbitrary record in the Arweave network. The record is stored as a JSON string and uses
    * JSON.stringify to convert the record to a string. The record has all of its big numbers converted
@@ -116,49 +172,65 @@ export class ArweaveClient {
    * @returns The transaction ID of the stored value
    */
   async set(value: Record<string, unknown>, topicTag?: string | undefined): Promise<string | undefined> {
-    // Get a template client to use for creating a transaction. Since clients are equal up to the gateway URL,
-    // it does not matter which gateway is used, so we just choose the first one.
-    const templateClient = this.gateways[0].client;
-    const transaction = await templateClient.createTransaction(
-      { data: JSON.stringify(value, jsonReplacerWithBigNumbers) },
-      this.arweaveJWT
-    );
+    const payload = JSON.stringify(value, jsonReplacerWithBigNumbers);
 
-    // Add tags to the transaction
-    transaction.addTag("Content-Type", "application/json");
-    transaction.addTag("App-Name", ARWEAVE_TAG_APP_NAME);
-    transaction.addTag("App-Version", ARWEAVE_TAG_APP_VERSION.toString());
-    if (isDefined(topicTag)) {
-      transaction.addTag("Topic", topicTag);
-    }
+    try {
+      return await this._failoverGateways(
+        "set",
+        async ({ client, url }, attempt) => {
+          let transaction;
+          try {
+            transaction = await client.createTransaction({ data: payload }, this.arweaveJWT);
+          } catch (error) {
+            throw this._wrapWriteError(error, "createTransaction", url);
+          }
 
-    // Sign the transaction
-    await templateClient.transactions.sign(transaction, this.arweaveJWT);
-    // Send the transaction
+          transaction.addTag("Content-Type", "application/json");
+          transaction.addTag("App-Name", ARWEAVE_TAG_APP_NAME);
+          transaction.addTag("App-Version", ARWEAVE_TAG_APP_VERSION.toString());
+          if (isDefined(topicTag)) {
+            transaction.addTag("Topic", topicTag);
+          }
 
-    return await this._failoverGateways("set", async ({ client }) => {
-      const result = await client.transactions.post(transaction);
+          try {
+            await client.transactions.sign(transaction, this.arweaveJWT);
+          } catch (error) {
+            throw this._wrapWriteError(error, "sign", url);
+          }
 
-      // Ensure that the result is successful
-      if (result.status !== 200) {
-        const message = result?.data?.error?.msg ?? "Unknown error";
-        this.logger.error({
-          at: "ArweaveClient:set",
-          message,
-          result,
-          txn: transaction.id,
-          address: await this.getAddress(),
-          balance: (await this.getBalance()).toString(),
-        });
-        throw new Error(message);
-      }
+          let result;
+          try {
+            result = await client.transactions.post(transaction);
+          } catch (error) {
+            throw this._wrapWriteError(error, "post", url);
+          }
 
-      this.logger.debug({
+          if (result.status !== 200) {
+            const message = result?.data?.error?.msg ?? result.statusText ?? `HTTP ${result.status}`;
+            throw new ArweaveWriteError(message, "post", url, result.status);
+          }
+
+          this.logger.debug({
+            at: "ArweaveClient:set",
+            message: `Arweave transaction posted with ${transaction.id}`,
+            gateway: url,
+            attempt,
+            phase: "post",
+            txn: transaction.id,
+          });
+          return transaction.id;
+        },
+        (error) => this._isRetryableWriteError(error)
+      );
+    } catch (error) {
+      this.logger.error({
         at: "ArweaveClient:set",
-        message: `Arweave transaction posted with ${transaction.id}`,
+        message: "Failed to persist data to Arweave after exhausting all gateways",
+        topicTag,
+        error: String(error),
       });
-      return transaction.id;
-    });
+      throw error;
+    }
   }
 
   /**

--- a/src/caching/Arweave/ArweaveClient.ts
+++ b/src/caching/Arweave/ArweaveClient.ts
@@ -27,6 +27,8 @@ interface Gateway {
   url: string;
 }
 
+type ArweaveTransaction = Parameters<Arweave["transactions"]["post"]>[0];
+
 type WritePhase = "createTransaction" | "sign" | "post";
 
 class ArweaveWriteError extends Error {
@@ -154,32 +156,37 @@ export class ArweaveClient {
    */
   async set(value: Record<string, unknown>, topicTag?: string | undefined): Promise<string | undefined> {
     const payload = JSON.stringify(value, jsonReplacerWithBigNumbers);
+    let signedTransaction: ArweaveTransaction | undefined;
 
     try {
       return await this._failoverGateways("set", async ({ client, url }, attempt) => {
-        let transaction;
-        try {
-          transaction = await client.createTransaction({ data: payload }, this.arweaveJWT);
-        } catch (error) {
-          throw this._wrapWriteError(error, "createTransaction", url);
-        }
+        if (!signedTransaction) {
+          let createdTransaction: ArweaveTransaction;
+          try {
+            createdTransaction = await client.createTransaction({ data: payload }, this.arweaveJWT);
+          } catch (error) {
+            throw this._wrapWriteError(error, "createTransaction", url);
+          }
 
-        transaction.addTag("Content-Type", "application/json");
-        transaction.addTag("App-Name", ARWEAVE_TAG_APP_NAME);
-        transaction.addTag("App-Version", ARWEAVE_TAG_APP_VERSION.toString());
-        if (isDefined(topicTag)) {
-          transaction.addTag("Topic", topicTag);
-        }
+          createdTransaction.addTag("Content-Type", "application/json");
+          createdTransaction.addTag("App-Name", ARWEAVE_TAG_APP_NAME);
+          createdTransaction.addTag("App-Version", ARWEAVE_TAG_APP_VERSION.toString());
+          if (isDefined(topicTag)) {
+            createdTransaction.addTag("Topic", topicTag);
+          }
 
-        try {
-          await client.transactions.sign(transaction, this.arweaveJWT);
-        } catch (error) {
-          throw this._wrapWriteError(error, "sign", url);
+          try {
+            await client.transactions.sign(createdTransaction, this.arweaveJWT);
+          } catch (error) {
+            throw this._wrapWriteError(error, "sign", url);
+          }
+
+          signedTransaction = createdTransaction;
         }
 
         let result;
         try {
-          result = await client.transactions.post(transaction);
+          result = await client.transactions.post(signedTransaction);
         } catch (error) {
           throw this._wrapWriteError(error, "post", url);
         }
@@ -191,13 +198,13 @@ export class ArweaveClient {
 
         this.logger.debug({
           at: "ArweaveClient:set",
-          message: `Arweave transaction posted with ${transaction.id}`,
+          message: `Arweave transaction posted with ${signedTransaction.id}`,
           gateway: url,
           attempt,
           phase: "post",
-          txn: transaction.id,
+          txn: signedTransaction.id,
         });
-        return transaction.id;
+        return signedTransaction.id;
       });
     } catch (error) {
       this.logger.error({

--- a/src/caching/Arweave/ArweaveClient.ts
+++ b/src/caching/Arweave/ArweaveClient.ts
@@ -1,4 +1,5 @@
 import Arweave from "arweave";
+import Transaction from "arweave/node/lib/transaction";
 import { JWKInterface } from "arweave/node/lib/wallet";
 
 import { Struct, create } from "superstruct";
@@ -26,8 +27,6 @@ interface Gateway {
   client: Arweave;
   url: string;
 }
-
-type ArweaveTransaction = Parameters<Arweave["transactions"]["post"]>[0];
 
 type WritePhase = "createTransaction" | "sign" | "post";
 
@@ -156,12 +155,12 @@ export class ArweaveClient {
    */
   async set(value: Record<string, unknown>, topicTag?: string | undefined): Promise<string | undefined> {
     const payload = JSON.stringify(value, jsonReplacerWithBigNumbers);
-    let signedTransaction: ArweaveTransaction | undefined;
+    let signedTransaction: Transaction | undefined;
 
     try {
       return await this._failoverGateways("set", async ({ client, url }, attempt) => {
         if (!signedTransaction) {
-          let createdTransaction: ArweaveTransaction;
+          let createdTransaction: Transaction;
           try {
             createdTransaction = await client.createTransaction({ data: payload }, this.arweaveJWT);
           } catch (error) {

--- a/src/caching/Arweave/ArweaveClient.ts
+++ b/src/caching/Arweave/ArweaveClient.ts
@@ -29,7 +29,6 @@ interface Gateway {
 }
 
 type WritePhase = "createTransaction" | "sign" | "post";
-type ArweavePostResponse = Awaited<ReturnType<Arweave["transactions"]["post"]>>;
 
 class ArweaveWriteError extends Error {
   constructor(
@@ -184,7 +183,7 @@ export class ArweaveClient {
           signedTransaction = createdTransaction;
         }
 
-        let result: ArweavePostResponse;
+        let result: Awaited<ReturnType<Arweave["transactions"]["post"]>>;
         try {
           result = await client.transactions.post(signedTransaction);
         } catch (error) {

--- a/src/caching/Arweave/ArweaveClient.ts
+++ b/src/caching/Arweave/ArweaveClient.ts
@@ -91,15 +91,11 @@ export class ArweaveClient {
    * Tries gateways sequentially, returning the first successful response.
    * Used for write operations where we want exactly one successful submission.
    */
-  private async _failoverGateways<T>(
-    label: string,
-    fn: (gw: Gateway, attempt: number) => Promise<T>,
-    shouldRetry: (error: unknown) => boolean = () => true
-  ): Promise<T> {
+  private async _failoverGateways<T>(label: string, fn: (gw: Gateway, attempt: number) => Promise<T>): Promise<T> {
     const errors: Error[] = [];
     for (const [index, gw] of this.gateways.entries()) {
       try {
-        return await this._retryRequest(() => fn(gw, index + 1), 0, shouldRetry);
+        return await this._retryRequest(() => fn(gw, index + 1), 0);
       } catch (e) {
         const error = e instanceof Error ? e : new Error(String(e));
         errors.push(error);
@@ -116,15 +112,11 @@ export class ArweaveClient {
     throw new Error(`All Arweave gateways failed for ${label}: ${details}`);
   }
 
-  private async _retryRequest<T>(
-    request: () => Promise<T>,
-    retryCount: number,
-    shouldRetry: (error: unknown) => boolean = () => true
-  ): Promise<T> {
+  private async _retryRequest<T>(request: () => Promise<T>, retryCount: number): Promise<T> {
     try {
       return await request();
     } catch (e) {
-      if (retryCount < this.retries && shouldRetry(e)) {
+      if (retryCount < this.retries) {
         // Implement a slightly aggressive exponential backoff to account for fierce parallelism.
         const baseDelay = this.retryDelaySeconds * Math.pow(2, retryCount);
         const delayS = baseDelay + baseDelay * Math.random();
@@ -152,17 +144,6 @@ export class ArweaveClient {
     return new ArweaveWriteError(message, phase, gateway);
   }
 
-  private _isRetryableWriteError(error: unknown): boolean {
-    const status =
-      error instanceof ArweaveWriteError ? error.status : isHttpError(error) ? error.status : undefined;
-    if (status !== undefined) {
-      return status >= 500 || status === 408 || status === 429;
-    }
-
-    const message = error instanceof Error ? error.message : String(error);
-    return !message.includes("You don't have enough tokens");
-  }
-
   /**
    * Stores an arbitrary record in the Arweave network. The record is stored as a JSON string and uses
    * JSON.stringify to convert the record to a string. The record has all of its big numbers converted
@@ -175,53 +156,49 @@ export class ArweaveClient {
     const payload = JSON.stringify(value, jsonReplacerWithBigNumbers);
 
     try {
-      return await this._failoverGateways(
-        "set",
-        async ({ client, url }, attempt) => {
-          let transaction;
-          try {
-            transaction = await client.createTransaction({ data: payload }, this.arweaveJWT);
-          } catch (error) {
-            throw this._wrapWriteError(error, "createTransaction", url);
-          }
+      return await this._failoverGateways("set", async ({ client, url }, attempt) => {
+        let transaction;
+        try {
+          transaction = await client.createTransaction({ data: payload }, this.arweaveJWT);
+        } catch (error) {
+          throw this._wrapWriteError(error, "createTransaction", url);
+        }
 
-          transaction.addTag("Content-Type", "application/json");
-          transaction.addTag("App-Name", ARWEAVE_TAG_APP_NAME);
-          transaction.addTag("App-Version", ARWEAVE_TAG_APP_VERSION.toString());
-          if (isDefined(topicTag)) {
-            transaction.addTag("Topic", topicTag);
-          }
+        transaction.addTag("Content-Type", "application/json");
+        transaction.addTag("App-Name", ARWEAVE_TAG_APP_NAME);
+        transaction.addTag("App-Version", ARWEAVE_TAG_APP_VERSION.toString());
+        if (isDefined(topicTag)) {
+          transaction.addTag("Topic", topicTag);
+        }
 
-          try {
-            await client.transactions.sign(transaction, this.arweaveJWT);
-          } catch (error) {
-            throw this._wrapWriteError(error, "sign", url);
-          }
+        try {
+          await client.transactions.sign(transaction, this.arweaveJWT);
+        } catch (error) {
+          throw this._wrapWriteError(error, "sign", url);
+        }
 
-          let result;
-          try {
-            result = await client.transactions.post(transaction);
-          } catch (error) {
-            throw this._wrapWriteError(error, "post", url);
-          }
+        let result;
+        try {
+          result = await client.transactions.post(transaction);
+        } catch (error) {
+          throw this._wrapWriteError(error, "post", url);
+        }
 
-          if (result.status !== 200) {
-            const message = result?.data?.error?.msg ?? result.statusText ?? `HTTP ${result.status}`;
-            throw new ArweaveWriteError(message, "post", url, result.status);
-          }
+        if (result.status !== 200) {
+          const message = result?.data?.error?.msg ?? result.statusText ?? `HTTP ${result.status}`;
+          throw new ArweaveWriteError(message, "post", url, result.status);
+        }
 
-          this.logger.debug({
-            at: "ArweaveClient:set",
-            message: `Arweave transaction posted with ${transaction.id}`,
-            gateway: url,
-            attempt,
-            phase: "post",
-            txn: transaction.id,
-          });
-          return transaction.id;
-        },
-        (error) => this._isRetryableWriteError(error)
-      );
+        this.logger.debug({
+          at: "ArweaveClient:set",
+          message: `Arweave transaction posted with ${transaction.id}`,
+          gateway: url,
+          attempt,
+          phase: "post",
+          txn: transaction.id,
+        });
+        return transaction.id;
+      });
     } catch (error) {
       this.logger.error({
         at: "ArweaveClient:set",

--- a/test/arweaveClient.ts
+++ b/test/arweaveClient.ts
@@ -8,8 +8,7 @@ import sinon from "sinon";
 import { ArweaveClient, ArweaveGatewayConfig } from "../src/caching";
 import { ARWEAVE_TAG_APP_NAME } from "../src/constants";
 import { fetchWithTimeout, toBN } from "../src/utils";
-import { assertPromiseError } from "./utils";
-import { createSpyLogger } from "./utils";
+import { assertPromiseError, createSpyLogger } from "./utils";
 
 const INITIAL_FUNDING_AMNT = "5000000000";
 const LOCAL_ARWEAVE_GATEWAY: ArweaveGatewayConfig = {
@@ -20,6 +19,28 @@ const LOCAL_ARWEAVE_GATEWAY: ArweaveGatewayConfig = {
 const LOCAL_ARWEAVE_URL = `${LOCAL_ARWEAVE_GATEWAY.protocol}://${LOCAL_ARWEAVE_GATEWAY.host}:${LOCAL_ARWEAVE_GATEWAY.port}`;
 
 const mineBlock = () => fetchWithTimeout(`${LOCAL_ARWEAVE_URL}/mine`, {}, {}, undefined, "text");
+type StubTransaction = {
+  id: string;
+  addTag: sinon.SinonStub;
+};
+
+type StubGateway = {
+  url: string;
+  client: {
+    createTransaction: sinon.SinonStub;
+    transactions: {
+      sign: sinon.SinonStub;
+      post: sinon.SinonStub;
+    };
+  };
+};
+
+function setStubGateways(client: ArweaveClient, gateways: StubGateway[]): void {
+  Object.defineProperty(client, "gateways", {
+    configurable: true,
+    value: gateways,
+  });
+}
 
 describe("ArweaveClient", () => {
   const arLocal = new ArLocal(LOCAL_ARWEAVE_GATEWAY.port as number, true);
@@ -202,7 +223,7 @@ describe("ArweaveClient", () => {
   it("should fail over writes when the first gateway fails during transaction creation", async () => {
     const { spyLogger } = createSpyLogger();
     const client = new ArweaveClient(jwk, spyLogger, [LOCAL_ARWEAVE_GATEWAY, LOCAL_ARWEAVE_GATEWAY]);
-    const transaction = {
+    const transaction: StubTransaction = {
       id: "tx-success",
       addTag: sinon.stub(),
     };
@@ -211,7 +232,7 @@ describe("ArweaveClient", () => {
     const signSecond = sinon.stub().resolves();
     const postSecond = sinon.stub().resolves({ status: 200 });
 
-    (client as any).gateways = [
+    setStubGateways(client, [
       {
         url: "https://gateway-a",
         client: {
@@ -226,7 +247,7 @@ describe("ArweaveClient", () => {
           transactions: { sign: signSecond, post: postSecond },
         },
       },
-    ];
+    ]);
 
     const result = await client.set({ test: "value" }, "topic-a");
 
@@ -248,7 +269,7 @@ describe("ArweaveClient", () => {
     const postFirst = sinon.stub().resolves({ status: 502, statusText: "Bad Gateway" });
     const postSecond = sinon.stub().resolves({ status: 200 });
 
-    (client as any).gateways = [
+    setStubGateways(client, [
       {
         url: "https://gateway-a",
         client: {
@@ -263,7 +284,7 @@ describe("ArweaveClient", () => {
           transactions: { sign, post: postSecond },
         },
       },
-    ];
+    ]);
 
     await client.set({ test: "value" }, "topic-b");
 
@@ -281,7 +302,7 @@ describe("ArweaveClient", () => {
     const { spy, spyLogger } = createSpyLogger();
     const client = new ArweaveClient(jwk, spyLogger, [LOCAL_ARWEAVE_GATEWAY, LOCAL_ARWEAVE_GATEWAY]);
 
-    (client as any).gateways = [
+    setStubGateways(client, [
       {
         url: "https://gateway-a",
         client: {
@@ -296,7 +317,7 @@ describe("ArweaveClient", () => {
           transactions: { sign: sinon.stub(), post: sinon.stub() },
         },
       },
-    ];
+    ]);
 
     await assertPromiseError(client.set({ test: "value" }, "topic-c"), "All Arweave gateways failed for set");
 

--- a/test/arweaveClient.ts
+++ b/test/arweaveClient.ts
@@ -4,10 +4,12 @@ import { JWKInterface } from "arweave/node/lib/wallet";
 import { expect } from "chai";
 import { object, string } from "superstruct";
 import winston from "winston";
+import sinon from "sinon";
 import { ArweaveClient, ArweaveGatewayConfig } from "../src/caching";
 import { ARWEAVE_TAG_APP_NAME } from "../src/constants";
 import { fetchWithTimeout, toBN } from "../src/utils";
 import { assertPromiseError } from "./utils";
+import { createSpyLogger } from "./utils";
 
 const INITIAL_FUNDING_AMNT = "5000000000";
 const LOCAL_ARWEAVE_GATEWAY: ArweaveGatewayConfig = {
@@ -56,6 +58,10 @@ describe("ArweaveClient", () => {
       }),
       [LOCAL_ARWEAVE_GATEWAY]
     );
+  });
+
+  afterEach(() => {
+    sinon.restore();
   });
 
   it(`should have ${INITIAL_FUNDING_AMNT} initial AR in the address`, async () => {
@@ -191,6 +197,112 @@ describe("ArweaveClient", () => {
       [LOCAL_ARWEAVE_GATEWAY]
     );
     await assertPromiseError(client.set({ test: "value" }), "You don't have enough tokens");
+  });
+
+  it("should fail over writes when the first gateway fails during transaction creation", async () => {
+    const { spyLogger } = createSpyLogger();
+    const client = new ArweaveClient(jwk, spyLogger, [LOCAL_ARWEAVE_GATEWAY, LOCAL_ARWEAVE_GATEWAY]);
+    const transaction = {
+      id: "tx-success",
+      addTag: sinon.stub(),
+    };
+    const createFirst = sinon.stub().rejects(new Error("Could not getPrice"));
+    const createSecond = sinon.stub().resolves(transaction);
+    const signSecond = sinon.stub().resolves();
+    const postSecond = sinon.stub().resolves({ status: 200 });
+
+    (client as any).gateways = [
+      {
+        url: "https://gateway-a",
+        client: {
+          createTransaction: createFirst,
+          transactions: { sign: sinon.stub(), post: sinon.stub() },
+        },
+      },
+      {
+        url: "https://gateway-b",
+        client: {
+          createTransaction: createSecond,
+          transactions: { sign: signSecond, post: postSecond },
+        },
+      },
+    ];
+
+    const result = await client.set({ test: "value" }, "topic-a");
+
+    expect(result).to.equal("tx-success");
+    expect(createFirst.called).to.be.true;
+    expect(createSecond.calledOnce).to.be.true;
+    expect(signSecond.calledOnce).to.be.true;
+    expect(postSecond.calledOnce).to.be.true;
+  });
+
+  it("should avoid error logs when a later gateway successfully posts the write", async () => {
+    const { spy, spyLogger } = createSpyLogger();
+    const client = new ArweaveClient(jwk, spyLogger, [LOCAL_ARWEAVE_GATEWAY, LOCAL_ARWEAVE_GATEWAY]);
+    const createTransaction = sinon.stub().resolves({
+      id: "tx-failover-success",
+      addTag: sinon.stub(),
+    });
+    const sign = sinon.stub().resolves();
+    const postFirst = sinon.stub().resolves({ status: 502, statusText: "Bad Gateway" });
+    const postSecond = sinon.stub().resolves({ status: 200 });
+
+    (client as any).gateways = [
+      {
+        url: "https://gateway-a",
+        client: {
+          createTransaction,
+          transactions: { sign, post: postFirst },
+        },
+      },
+      {
+        url: "https://gateway-b",
+        client: {
+          createTransaction,
+          transactions: { sign, post: postSecond },
+        },
+      },
+    ];
+
+    await client.set({ test: "value" }, "topic-b");
+
+    const errorLogs = spy.getCalls().filter((call) => call.lastArg.level === "error");
+    const successLog = spy
+      .getCalls()
+      .find((call) => call.lastArg.at === "ArweaveClient:set" && call.lastArg.gateway === "https://gateway-b");
+
+    expect(errorLogs).to.have.lengthOf(0);
+    expect(successLog?.lastArg.phase).to.equal("post");
+    expect(successLog?.lastArg.attempt).to.equal(2);
+  });
+
+  it("should emit one terminal error log when all gateways fail to write", async () => {
+    const { spy, spyLogger } = createSpyLogger();
+    const client = new ArweaveClient(jwk, spyLogger, [LOCAL_ARWEAVE_GATEWAY, LOCAL_ARWEAVE_GATEWAY]);
+
+    (client as any).gateways = [
+      {
+        url: "https://gateway-a",
+        client: {
+          createTransaction: sinon.stub().rejects(new Error("bad anchor")),
+          transactions: { sign: sinon.stub(), post: sinon.stub() },
+        },
+      },
+      {
+        url: "https://gateway-b",
+        client: {
+          createTransaction: sinon.stub().rejects(new Error("bad anchor")),
+          transactions: { sign: sinon.stub(), post: sinon.stub() },
+        },
+      },
+    ];
+
+    await assertPromiseError(client.set({ test: "value" }, "topic-c"), "All Arweave gateways failed for set");
+
+    const errorLogs = spy.getCalls().filter((call) => call.lastArg.level === "error");
+    expect(errorLogs).to.have.lengthOf(1);
+    expect(errorLogs[0].lastArg.at).to.equal("ArweaveClient:set");
   });
 
   after(async () => {

--- a/test/arweaveClient.ts
+++ b/test/arweaveClient.ts
@@ -222,7 +222,7 @@ describe("ArweaveClient", () => {
 
   it("should fail over writes when the first gateway fails during transaction creation", async () => {
     const { spyLogger } = createSpyLogger();
-    const client = new ArweaveClient(jwk, spyLogger, [LOCAL_ARWEAVE_GATEWAY, LOCAL_ARWEAVE_GATEWAY]);
+    const client = new ArweaveClient(jwk, spyLogger, [LOCAL_ARWEAVE_GATEWAY, LOCAL_ARWEAVE_GATEWAY], 0, 0);
     const transaction: StubTransaction = {
       id: "tx-success",
       addTag: sinon.stub(),
@@ -260,7 +260,7 @@ describe("ArweaveClient", () => {
 
   it("should avoid error logs when a later gateway successfully posts the write", async () => {
     const { spy, spyLogger } = createSpyLogger();
-    const client = new ArweaveClient(jwk, spyLogger, [LOCAL_ARWEAVE_GATEWAY, LOCAL_ARWEAVE_GATEWAY]);
+    const client = new ArweaveClient(jwk, spyLogger, [LOCAL_ARWEAVE_GATEWAY, LOCAL_ARWEAVE_GATEWAY], 0, 0);
     const createTransaction = sinon.stub().resolves({
       id: "tx-failover-success",
       addTag: sinon.stub(),
@@ -304,7 +304,7 @@ describe("ArweaveClient", () => {
 
   it("should emit one terminal error log when all gateways fail to write", async () => {
     const { spy, spyLogger } = createSpyLogger();
-    const client = new ArweaveClient(jwk, spyLogger, [LOCAL_ARWEAVE_GATEWAY, LOCAL_ARWEAVE_GATEWAY]);
+    const client = new ArweaveClient(jwk, spyLogger, [LOCAL_ARWEAVE_GATEWAY, LOCAL_ARWEAVE_GATEWAY], 0, 0);
 
     setStubGateways(client, [
       {

--- a/test/arweaveClient.ts
+++ b/test/arweaveClient.ts
@@ -293,6 +293,10 @@ describe("ArweaveClient", () => {
       .getCalls()
       .find((call) => call.lastArg.at === "ArweaveClient:set" && call.lastArg.gateway === "https://gateway-b");
 
+    expect(createTransaction.calledOnce).to.be.true;
+    expect(sign.calledOnce).to.be.true;
+    expect(postFirst.calledOnce).to.be.true;
+    expect(postSecond.calledOnce).to.be.true;
     expect(errorLogs).to.have.lengthOf(0);
     expect(successLog?.lastArg.phase).to.equal("post");
     expect(successLog?.lastArg.attempt).to.equal(2);


### PR DESCRIPTION
## Problem
`ArweaveClient.set()` sits on the write hot path for Arweave persistence. Before this change, only the final `post()` call participated in gateway failover. `createTransaction()` and `sign()` still ran against the first gateway client, so failures like price lookup, anchor fetch, signing errors, or upstream gateway failures could fail the write before failover started. The method also logged intermediate gateway failures at `error`, which made transient failover events look like terminal write failures.

## Solution
- wrap the full write lifecycle in sequential gateway failover: `createTransaction -> sign -> post`
- retry write attempts within each gateway before failing over to the next gateway
- preserve aggregated terminal errors after all gateways are exhausted
- emit `error` only for terminal write failure, while keeping successful failover writes visible in debug logs
- add focused write-path coverage for create-time failover, post-time failover, and terminal logging

## Scope
This PR is intentionally limited to write-path behavior in `ArweaveClient.set()` and its direct tests.