### PR TITLE
fix(arweave): fetch transaction metadata directly

### DIFF
--- a/src/caching/Arweave/ArweaveClient.ts
+++ b/src/caching/Arweave/ArweaveClient.ts
@@ -29,6 +29,10 @@ interface ArweaveTransactionResponse {
 }
 
 function decodeBase64UrlUtf8(value: string): string {
+  // `/tx/{id}` returns tag names and values in RFC 4648 base64url form.
+  // Convert back to standard base64 alphabet, restore omitted `=` padding,
+  // then decode the bytes as UTF-8 so metadata parsing matches the SDK's
+  // `tag.get(..., { decode: true, string: true })` behavior.
   const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
   const padding = normalized.length % 4 === 0 ? "" : "=".repeat(4 - (normalized.length % 4));
   return Buffer.from(`${normalized}${padding}`, "base64").toString("utf-8");

--- a/src/caching/Arweave/ArweaveClient.ts
+++ b/src/caching/Arweave/ArweaveClient.ts
@@ -19,6 +19,21 @@ interface Gateway {
   url: string;
 }
 
+interface ArweaveTransactionTag {
+  name: string;
+  value: string;
+}
+
+interface ArweaveTransactionResponse {
+  tags?: ArweaveTransactionTag[];
+}
+
+function decodeBase64UrlUtf8(value: string): string {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = normalized.length % 4 === 0 ? "" : "=".repeat(4 - (normalized.length % 4));
+  return Buffer.from(`${normalized}${padding}`, "base64").toString("utf-8");
+}
+
 export class ArweaveClient {
   private gateways: Gateway[];
 
@@ -267,17 +282,14 @@ export class ArweaveClient {
    * @returns The metadata of the transaction if it exists, otherwise null
    */
   async getMetadata(transactionID: string): Promise<Record<string, string> | null> {
-    const transaction = await this._raceGateways("getMetadata", async ({ client }) => {
-      return await client.transactions.get(transactionID);
+    const transaction = await this._raceGateways("getMetadata", async ({ url }) => {
+      return await fetchWithTimeout<ArweaveTransactionResponse>(`${url}/tx/${transactionID}`, {}, {}, 20_000);
     });
     if (!isDefined(transaction)) {
       return null;
     }
     const tags = Object.fromEntries(
-      transaction.tags.map((tag) => [
-        tag.get("name", { decode: true, string: true }),
-        tag.get("value", { decode: true, string: true }),
-      ])
+      (transaction.tags ?? []).map((tag) => [decodeBase64UrlUtf8(tag.name), decodeBase64UrlUtf8(tag.value)])
     );
     return {
       contentType: tags["Content-Type"],

--- a/src/caching/Arweave/ArweaveClient.ts
+++ b/src/caching/Arweave/ArweaveClient.ts
@@ -30,12 +30,10 @@ interface ArweaveTransactionResponse {
 
 function decodeBase64UrlUtf8(value: string): string {
   // `/tx/{id}` returns tag names and values in RFC 4648 base64url form.
-  // Convert back to standard base64 alphabet, restore omitted `=` padding,
-  // then decode the bytes as UTF-8 so metadata parsing matches the SDK's
-  // `tag.get(..., { decode: true, string: true })` behavior.
-  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
-  const padding = normalized.length % 4 === 0 ? "" : "=".repeat(4 - (normalized.length % 4));
-  return Buffer.from(`${normalized}${padding}`, "base64").toString("utf-8");
+  // Node's built-in `base64url` decoder handles the URL-safe alphabet and
+  // omitted padding for us, so this matches the SDK's
+  // `tag.get(..., { decode: true, string: true })` behavior without a custom transform.
+  return Buffer.from(value, "base64url").toString("utf-8");
 }
 
 export class ArweaveClient {

--- a/test/arweaveClient.ts
+++ b/test/arweaveClient.ts
@@ -7,7 +7,7 @@ import winston from "winston";
 import { ArweaveClient, ArweaveGatewayConfig } from "../src/caching";
 import { ARWEAVE_TAG_APP_NAME } from "../src/constants";
 import { fetchWithTimeout, toBN } from "../src/utils";
-import { assertPromiseError } from "./utils";
+import { assertPromiseError, sinon } from "./utils";
 
 const INITIAL_FUNDING_AMNT = "5000000000";
 const LOCAL_ARWEAVE_GATEWAY: ArweaveGatewayConfig = {
@@ -56,6 +56,10 @@ describe("ArweaveClient", () => {
       }),
       [LOCAL_ARWEAVE_GATEWAY]
     );
+  });
+
+  afterEach(() => {
+    sinon.restore();
   });
 
   it(`should have ${INITIAL_FUNDING_AMNT} initial AR in the address`, async () => {
@@ -153,6 +157,34 @@ describe("ArweaveClient", () => {
       contentType: "application/json",
       appName: ARWEAVE_TAG_APP_NAME,
       topic: topicTag,
+    });
+  });
+
+  it("should fetch metadata from /tx/{id} and decode base64url tags", async () => {
+    const fetchStub = sinon.stub(globalThis, "fetch").resolves(
+      new Response(
+        JSON.stringify({
+          tags: [
+            { name: "Q29udGVudC1UeXBl", value: "YXBwbGljYXRpb24vanNvbg" },
+            { name: "QXBwLU5hbWU", value: "YWNyb3NzLXByb3RvY29s" },
+            { name: "VG9waWM", value: "dGVzdC10b3BpYw" },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }
+      )
+    );
+
+    const metadata = await client.getMetadata("test-tx-id");
+
+    expect(fetchStub.calledOnce).to.be.true;
+    expect(fetchStub.firstCall.args[0]).to.equal(`${LOCAL_ARWEAVE_URL}/tx/test-tx-id`);
+    expect(metadata).to.deep.equal({
+      contentType: "application/json",
+      appName: "across-protocol",
+      topic: "test-topic",
     });
   });
 

--- a/test/arweaveClient.ts
+++ b/test/arweaveClient.ts
@@ -8,7 +8,7 @@ import sinon from "sinon";
 import { ArweaveClient, ArweaveGatewayConfig } from "../src/caching";
 import { ARWEAVE_TAG_APP_NAME } from "../src/constants";
 import { fetchWithTimeout, toBN } from "../src/utils";
-import { assertPromiseError, sinon, createSpyLogger } from "./utils";
+import { assertPromiseError, createSpyLogger } from "./utils";
 
 const INITIAL_FUNDING_AMNT = "5000000000";
 const LOCAL_ARWEAVE_GATEWAY: ArweaveGatewayConfig = {


### PR DESCRIPTION
## Problem
`ArweaveClient.getMetadata()` currently goes through `client.transactions.get(transactionID)`. In the Arweave SDK, that path is heavier than it looks: for format-2 transactions with small enough payloads it can eagerly fall through into transaction data loading, even though this method only needs the transaction tags. That makes metadata reads more fragile than necessary and keeps them coupled to SDK transaction-loading behavior.

## Solution
- replace the SDK transaction fetch in `getMetadata()` with a repo-owned `fetchWithTimeout()` call to `GET /tx/{id}`
- decode the returned base64url tag names and values directly
- keep the public return shape unchanged: `contentType`, `appName`, and `topic`

## Verification
- `eslint src/caching/Arweave/ArweaveClient.ts`
- `prettier --check src/caching/Arweave/ArweaveClient.ts`
- attempted `hardhat test test/arweaveClient.ts`, but this environment still hits the unrelated local `viem/@noble/curves` runtime failure after compilation