### PR TITLE
improve(ArweaveClient): Change log level to `warn` for failure to write to Arweave

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.147",
+  "version": "4.3.148",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.145",
+  "version": "4.3.146",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/src/caching/Arweave/ArweaveClient.ts
+++ b/src/caching/Arweave/ArweaveClient.ts
@@ -240,7 +240,7 @@ export class ArweaveClient {
         return signedTransaction.id;
       });
     } catch (error) {
-      this.logger.error({
+      this.logger.warn({
         at: "ArweaveClient:set",
         message: "Failed to persist data to Arweave after exhausting all gateways",
         topicTag,

--- a/test/arweaveClient.ts
+++ b/test/arweaveClient.ts
@@ -355,7 +355,7 @@ describe("ArweaveClient", () => {
     expect(successLog?.lastArg.attempt).to.equal(2);
   });
 
-  it("should emit one terminal error log when all gateways fail to write", async () => {
+  it("should emit one terminal warn log when all gateways fail to write", async () => {
     const { spy, spyLogger } = createSpyLogger();
     const client = new ArweaveClient(jwk, spyLogger, [LOCAL_ARWEAVE_GATEWAY, LOCAL_ARWEAVE_GATEWAY], 0, 0);
 
@@ -378,9 +378,9 @@ describe("ArweaveClient", () => {
 
     await assertPromiseError(client.set({ test: "value" }, "topic-c"), "All Arweave gateways failed for set");
 
-    const errorLogs = spy.getCalls().filter((call) => call.lastArg.level === "error");
-    expect(errorLogs).to.have.lengthOf(1);
-    expect(errorLogs[0].lastArg.at).to.equal("ArweaveClient:set");
+    const warnLogs = spy.getCalls().filter((call) => call.lastArg.level === "warn");
+    expect(warnLogs).to.have.lengthOf(1);
+    expect(warnLogs[0].lastArg.at).to.equal("ArweaveClient:set");
   });
 
   after(async () => {


### PR DESCRIPTION
Writing to Arweave is not on the hot path (never has been) and we don't need to be paged about it.
