### PR TITLE
feat(cache): add Arweave topic cache for bundle data

### DIFF
--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
 import _ from "lodash";
+import { create } from "superstruct";
 import {
   SlowFillRequestWithBlock,
   SpokePoolClientsByChain,
@@ -16,6 +17,7 @@ import {
   FillWithBlock,
   Deposit,
   DepositWithBlock,
+  CachingMechanismInterface,
 } from "../../interfaces";
 import { SpokePoolClient } from "..";
 import { findFillEvent as findEvmFillEvent } from "../../arch/evm";
@@ -42,10 +44,13 @@ import {
   convertRelayDataParamsToBytes32,
   convertFillParamsToBytes32,
   chainIsTvm,
+  getArweaveTopicCacheKey,
+  jsonReplacerWithBigNumbers,
 } from "../../utils";
 import winston from "winston";
 import {
   BundleDataSS,
+  BundleData as PersistedArweaveBundleData,
   getRefundInformationFromFill,
   isChainDisabledAtBlock,
   isChainPaused,
@@ -56,7 +61,7 @@ import {
 } from "./utils";
 import { isEVMSpokePoolClient, isSVMSpokePoolClient } from "../SpokePoolClient";
 import { SpokePoolManager } from "../SpokePoolClient/SpokePoolClientManager";
-
+import { DEFAULT_CACHING_TTL } from "../../constants";
 type DataCache = Record<string, Promise<LoadDataReturnValue>>;
 
 // V3 dictionary helper functions
@@ -164,7 +169,8 @@ export class BundleDataClient {
     readonly clients: Clients,
     spokePoolClients: { [chainId: number]: SpokePoolClient },
     readonly chainIdListForBundleEvaluationBlockNumbers: number[],
-    readonly blockRangeEndBlockBuffer: { [chainId: number]: number } = {}
+    readonly blockRangeEndBlockBuffer: { [chainId: number]: number } = {},
+    readonly arweaveTopicCache?: CachingMechanismInterface
   ) {
     this.spokePoolClientManager = new SpokePoolManager(logger, spokePoolClients);
   }
@@ -204,6 +210,50 @@ export class BundleDataClient {
     return `bundles-${BundleDataClient.getArweaveClientKey(blockRangesForChains)}`;
   }
 
+  private async getPersistedArweaveTopicFromCache(tag: string): Promise<PersistedArweaveBundleData | undefined> {
+    if (!isDefined(this.arweaveTopicCache)) {
+      return undefined;
+    }
+
+    try {
+      const cachedPayload = await this.arweaveTopicCache.get<string>(getArweaveTopicCacheKey(tag));
+      if (!isDefined(cachedPayload)) {
+        return undefined;
+      }
+
+      return create(JSON.parse(cachedPayload), BundleDataSS);
+    } catch (error) {
+      this.logger.debug({
+        at: "BundleDataClient#getPersistedArweaveTopicFromCache",
+        message: "Failed to restore persisted bundle data from topic cache, falling back to Arweave",
+        tag,
+        error: String(error),
+      });
+      return undefined;
+    }
+  }
+
+  private async backfillPersistedArweaveTopicCache(tag: string, data: PersistedArweaveBundleData): Promise<void> {
+    if (!isDefined(this.arweaveTopicCache)) {
+      return;
+    }
+
+    try {
+      await this.arweaveTopicCache.set(
+        getArweaveTopicCacheKey(tag),
+        JSON.stringify(data, jsonReplacerWithBigNumbers),
+        DEFAULT_CACHING_TTL
+      );
+    } catch (error) {
+      this.logger.debug({
+        at: "BundleDataClient#backfillPersistedArweaveTopicCache",
+        message: "Failed to backfill persisted bundle data into topic cache",
+        tag,
+        error: String(error),
+      });
+    }
+  }
+
   private async loadPersistedDataFromArweave(
     blockRangesForChains: number[][]
   ): Promise<LoadDataReturnValue | undefined> {
@@ -211,14 +261,25 @@ export class BundleDataClient {
       return undefined;
     }
     const start = performance.now();
-    const persistedData = await this.clients.arweaveClient.getByTopic(
-      this.getArweaveBundleDataClientKey(blockRangesForChains),
-      BundleDataSS
-    );
-    // If there is no data or the data is empty, return undefined because we couldn't
-    // pull info from the Arweave persistence layer.
-    if (!isDefined(persistedData) || persistedData.length < 1) {
-      return undefined;
+    const tag = this.getArweaveBundleDataClientKey(blockRangesForChains);
+    let data = await this.getPersistedArweaveTopicFromCache(tag);
+
+    if (!isDefined(data)) {
+      const persistedData = await this.clients.arweaveClient.getByTopic(tag, BundleDataSS);
+      // If there is no data or the data is empty, return undefined because we couldn't
+      // pull info from the Arweave persistence layer.
+      if (!isDefined(persistedData) || persistedData.length < 1) {
+        return undefined;
+      }
+      data = persistedData[0].data;
+      await this.backfillPersistedArweaveTopicCache(tag, data);
+    } else {
+      this.logger.debug({
+        at: "BundleDataClient#loadPersistedDataFromArweave",
+        message: "Loaded persisted bundle data from topic cache",
+        blockRanges: JSON.stringify(blockRangesForChains),
+        tag,
+      });
     }
 
     // A converter function to account for the fact that our SuperStruct schema does not support numeric
@@ -301,8 +362,6 @@ export class BundleDataClient {
         ])
       );
     };
-
-    const data = persistedData[0].data;
 
     // This section processes and transforms bundle data loaded from Arweave storage into the correct format:
     // 1. Each field (bundleFillsV3, expiredDepositsToRefundV3, etc.) contains nested records keyed by chainId and token

--- a/src/utils/CachingUtils.ts
+++ b/src/utils/CachingUtils.ts
@@ -54,3 +54,7 @@ export function getDepositKey(bridgeEvent: Deposit | Fill | SlowFillRequest): st
   const relayHash = getRelayEventKey(bridgeEvent);
   return `deposit_${bridgeEvent.originChainId}_${bridgeEvent.depositId.toString()}_${relayHash}`;
 }
+
+export function getArweaveTopicCacheKey(tag: string): string {
+  return `arweave-topic:${tag}`;
+}

--- a/test/BundleDataClient.cache.ts
+++ b/test/BundleDataClient.cache.ts
@@ -1,0 +1,73 @@
+import sinon from "sinon";
+import { expect, createSpyLogger } from "./utils";
+import { BundleDataClient } from "../src/clients/BundleDataClient";
+import { MemoryCacheClient } from "../src/caching";
+import { getArweaveTopicCacheKey } from "../src/utils";
+
+describe("BundleDataClient Arweave cache behavior", () => {
+  const blockRanges = [[100, 123]];
+  const tag = `bundles-${BundleDataClient.getArweaveClientKey(blockRanges)}`;
+  const emptyPersistedBundle = {
+    bundleDepositsV3: {},
+    expiredDepositsToRefundV3: {},
+    bundleFillsV3: {},
+    unexecutableSlowFills: {},
+    bundleSlowFillsV3: {},
+  };
+  const emptyLoadDataResult = {
+    bundleDepositsV3: {},
+    expiredDepositsToRefundV3: {},
+    bundleFillsV3: {},
+    unexecutableSlowFills: {},
+    bundleSlowFillsV3: {},
+  };
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("should load persisted bundle data from the topic cache before querying Arweave", async () => {
+    const { spyLogger } = createSpyLogger();
+    const cache = new MemoryCacheClient();
+    const arweaveClient = { getByTopic: sinon.stub().rejects(new Error("should not query Arweave")) };
+    const bundleDataClient = new BundleDataClient(spyLogger, { arweaveClient } as any, {}, [], {}, cache);
+
+    await cache.set(getArweaveTopicCacheKey(tag), JSON.stringify(emptyPersistedBundle));
+
+    const result = await (bundleDataClient as any).loadPersistedDataFromArweave(blockRanges);
+
+    expect(result).to.deep.equal(emptyLoadDataResult);
+    expect(arweaveClient.getByTopic.called).to.be.false;
+  });
+
+  it("should backfill the topic cache after a successful Arweave read", async () => {
+    const { spyLogger } = createSpyLogger();
+    const cache = new MemoryCacheClient();
+    const arweaveClient = {
+      getByTopic: sinon.stub().resolves([{ data: emptyPersistedBundle, hash: "tx-1" }]),
+    };
+    const bundleDataClient = new BundleDataClient(spyLogger, { arweaveClient } as any, {}, [], {}, cache);
+
+    const result = await (bundleDataClient as any).loadPersistedDataFromArweave(blockRanges);
+    const cachedPayload = await cache.get<string>(getArweaveTopicCacheKey(tag));
+
+    expect(result).to.deep.equal(emptyLoadDataResult);
+    expect(JSON.parse(cachedPayload!)).to.deep.equal(emptyPersistedBundle);
+  });
+
+  it("should ignore malformed cached payloads and refresh from Arweave", async () => {
+    const { spyLogger } = createSpyLogger();
+    const cache = new MemoryCacheClient();
+    const arweaveClient = {
+      getByTopic: sinon.stub().resolves([{ data: emptyPersistedBundle, hash: "tx-2" }]),
+    };
+    const bundleDataClient = new BundleDataClient(spyLogger, { arweaveClient } as any, {}, [], {}, cache);
+
+    await cache.set(getArweaveTopicCacheKey(tag), '{"bundleDepositsV3":');
+
+    const result = await (bundleDataClient as any).loadPersistedDataFromArweave(blockRanges);
+
+    expect(result).to.deep.equal(emptyLoadDataResult);
+    expect(arweaveClient.getByTopic.calledOnce).to.be.true;
+  });
+});

--- a/test/BundleDataClient.cache.ts
+++ b/test/BundleDataClient.cache.ts
@@ -1,8 +1,26 @@
 import sinon from "sinon";
+import { Clients, LoadDataReturnValue } from "../src/interfaces";
 import { expect, createSpyLogger } from "./utils";
 import { BundleDataClient } from "../src/clients/BundleDataClient";
 import { MemoryCacheClient } from "../src/caching";
 import { getArweaveTopicCacheKey } from "../src/utils";
+
+type ArweaveClientTopicReader = Pick<Clients["arweaveClient"], "getByTopic">;
+
+type BundleDataClientTestAccess = BundleDataClient & {
+  loadPersistedDataFromArweave(blockRangesForChains: number[][]): Promise<LoadDataReturnValue | undefined>;
+};
+
+function makeClients(arweaveClient: ArweaveClientTopicReader): Clients {
+  return { arweaveClient: arweaveClient as unknown as Clients["arweaveClient"] } as unknown as Clients;
+}
+
+function loadPersistedDataFromArweave(
+  bundleDataClient: BundleDataClient,
+  blockRangesForChains: number[][]
+): Promise<LoadDataReturnValue | undefined> {
+  return (bundleDataClient as unknown as BundleDataClientTestAccess).loadPersistedDataFromArweave(blockRangesForChains);
+}
 
 describe("BundleDataClient Arweave cache behavior", () => {
   const blockRanges = [[100, 123]];
@@ -30,11 +48,11 @@ describe("BundleDataClient Arweave cache behavior", () => {
     const { spyLogger } = createSpyLogger();
     const cache = new MemoryCacheClient();
     const arweaveClient = { getByTopic: sinon.stub().rejects(new Error("should not query Arweave")) };
-    const bundleDataClient = new BundleDataClient(spyLogger, { arweaveClient } as any, {}, [], {}, cache);
+    const bundleDataClient = new BundleDataClient(spyLogger, makeClients(arweaveClient), {}, [], {}, cache);
 
     await cache.set(getArweaveTopicCacheKey(tag), JSON.stringify(emptyPersistedBundle));
 
-    const result = await (bundleDataClient as any).loadPersistedDataFromArweave(blockRanges);
+    const result = await loadPersistedDataFromArweave(bundleDataClient, blockRanges);
 
     expect(result).to.deep.equal(emptyLoadDataResult);
     expect(arweaveClient.getByTopic.called).to.be.false;
@@ -46,9 +64,9 @@ describe("BundleDataClient Arweave cache behavior", () => {
     const arweaveClient = {
       getByTopic: sinon.stub().resolves([{ data: emptyPersistedBundle, hash: "tx-1" }]),
     };
-    const bundleDataClient = new BundleDataClient(spyLogger, { arweaveClient } as any, {}, [], {}, cache);
+    const bundleDataClient = new BundleDataClient(spyLogger, makeClients(arweaveClient), {}, [], {}, cache);
 
-    const result = await (bundleDataClient as any).loadPersistedDataFromArweave(blockRanges);
+    const result = await loadPersistedDataFromArweave(bundleDataClient, blockRanges);
     const cachedPayload = await cache.get<string>(getArweaveTopicCacheKey(tag));
 
     expect(result).to.deep.equal(emptyLoadDataResult);
@@ -61,11 +79,11 @@ describe("BundleDataClient Arweave cache behavior", () => {
     const arweaveClient = {
       getByTopic: sinon.stub().resolves([{ data: emptyPersistedBundle, hash: "tx-2" }]),
     };
-    const bundleDataClient = new BundleDataClient(spyLogger, { arweaveClient } as any, {}, [], {}, cache);
+    const bundleDataClient = new BundleDataClient(spyLogger, makeClients(arweaveClient), {}, [], {}, cache);
 
     await cache.set(getArweaveTopicCacheKey(tag), '{"bundleDepositsV3":');
 
-    const result = await (bundleDataClient as any).loadPersistedDataFromArweave(blockRanges);
+    const result = await loadPersistedDataFromArweave(bundleDataClient, blockRanges);
 
     expect(result).to.deep.equal(emptyLoadDataResult);
     expect(arweaveClient.getByTopic.calledOnce).to.be.true;


### PR DESCRIPTION
## Problem
Even when persisted bundle data has already been materialized recently, the read hot path still has to query external Arweave gateways before it can reuse that payload. That adds latency and keeps `BundleDataClient` dependent on external gateway availability for repeated reads of the same bundle topic.

There was also no SDK-level helper for consistently naming and validating cached Arweave topic payloads.

## Solution
- add a reusable `getArweaveTopicCacheKey()` helper for Arweave topic cache entries
- extend `BundleDataClient` with an optional `arweaveTopicCache`
- check the topic cache before calling `getByTopic()`
- validate cached payloads with `BundleDataSS` before using them
- backfill the cache after a successful Arweave bundle read
- treat malformed cached payloads as cache misses and fall through to Arweave
- add focused cache coverage for cache hits, cache backfill, and malformed cache refresh

## Scope
This PR is limited to SDK-side bundle topic caching behavior in `BundleDataClient` and does not change Arweave gateway transport behavior.