### PR TITLE
improve: add retry context to Arweave debug logs

### DIFF
--- a/src/caching/Arweave/ArweaveClient.ts
+++ b/src/caching/Arweave/ArweaveClient.ts
@@ -99,9 +99,7 @@ export class ArweaveClient {
    */
   private async _raceGateways<T>(label: string, fn: (gw: Gateway) => Promise<T>, topicTag?: string): Promise<T> {
     try {
-      return await Promise.any(
-        this.gateways.map((gw) => this._retryRequest(() => fn(gw), 0, label, gw.url, topicTag))
-      );
+      return await Promise.any(this.gateways.map((gw) => this._retryRequest(() => fn(gw), 0, label, gw.url, topicTag)));
     } catch (e) {
       if (e instanceof AggregateError) {
         const details = this.gateways.map((gw, i) => `${gw.url}: ${e.errors[i]}`).join("; ");
@@ -214,46 +212,46 @@ export class ArweaveClient {
             try {
               createdTransaction = await client.createTransaction({ data: payload }, this.arweaveJWT);
             } catch (error) {
-            throw this._wrapWriteError(error, "createTransaction", url);
+              throw this._wrapWriteError(error, "createTransaction", url);
+            }
+
+            createdTransaction.addTag("Content-Type", "application/json");
+            createdTransaction.addTag("App-Name", ARWEAVE_TAG_APP_NAME);
+            createdTransaction.addTag("App-Version", ARWEAVE_TAG_APP_VERSION.toString());
+            if (isDefined(topicTag)) {
+              createdTransaction.addTag("Topic", topicTag);
+            }
+
+            try {
+              await client.transactions.sign(createdTransaction, this.arweaveJWT);
+            } catch (error) {
+              throw this._wrapWriteError(error, "sign", url);
+            }
+
+            signedTransaction = createdTransaction;
           }
 
-          createdTransaction.addTag("Content-Type", "application/json");
-          createdTransaction.addTag("App-Name", ARWEAVE_TAG_APP_NAME);
-          createdTransaction.addTag("App-Version", ARWEAVE_TAG_APP_VERSION.toString());
-          if (isDefined(topicTag)) {
-            createdTransaction.addTag("Topic", topicTag);
-          }
-
+          let result: Awaited<ReturnType<Arweave["transactions"]["post"]>>;
           try {
-            await client.transactions.sign(createdTransaction, this.arweaveJWT);
+            result = await client.transactions.post(signedTransaction);
           } catch (error) {
-            throw this._wrapWriteError(error, "sign", url);
+            throw this._wrapWriteError(error, "post", url);
           }
 
-          signedTransaction = createdTransaction;
-        }
+          if (result.status !== 200) {
+            const message = result?.data?.error?.msg ?? result.statusText ?? `HTTP ${result.status}`;
+            throw new ArweaveWriteError(message, "post", url, result.status);
+          }
 
-        let result: Awaited<ReturnType<Arweave["transactions"]["post"]>>;
-        try {
-          result = await client.transactions.post(signedTransaction);
-        } catch (error) {
-          throw this._wrapWriteError(error, "post", url);
-        }
-
-        if (result.status !== 200) {
-          const message = result?.data?.error?.msg ?? result.statusText ?? `HTTP ${result.status}`;
-          throw new ArweaveWriteError(message, "post", url, result.status);
-        }
-
-        this.logger.debug({
-          at: "ArweaveClient:set",
-          message: `Arweave transaction posted with ${signedTransaction.id}`,
-          gateway: url,
-          attempt,
-          phase: "post",
-          txn: signedTransaction.id,
-        });
-        return signedTransaction.id;
+          this.logger.debug({
+            at: "ArweaveClient:set",
+            message: `Arweave transaction posted with ${signedTransaction.id}`,
+            gateway: url,
+            attempt,
+            phase: "post",
+            txn: signedTransaction.id,
+          });
+          return signedTransaction.id;
         },
         topicTag
       );

--- a/src/caching/Arweave/ArweaveClient.ts
+++ b/src/caching/Arweave/ArweaveClient.ts
@@ -5,16 +5,11 @@ import { JWKInterface } from "arweave/node/lib/wallet";
 import { Struct, create } from "superstruct";
 import winston from "winston";
 import { ARWEAVE_TAG_APP_NAME, ARWEAVE_TAG_APP_VERSION, DEFAULT_ARWEAVE_STORAGE_ADDRESS } from "../../constants";
-import {
-  BigNumber,
-  delay,
-  fetchWithTimeout,
-  isDefined,
-  isHttpError,
-  jsonReplacerWithBigNumbers,
-  postWithTimeout,
-  toBN,
-} from "../../utils";
+import { BigNumber, toBN } from "../../utils/BigNumberUtils";
+import { delay } from "../../utils/common";
+import { fetchWithTimeout, isHttpError, postWithTimeout } from "../../utils/FetchUtils";
+import { jsonReplacerWithBigNumbers } from "../../utils/JSONUtils";
+import { isDefined } from "../../utils/TypeGuards";
 
 export interface ArweaveGatewayConfig {
   host: string;
@@ -102,9 +97,11 @@ export class ArweaveClient {
    * Races a request across all gateways, returning the first successful response.
    * If all gateways fail, throws an error with details from each gateway.
    */
-  private async _raceGateways<T>(label: string, fn: (gw: Gateway) => Promise<T>): Promise<T> {
+  private async _raceGateways<T>(label: string, fn: (gw: Gateway) => Promise<T>, topicTag?: string): Promise<T> {
     try {
-      return await Promise.any(this.gateways.map((gw) => this._retryRequest(() => fn(gw), 0)));
+      return await Promise.any(
+        this.gateways.map((gw) => this._retryRequest(() => fn(gw), 0, label, gw.url, topicTag))
+      );
     } catch (e) {
       if (e instanceof AggregateError) {
         const details = this.gateways.map((gw, i) => `${gw.url}: ${e.errors[i]}`).join("; ");
@@ -118,11 +115,15 @@ export class ArweaveClient {
    * Tries gateways sequentially, returning the first successful response.
    * Used for write operations where we want exactly one successful submission.
    */
-  private async _failoverGateways<T>(label: string, fn: (gw: Gateway, attempt: number) => Promise<T>): Promise<T> {
+  private async _failoverGateways<T>(
+    label: string,
+    fn: (gw: Gateway, attempt: number) => Promise<T>,
+    topicTag?: string
+  ): Promise<T> {
     const errors: Error[] = [];
     for (const [index, gw] of this.gateways.entries()) {
       try {
-        return await this._retryRequest(() => fn(gw, index + 1), 0);
+        return await this._retryRequest(() => fn(gw, index + 1), 0, label, gw.url, topicTag);
       } catch (e) {
         const error = e instanceof Error ? e : new Error(String(e));
         errors.push(error);
@@ -139,7 +140,13 @@ export class ArweaveClient {
     throw new Error(`All Arweave gateways failed for ${label}: ${details}`);
   }
 
-  private async _retryRequest<T>(request: () => Promise<T>, retryCount: number): Promise<T> {
+  private async _retryRequest<T>(
+    request: () => Promise<T>,
+    retryCount: number,
+    label: string,
+    gateway: string,
+    topicTag?: string
+  ): Promise<T> {
     try {
       return await request();
     } catch (e) {
@@ -149,11 +156,18 @@ export class ArweaveClient {
         const delayS = baseDelay + baseDelay * Math.random();
         this.logger.debug({
           at: "ArweaveClient:retryRequest",
-          message: `Arweave request failed, retrying after waiting ${delayS} seconds: ${e}`,
+          message: `Arweave request failed, retrying after waiting ${delayS} seconds`,
+          label,
+          gateway,
+          topicTag,
           retryCount,
+          retryAttempt: retryCount + 1,
+          maxRetries: this.retries,
+          nextRetryDelaySeconds: delayS,
+          error: String(e),
         });
         await delay(delayS);
-        return this._retryRequest(request, retryCount + 1);
+        return this._retryRequest(request, retryCount + 1, label, gateway, topicTag);
       } else {
         throw e;
       }
@@ -192,12 +206,14 @@ export class ArweaveClient {
     let signedTransaction: Transaction | undefined;
 
     try {
-      return await this._failoverGateways("set", async ({ client, url }, attempt) => {
-        if (!signedTransaction) {
-          let createdTransaction: Transaction;
-          try {
-            createdTransaction = await client.createTransaction({ data: payload }, this.arweaveJWT);
-          } catch (error) {
+      return await this._failoverGateways(
+        "set",
+        async ({ client, url }, attempt) => {
+          if (!signedTransaction) {
+            let createdTransaction: Transaction;
+            try {
+              createdTransaction = await client.createTransaction({ data: payload }, this.arweaveJWT);
+            } catch (error) {
             throw this._wrapWriteError(error, "createTransaction", url);
           }
 
@@ -238,7 +254,9 @@ export class ArweaveClient {
           txn: signedTransaction.id,
         });
         return signedTransaction.id;
-      });
+        },
+        topicTag
+      );
     } catch (error) {
       this.logger.error({
         at: "ArweaveClient:set",
@@ -307,9 +325,13 @@ export class ArweaveClient {
       ) { edges { node { id } } }
     }`;
 
-    const response = await this._raceGateways("getByTopic", async ({ url }) => {
-      return await postWithTimeout<GraphQLTransactionsResponse>(`${url}/graphql`, { query }, {}, {}, 20_000);
-    });
+    const response = await this._raceGateways(
+      "getByTopic",
+      async ({ url }) => {
+        return await postWithTimeout<GraphQLTransactionsResponse>(`${url}/graphql`, { query }, {}, {}, 20_000);
+      },
+      tag
+    );
 
     const entries = response?.data?.transactions?.edges ?? [];
     this.logger.debug({

--- a/test/arweaveClient.ts
+++ b/test/arweaveClient.ts
@@ -5,10 +5,11 @@ import { expect } from "chai";
 import { object, string } from "superstruct";
 import winston from "winston";
 import sinon from "sinon";
-import { ArweaveClient, ArweaveGatewayConfig } from "../src/caching";
+import { ArweaveClient, ArweaveGatewayConfig } from "../src/caching/Arweave";
 import { ARWEAVE_TAG_APP_NAME } from "../src/constants";
-import { HttpError, fetchWithTimeout, toBN } from "../src/utils";
-import { assertPromiseError, createSpyLogger } from "./utils";
+import { toBN } from "../src/utils/BigNumberUtils";
+import { HttpError, fetchWithTimeout } from "../src/utils/FetchUtils";
+import { SpyTransport } from "./utils/SpyTransport";
 
 const INITIAL_FUNDING_AMNT = "5000000000";
 const LOCAL_ARWEAVE_GATEWAY: ArweaveGatewayConfig = {
@@ -40,6 +41,33 @@ function setStubGateways(client: ArweaveClient, gateways: StubGateway[]): void {
     configurable: true,
     value: gateways,
   });
+}
+
+async function assertPromiseError<T>(promise: Promise<T>, errMessage?: string): Promise<void> {
+  const specialErrorMessage = "Promise didn't fail";
+  try {
+    await promise;
+    throw new Error(specialErrorMessage);
+  } catch (e: unknown) {
+    const err = e as Error;
+    if (err.message.includes(specialErrorMessage)) {
+      throw err;
+    }
+    if (errMessage) {
+      expect(err.message).to.include(errMessage);
+    }
+  }
+}
+
+function createSpyLogger(): { spy: sinon.SinonSpy; spyLogger: winston.Logger } {
+  const spy = sinon.spy();
+  const spyLogger = winston.createLogger({
+    level: "debug",
+    format: winston.format.json(),
+    transports: [new SpyTransport({ level: "debug" }, { spy })],
+  });
+
+  return { spy, spyLogger };
 }
 
 describe("ArweaveClient", () => {
@@ -311,6 +339,49 @@ describe("ArweaveClient", () => {
     expect(postSecond.calledOnce).to.be.true;
   });
 
+  it("should include retry context when retrying a write on the same gateway", async () => {
+    const { spy, spyLogger } = createSpyLogger();
+    const client = new ArweaveClient(jwk, spyLogger, [LOCAL_ARWEAVE_GATEWAY], 1, 0);
+    const createTransaction = sinon.stub().resolves({
+      id: "tx-retry-context",
+      addTag: sinon.stub(),
+    });
+    const sign = sinon.stub().resolves();
+    const post = sinon.stub();
+    post.onFirstCall().resolves({ status: 502, statusText: "Bad Gateway" });
+    post.onSecondCall().resolves({ status: 200 });
+
+    setStubGateways(client, [
+      {
+        url: "https://gateway-a",
+        client: {
+          createTransaction,
+          transactions: { sign, post },
+        },
+      },
+    ]);
+
+    const result = await client.set({ test: "value" }, "topic-retry-write");
+
+    const retryLogs = spy
+      .getCalls()
+      .map((call) => call.lastArg)
+      .filter((log) => log.at === "ArweaveClient:retryRequest");
+
+    expect(result).to.equal("tx-retry-context");
+    expect(retryLogs).to.have.lengthOf(1);
+    expect(retryLogs[0]).to.include({
+      label: "set",
+      gateway: "https://gateway-a",
+      topicTag: "topic-retry-write",
+      retryCount: 0,
+      retryAttempt: 1,
+      maxRetries: 1,
+    });
+    expect(retryLogs[0].nextRetryDelaySeconds).to.equal(0);
+    expect(retryLogs[0].error).to.include("Bad Gateway");
+  });
+
   it("should avoid error logs when a later gateway successfully posts the write", async () => {
     const { spy, spyLogger } = createSpyLogger();
     const client = new ArweaveClient(jwk, spyLogger, [LOCAL_ARWEAVE_GATEWAY, LOCAL_ARWEAVE_GATEWAY], 0, 0);
@@ -353,6 +424,39 @@ describe("ArweaveClient", () => {
     expect(errorLogs).to.have.lengthOf(0);
     expect(successLog?.lastArg.phase).to.equal("post");
     expect(successLog?.lastArg.attempt).to.equal(2);
+  });
+
+  it("should include retry context when retrying topic reads", async () => {
+    const { spy, spyLogger } = createSpyLogger();
+    const client = new ArweaveClient(jwk, spyLogger, [LOCAL_ARWEAVE_GATEWAY], 1, 0);
+    const fetchStub = sinon.stub(globalThis, "fetch");
+    fetchStub.onFirstCall().rejects(new Error("fetch failed"));
+    fetchStub.onSecondCall().resolves(
+      new Response(JSON.stringify({ data: { transactions: { edges: [] } } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    );
+
+    const result = await client.getByTopic("topic-retry-read", object({ test: string() }));
+
+    const retryLogs = spy
+      .getCalls()
+      .map((call) => call.lastArg)
+      .filter((log) => log.at === "ArweaveClient:retryRequest");
+
+    expect(result).to.deep.equal([]);
+    expect(retryLogs).to.have.lengthOf(1);
+    expect(retryLogs[0]).to.include({
+      label: "getByTopic",
+      gateway: LOCAL_ARWEAVE_URL,
+      topicTag: "topic-retry-read",
+      retryCount: 0,
+      retryAttempt: 1,
+      maxRetries: 1,
+    });
+    expect(retryLogs[0].nextRetryDelaySeconds).to.equal(0);
+    expect(retryLogs[0].error).to.include("fetch failed");
   });
 
   it("should emit one terminal error log when all gateways fail to write", async () => {


### PR DESCRIPTION
## Summary
Adds retry context to `ArweaveClient` debug logs so Cloud Logging investigations can identify which operation retried, which gateway it retried against, and which topic tag was involved.

## What Changed
- Threaded retry context through `_raceGateways`, `_failoverGateways`, and `_retryRequest`
- Added `label`, `gateway`, `topicTag`, `retryAttempt`, `maxRetries`, and `nextRetryDelaySeconds` to `ArweaveClient:retryRequest` debug logs
- Added focused test coverage for retry-context logging on both write retries and `getByTopic` retries
- Kept the change observability-only with no behavior changes to failover or retry semantics

## Why
The existing retry logs were enough to reconstruct incidents, but they did not identify whether a retry came from `set`, `getByTopic`, or another operation, and they did not carry the relevant `topicTag`. That made GCP-only incident investigation slower than it needed to be.

## Impact
Operators can now filter Cloud Logging directly by operation and topic tag when investigating Arweave persistence issues, without reintroducing PagerDuty noise.

## Validation
- `yarn hardhat test test/arweaveClient.ts`
