### PR TITLE
fix(arweave): harden topic reads and fallback

### DIFF
--- a/src/caching/Arweave/ArweaveClient.ts
+++ b/src/caching/Arweave/ArweaveClient.ts
@@ -4,7 +4,16 @@ import { JWKInterface } from "arweave/node/lib/wallet";
 import { Struct, create } from "superstruct";
 import winston from "winston";
 import { ARWEAVE_TAG_APP_NAME, ARWEAVE_TAG_APP_VERSION, DEFAULT_ARWEAVE_STORAGE_ADDRESS } from "../../constants";
-import { BigNumber, delay, fetchWithTimeout, isDefined, jsonReplacerWithBigNumbers, toBN } from "../../utils";
+import {
+  BigNumber,
+  delay,
+  fetchWithTimeout,
+  isDefined,
+  isHttpError,
+  jsonReplacerWithBigNumbers,
+  postWithTimeout,
+  toBN,
+} from "../../utils";
 
 export interface ArweaveGatewayConfig {
   host: string;
@@ -17,6 +26,14 @@ export const DEFAULT_ARWEAVE_GATEWAYS: ArweaveGatewayConfig[] = [{ host: "arweav
 interface Gateway {
   client: Arweave;
   url: string;
+}
+
+interface GraphQLTransactionsResponse {
+  data?: {
+    transactions?: {
+      edges?: { node: { id: string } }[];
+    };
+  };
 }
 
 export class ArweaveClient {
@@ -105,6 +122,14 @@ export class ArweaveClient {
         throw e;
       }
     }
+  }
+
+  private _isNotFoundError(error: unknown): boolean {
+    if (isHttpError(error)) {
+      return error.status === 404;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return message.includes("HTTP 404") || message.includes("404: Not Found");
   }
 
   /**
@@ -218,17 +243,11 @@ export class ArweaveClient {
       ) { edges { node { id } } }
     }`;
 
-    const response = await this._raceGateways("getByTopic", async ({ client }) => {
-      const response = await client.api.post<{
-        data: { transactions: { edges: { node: { id: string } }[] } };
-      }>("/graphql", { query });
-      if (!response.ok) {
-        throw new Error(`Arweave GraphQL request failed with status ${response.status}`);
-      }
-      return response;
+    const response = await this._raceGateways("getByTopic", async ({ url }) => {
+      return await postWithTimeout<GraphQLTransactionsResponse>(`${url}/graphql`, { query }, {}, {}, 20_000);
     });
 
-    const entries = response?.data?.data?.transactions?.edges ?? [];
+    const entries = response?.data?.transactions?.edges ?? [];
     this.logger.debug({
       at: "ArweaveClient:getByTopic",
       message: `Retrieved ${entries.length} matching transactions from Arweave`,
@@ -239,6 +258,7 @@ export class ArweaveClient {
         appVersion: ARWEAVE_TAG_APP_VERSION,
       },
     });
+    const failures: { hash: string; error: unknown }[] = [];
     const results = await Promise.all(
       entries.map(async (edge) => {
         try {
@@ -250,14 +270,35 @@ export class ArweaveClient {
               }
             : null;
         } catch (e) {
-          this.logger.warn({
-            at: "ArweaveClient:getByTopic",
-            message: `Bad request for Arweave topic ${edge.node.id}: ${e}`,
-          });
+          failures.push({ hash: edge.node.id, error: e });
           return null;
         }
       })
     );
+    const notFoundFailures = failures.filter(({ error }) => this._isNotFoundError(error));
+    const unexpectedFailures = failures.filter(({ error }) => !this._isNotFoundError(error));
+
+    if (notFoundFailures.length > 0) {
+      this.logger.debug({
+        at: "ArweaveClient:getByTopic",
+        message: `Skipped ${notFoundFailures.length} Arweave topic entries that were not yet available`,
+        tag,
+        transactions: notFoundFailures.map(({ hash }) => hash),
+      });
+    }
+
+    if (unexpectedFailures.length > 0) {
+      this.logger.warn({
+        at: "ArweaveClient:getByTopic",
+        message: `Failed to fetch ${unexpectedFailures.length} Arweave topic entries`,
+        tag,
+        failures: unexpectedFailures.map(({ hash, error }) => ({
+          hash,
+          error: String(error),
+        })),
+      });
+    }
+
     return results.filter(isDefined);
   }
 

--- a/src/caching/Arweave/ArweaveClient.ts
+++ b/src/caching/Arweave/ArweaveClient.ts
@@ -150,7 +150,7 @@ export class ArweaveClient {
     const message = error instanceof Error ? error.message : String(error);
     return /404/i.test(message);
   }
-  
+
   private _wrapWriteError(error: unknown, phase: WritePhase, gateway: string): ArweaveWriteError {
     if (error instanceof ArweaveWriteError) {
       return error;

--- a/src/caching/Arweave/ArweaveClient.ts
+++ b/src/caching/Arweave/ArweaveClient.ts
@@ -129,7 +129,7 @@ export class ArweaveClient {
       return error.status === 404;
     }
     const message = error instanceof Error ? error.message : String(error);
-    return message.includes("HTTP 404") || message.includes("404: Not Found");
+    return /404/i.test(message);
   }
 
   /**

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -385,7 +385,7 @@ export class BundleDataClient {
     const key = JSON.stringify(blockRangesForChains);
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     if (!this.loadDataCache[key]) {
-      let arweaveData;
+      let arweaveData: LoadDataReturnValue | undefined;
       if (attemptArweaveLoad) {
         try {
           arweaveData = await this.loadArweaveData(blockRangesForChains);
@@ -396,10 +396,7 @@ export class BundleDataClient {
             blockRanges: JSON.stringify(blockRangesForChains),
             error: String(error),
           });
-          arweaveData = undefined;
         }
-      } else {
-        arweaveData = undefined;
       }
       const data = isDefined(arweaveData)
         ? // We can return the data to a Promise to keep the return type consistent.

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -365,7 +365,10 @@ export class BundleDataClient {
     const arweaveKey = this.getArweaveBundleDataClientKey(blockRangesForChains);
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     if (!this.arweaveDataCache[arweaveKey]) {
-      this.arweaveDataCache[arweaveKey] = this.loadPersistedDataFromArweave(blockRangesForChains);
+      this.arweaveDataCache[arweaveKey] = this.loadPersistedDataFromArweave(blockRangesForChains).catch((error) => {
+        delete this.arweaveDataCache[arweaveKey];
+        throw error;
+      });
     }
     const arweaveData = _.cloneDeep(await this.arweaveDataCache[arweaveKey]);
     return arweaveData!;
@@ -384,7 +387,17 @@ export class BundleDataClient {
     if (!this.loadDataCache[key]) {
       let arweaveData;
       if (attemptArweaveLoad) {
-        arweaveData = await this.loadArweaveData(blockRangesForChains);
+        try {
+          arweaveData = await this.loadArweaveData(blockRangesForChains);
+        } catch (error) {
+          this.logger.warn({
+            at: "BundleDataClient#loadData",
+            message: "Failed to load bundle data from Arweave, falling back to on-chain reconstruction",
+            blockRanges: JSON.stringify(blockRangesForChains),
+            error: String(error),
+          });
+          arweaveData = undefined;
+        }
       } else {
         arweaveData = undefined;
       }

--- a/test/BundleDataClient.arweave.ts
+++ b/test/BundleDataClient.arweave.ts
@@ -1,0 +1,29 @@
+import sinon from "sinon";
+import { BundleDataClient } from "../src/clients/BundleDataClient";
+import { expect, createSpyLogger } from "./utils";
+
+describe("BundleDataClient Arweave fallback behavior", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("should fall back to on-chain reconstruction when the Arweave load throws", async () => {
+    const { spyLogger } = createSpyLogger();
+    const bundleDataClient = new BundleDataClient(spyLogger, {} as any, {}, [], {});
+    const blockRanges = [[100, 123]];
+    const expected = {
+      bundleDepositsV3: { 1: {} },
+      expiredDepositsToRefundV3: {},
+      bundleFillsV3: {},
+      unexecutableSlowFills: {},
+      bundleSlowFillsV3: {},
+    };
+
+    sinon.stub(bundleDataClient as any, "loadArweaveData").rejects(new Error("gateway timeout"));
+    sinon.stub(bundleDataClient as any, "loadDataFromScratch").resolves(expected);
+
+    const result = await bundleDataClient.loadData(blockRanges, {} as any, true);
+
+    expect(result).to.deep.equal(expected);
+  });
+});

--- a/test/BundleDataClient.arweave.ts
+++ b/test/BundleDataClient.arweave.ts
@@ -1,6 +1,24 @@
 import sinon from "sinon";
 import { BundleDataClient } from "../src/clients/BundleDataClient";
+import { AcrossConfigStoreClient, HubPoolClient } from "../src/clients";
+import { ArweaveClient } from "../src/caching";
+import { Clients, LoadDataReturnValue, SpokePoolClientsByChain } from "../src/interfaces";
 import { expect, createSpyLogger } from "./utils";
+
+function makeStubClients(): Clients {
+  return {
+    arweaveClient: Object.create(ArweaveClient.prototype) as ArweaveClient,
+    hubPoolClient: Object.create(HubPoolClient.prototype) as HubPoolClient,
+    configStoreClient: Object.create(AcrossConfigStoreClient.prototype) as AcrossConfigStoreClient,
+  };
+}
+
+function setHiddenMethod(target: object, key: string, value: unknown): void {
+  Object.defineProperty(target, key, {
+    configurable: true,
+    value,
+  });
+}
 
 describe("BundleDataClient Arweave fallback behavior", () => {
   afterEach(() => {
@@ -9,9 +27,10 @@ describe("BundleDataClient Arweave fallback behavior", () => {
 
   it("should fall back to on-chain reconstruction when the Arweave load throws", async () => {
     const { spyLogger } = createSpyLogger();
-    const bundleDataClient = new BundleDataClient(spyLogger, {} as any, {}, [], {});
+    const bundleDataClient = new BundleDataClient(spyLogger, makeStubClients(), {}, [], {});
     const blockRanges = [[100, 123]];
-    const expected = {
+    const spokePoolClients: SpokePoolClientsByChain = {};
+    const expected: LoadDataReturnValue = {
       bundleDepositsV3: { 1: {} },
       expiredDepositsToRefundV3: {},
       bundleFillsV3: {},
@@ -19,10 +38,10 @@ describe("BundleDataClient Arweave fallback behavior", () => {
       bundleSlowFillsV3: {},
     };
 
-    sinon.stub(bundleDataClient as any, "loadArweaveData").rejects(new Error("gateway timeout"));
-    sinon.stub(bundleDataClient as any, "loadDataFromScratch").resolves(expected);
+    setHiddenMethod(bundleDataClient, "loadArweaveData", sinon.stub().rejects(new Error("gateway timeout")));
+    setHiddenMethod(bundleDataClient, "loadDataFromScratch", sinon.stub().resolves(expected));
 
-    const result = await bundleDataClient.loadData(blockRanges, {} as any, true);
+    const result = await bundleDataClient.loadData(blockRanges, spokePoolClients, true);
 
     expect(result).to.deep.equal(expected);
   });

--- a/test/arweaveClient.ts
+++ b/test/arweaveClient.ts
@@ -8,8 +8,7 @@ import sinon from "sinon";
 import { ArweaveClient, ArweaveGatewayConfig } from "../src/caching";
 import { ARWEAVE_TAG_APP_NAME } from "../src/constants";
 import { HttpError, fetchWithTimeout, toBN } from "../src/utils";
-import { assertPromiseError } from "./utils";
-import { createSpyLogger } from "./utils";
+import { assertPromiseError, createSpyLogger } from "./utils";
 
 const INITIAL_FUNDING_AMNT = "5000000000";
 const LOCAL_ARWEAVE_GATEWAY: ArweaveGatewayConfig = {
@@ -202,14 +201,12 @@ describe("ArweaveClient", () => {
   it("should log 404 topic fetch failures at debug instead of warn", async () => {
     const { spy, spyLogger } = createSpyLogger();
     const client = new ArweaveClient(jwk, spyLogger, [LOCAL_ARWEAVE_GATEWAY]);
-    sinon
-      .stub(globalThis, "fetch")
-      .resolves(
-        new Response(JSON.stringify({ data: { transactions: { edges: [{ node: { id: "missing-tx" } }] } } }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        })
-      );
+    sinon.stub(globalThis, "fetch").resolves(
+      new Response(JSON.stringify({ data: { transactions: { edges: [{ node: { id: "missing-tx" } }] } } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    );
     sinon.stub(client, "get").rejects(new HttpError(404, "HTTP 404: Not Found"));
 
     const result = await client.getByTopic("topic-404", object({ test: string() }));

--- a/test/arweaveClient.ts
+++ b/test/arweaveClient.ts
@@ -4,10 +4,12 @@ import { JWKInterface } from "arweave/node/lib/wallet";
 import { expect } from "chai";
 import { object, string } from "superstruct";
 import winston from "winston";
+import sinon from "sinon";
 import { ArweaveClient, ArweaveGatewayConfig } from "../src/caching";
 import { ARWEAVE_TAG_APP_NAME } from "../src/constants";
-import { fetchWithTimeout, toBN } from "../src/utils";
+import { HttpError, fetchWithTimeout, toBN } from "../src/utils";
 import { assertPromiseError } from "./utils";
+import { createSpyLogger } from "./utils";
 
 const INITIAL_FUNDING_AMNT = "5000000000";
 const LOCAL_ARWEAVE_GATEWAY: ArweaveGatewayConfig = {
@@ -56,6 +58,10 @@ describe("ArweaveClient", () => {
       }),
       [LOCAL_ARWEAVE_GATEWAY]
     );
+  });
+
+  afterEach(() => {
+    sinon.restore();
   });
 
   it(`should have ${INITIAL_FUNDING_AMNT} initial AR in the address`, async () => {
@@ -191,6 +197,33 @@ describe("ArweaveClient", () => {
       [LOCAL_ARWEAVE_GATEWAY]
     );
     await assertPromiseError(client.set({ test: "value" }), "You don't have enough tokens");
+  });
+
+  it("should log 404 topic fetch failures at debug instead of warn", async () => {
+    const { spy, spyLogger } = createSpyLogger();
+    const client = new ArweaveClient(jwk, spyLogger, [LOCAL_ARWEAVE_GATEWAY]);
+    sinon
+      .stub(globalThis, "fetch")
+      .resolves(
+        new Response(JSON.stringify({ data: { transactions: { edges: [{ node: { id: "missing-tx" } }] } } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      );
+    sinon.stub(client, "get").rejects(new HttpError(404, "HTTP 404: Not Found"));
+
+    const result = await client.getByTopic("topic-404", object({ test: string() }));
+
+    const debugLogs = spy
+      .getCalls()
+      .filter((call) => call.lastArg.level === "debug" && call.lastArg.at === "ArweaveClient:getByTopic");
+    const warnLogs = spy
+      .getCalls()
+      .filter((call) => call.lastArg.level === "warn" && call.lastArg.at === "ArweaveClient:getByTopic");
+
+    expect(result).to.deep.equal([]);
+    expect(debugLogs.some((call) => call.lastArg.transactions?.includes("missing-tx"))).to.be.true;
+    expect(warnLogs).to.have.lengthOf(0);
   });
 
   after(async () => {

--- a/test/arweaveClient.ts
+++ b/test/arweaveClient.ts
@@ -244,7 +244,7 @@ describe("ArweaveClient", () => {
     expect(debugLogs.some((call) => call.lastArg.transactions?.includes("missing-tx"))).to.be.true;
     expect(warnLogs).to.have.lengthOf(0);
   });
-     
+
   it("should fail over writes when the first gateway fails during transaction creation", async () => {
     const { spyLogger } = createSpyLogger();
     const client = new ArweaveClient(jwk, spyLogger, [LOCAL_ARWEAVE_GATEWAY, LOCAL_ARWEAVE_GATEWAY], 0, 0);


### PR DESCRIPTION
## Problem
The Arweave read hot path was fragile in two places.

First, `ArweaveClient.getByTopic()` relied on the SDK GraphQL transport, which is where the `maxContentLength` / transport-style failures were occurring. It also logged expected per-entry `404` misses as warnings, which inflated noise during gateway propagation delays.

Second, `BundleDataClient.loadData()` treated Arweave-assisted reads too much like a dependency. If the Arweave path threw, the bundle load could fail instead of degrading cleanly to on-chain reconstruction.

## Solution
- replace topic GraphQL lookups with a repo-owned HTTP transport
- classify per-entry `404` topic misses as debug-level noise instead of warn-level failures
- summarize unexpected per-entry topic fetch failures instead of emitting one warning per miss
- clear rejected in-memory Arweave promises so a single failed lookup does not poison later attempts in the same process
- fall back to `loadDataFromScratch()` when the Arweave-assisted path throws
- add focused coverage for 404 classification and bundle-load fallback behavior

## Scope
This PR is limited to read-path hardening for `ArweaveClient.getByTopic()` and `BundleDataClient.loadData()`.