### PR TITLE
fix(coingecko): URL-encode params and surface a typed price-not-found error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.153",
+  "version": "4.3.154",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/src/coingecko/Coingecko.ts
+++ b/src/coingecko/Coingecko.ts
@@ -1,6 +1,7 @@
 import assert from "assert";
 import { fetchWithTimeout, getCoingeckoTokenIdByAddress, retry } from "../utils";
 import { Logger } from "../relayFeeCalculator";
+import { CoingeckoPriceNotFoundError } from "./CoingeckoErrors";
 
 export function msToS(ms: number) {
   return Math.floor(ms / 1000);
@@ -206,7 +207,9 @@ export class Coingecko {
     const _from = msToS(from);
     const _to = msToS(to);
     const result = await this.call<HistoricPriceChartData>(
-      `coins/ethereum/contract/${contract.toLowerCase()}/market_chart/range/?vs_currency=${currency}&from=${_from}&to=${_to}`
+      `coins/ethereum/contract/${encodeURIComponent(
+        contract.toLowerCase()
+      )}/market_chart/range/?vs_currency=${encodeURIComponent(currency)}&from=${_from}&to=${_to}`
     );
     // fyi timestamps are returned in ms in contrast to the current price endpoint
     if (result.prices) return result.prices;
@@ -230,7 +233,7 @@ export class Coingecko {
     const coingeckoTokenIdentifier = await this.getCoingeckoTokenId(contractAddress, chainId);
     assert(date, "Requires date string");
     // Build the path for the Coingecko API request
-    const url = `coins/${coingeckoTokenIdentifier}/history`;
+    const url = `coins/${encodeURIComponent(coingeckoTokenIdentifier)}/history`;
     // Build the query parameters for the Coingecko API request
     const queryParams = {
       date,
@@ -244,7 +247,9 @@ export class Coingecko {
   }
 
   getContractDetails(contract_address: string, platform_id = "ethereum") {
-    return this.call(`coins/${platform_id}/contract/${contract_address.toLowerCase()}`);
+    return this.call(
+      `coins/${encodeURIComponent(platform_id)}/contract/${encodeURIComponent(contract_address.toLowerCase())}`
+    );
   }
 
   async getCurrentPriceByContract(contractAddress: string, currency = "usd", chainId = 1): Promise<[string, number]> {
@@ -256,7 +261,9 @@ export class Coingecko {
       tokenPrice = priceCache[contractAddress];
     }
 
-    assert(tokenPrice !== undefined);
+    if (tokenPrice === undefined) {
+      throw new CoingeckoPriceNotFoundError({ identifier: contractAddress, currency, lookupType: "address" });
+    }
     return [tokenPrice.timestamp.toString(), tokenPrice.price];
   }
 
@@ -268,22 +275,25 @@ export class Coingecko {
       const coingeckoId = await this.getCoingeckoTokenId(contractAddress, chainId);
       // Build the path for the Coingecko API request
       const result = await this.call<Record<string, CGTokenPrice>>(
-        `simple/price?ids=${coingeckoId}&vs_currencies=${currency}&include_last_updated_at=true`
+        `simple/price?ids=${encodeURIComponent(coingeckoId)}&vs_currencies=${encodeURIComponent(
+          currency
+        )}&include_last_updated_at=true`
       );
       const cgPrice = result?.[coingeckoId];
       if (cgPrice === undefined || !cgPrice?.[currency]) {
-        const errMsg = `No price found for ${coingeckoId}`;
         this.logger.debug({
           at: "Coingecko#getCurrentPriceById",
-          message: errMsg,
+          message: `No Coingecko price found for id '${coingeckoId}' in ${currency}`,
         });
-        throw new Error(errMsg);
+        throw new CoingeckoPriceNotFoundError({ identifier: coingeckoId, currency, lookupType: "id" });
       } else {
         this.updatePriceCache(cgPrice, contractAddress, currency, platform_id);
       }
     }
     tokenPrice = priceCache[contractAddress];
-    assert(tokenPrice !== undefined);
+    if (tokenPrice === undefined) {
+      throw new CoingeckoPriceNotFoundError({ identifier: contractAddress, currency, lookupType: "address" });
+    }
     return [tokenPrice.timestamp.toString(), tokenPrice.price];
   }
 
@@ -291,22 +301,25 @@ export class Coingecko {
     let tokenPrice = this.getCachedSymbolPrice(symbol, currency);
     if (tokenPrice === undefined) {
       const result = await this.call<Record<string, CGTokenPrice>>(
-        `simple/price?symbols=${symbol}&vs_currencies=${currency}&include_last_updated_at=true`
+        `simple/price?symbols=${encodeURIComponent(symbol)}&vs_currencies=${encodeURIComponent(
+          currency
+        )}&include_last_updated_at=true`
       );
       const cgPrice = result?.[symbol.toLowerCase()] || result?.[symbol.toUpperCase()];
       if (cgPrice === undefined || !cgPrice?.[currency]) {
-        const errMsg = `Failed to retrieve ${symbol}/${currency} price via Coingecko API`;
         this.logger.debug({
           at: "Coingecko#getCurrentPriceBySymbol",
-          message: errMsg,
+          message: `No Coingecko price found for symbol '${symbol}' in ${currency}`,
         });
-        throw new Error(errMsg);
+        throw new CoingeckoPriceNotFoundError({ identifier: symbol, currency, lookupType: "symbol" });
       } else {
         this.updatePriceCacheBySymbol(cgPrice, symbol, currency);
       }
     }
     tokenPrice = this.getCachedSymbolPrice(symbol, currency);
-    assert(tokenPrice !== undefined);
+    if (tokenPrice === undefined) {
+      throw new CoingeckoPriceNotFoundError({ identifier: symbol, currency, lookupType: "symbol" });
+    }
     return [tokenPrice.timestamp.toString(), tokenPrice.price];
   }
 
@@ -344,9 +357,9 @@ export class Coingecko {
     try {
       // Coingecko expects a comma-delimited (%2c) list.
       result = await this.call(
-        `simple/token_price/${platform_id}?contract_addresses=${contract_addresses.join(
-          "%2C"
-        )}&vs_currencies=${currency}&include_last_updated_at=true`
+        `simple/token_price/${encodeURIComponent(platform_id)}?contract_addresses=${contract_addresses
+          .map((addr) => encodeURIComponent(addr))
+          .join("%2C")}&vs_currencies=${encodeURIComponent(currency)}&include_last_updated_at=true`
       );
     } catch (err) {
       const errMsg = `Failed to retrieve ${platform_id}/${currency} prices (${err})`;

--- a/src/coingecko/CoingeckoErrors.ts
+++ b/src/coingecko/CoingeckoErrors.ts
@@ -1,0 +1,24 @@
+/**
+ * Thrown when a price lookup against the Coingecko API does not return a
+ * usable price for the requested identifier. Callers can use `instanceof` to
+ * map this to a 404 / not-found response without needing to string-match
+ * the underlying message.
+ */
+export type CoingeckoLookupType = "symbol" | "address" | "id";
+
+export class CoingeckoPriceNotFoundError extends Error {
+  readonly identifier: string;
+  readonly currency: string;
+  readonly lookupType: CoingeckoLookupType;
+
+  constructor(args: { identifier: string; currency: string; lookupType: CoingeckoLookupType; cause?: unknown }) {
+    super(
+      `No Coingecko price found for ${args.lookupType} '${args.identifier}' in ${args.currency}`,
+      args.cause !== undefined ? { cause: args.cause } : undefined
+    );
+    this.name = "CoingeckoPriceNotFoundError";
+    this.identifier = args.identifier;
+    this.currency = args.currency;
+    this.lookupType = args.lookupType;
+  }
+}

--- a/src/coingecko/index.ts
+++ b/src/coingecko/index.ts
@@ -1,1 +1,2 @@
 export * from "./Coingecko";
+export * from "./CoingeckoErrors";

--- a/test/Coingecko.test.ts
+++ b/test/Coingecko.test.ts
@@ -1,0 +1,151 @@
+import winston from "winston";
+import { Coingecko, msToS } from "../src/coingecko/Coingecko";
+import { CoingeckoPriceNotFoundError } from "../src/coingecko/CoingeckoErrors";
+import { expect, sinon } from "./utils";
+
+// Bypass the singleton + protected constructor so each test gets isolated state.
+class TestGecko extends Coingecko {
+  public constructor(host: string, logger: winston.Logger) {
+    super(host, host, logger);
+  }
+}
+
+const silentLogger = winston.createLogger({
+  level: "error",
+  transports: [new winston.transports.Console({ silent: true })],
+});
+
+const HOST = "https://test.example";
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+describe("Coingecko", () => {
+  let cg: TestGecko;
+  let fetchStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    cg = new TestGecko(HOST, silentLogger);
+    fetchStub = sinon.stub(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("URL encoding (getCurrentPriceBySymbol)", () => {
+    it("does not change the URL for normal ASCII symbols", async () => {
+      fetchStub.resolves(jsonResponse({ usdc: { usd: 0.999, last_updated_at: msToS(Date.now()) } }));
+
+      await cg.getCurrentPriceBySymbol("USDC", "usd");
+
+      const calledUrl = fetchStub.firstCall.args[0] as string;
+      expect(calledUrl).to.include("symbols=USDC");
+      expect(calledUrl).to.include("vs_currencies=usd");
+      // No percent-escapes for purely ASCII alphanumeric inputs.
+      expect(calledUrl).to.not.include("%");
+    });
+
+    it("preserves '.' and '-' in symbols (USDC.e, USDH-SPOT) without encoding", async () => {
+      fetchStub.resolves(jsonResponse({}));
+
+      await cg.getCurrentPriceBySymbol("USDC.e", "usd").catch(() => undefined);
+      expect(fetchStub.firstCall.args[0] as string).to.include("symbols=USDC.e");
+
+      fetchStub.resetHistory();
+      fetchStub.resolves(jsonResponse({}));
+      await cg.getCurrentPriceBySymbol("USDH-SPOT", "usd").catch(() => undefined);
+      expect(fetchStub.firstCall.args[0] as string).to.include("symbols=USDH-SPOT");
+    });
+
+    it("percent-encodes non-ASCII symbols and reaches fetch (regression)", async () => {
+      // Pre-fix this would throw TypeError: Request path contains unescaped characters
+      // *before* fetch was ever called.
+      fetchStub.resolves(jsonResponse({}));
+
+      await cg.getCurrentPriceBySymbol("熊猫头", "usd").catch(() => undefined);
+
+      expect(fetchStub.calledOnce).to.equal(true);
+      const calledUrl = fetchStub.firstCall.args[0] as string;
+      expect(calledUrl).to.include("symbols=%E7%86%8A%E7%8C%AB%E5%A4%B4");
+    });
+
+    it("percent-encodes reserved characters in symbols", async () => {
+      fetchStub.resolves(jsonResponse({}));
+      await cg.getCurrentPriceBySymbol("BTC/USD", "usd").catch(() => undefined);
+      expect(fetchStub.firstCall.args[0] as string).to.include("symbols=BTC%2FUSD");
+    });
+  });
+
+  describe("CoingeckoPriceNotFoundError", () => {
+    it("throws when CG returns no entry for the symbol", async () => {
+      fetchStub.resolves(jsonResponse({}));
+
+      try {
+        await cg.getCurrentPriceBySymbol("UNKNOWN", "usd");
+        expect.fail("Expected CoingeckoPriceNotFoundError");
+      } catch (e) {
+        expect(e).to.be.instanceOf(CoingeckoPriceNotFoundError);
+        expect(e).to.be.instanceOf(Error);
+        const err = e as CoingeckoPriceNotFoundError;
+        expect(err.identifier).to.equal("UNKNOWN");
+        expect(err.currency).to.equal("usd");
+        expect(err.lookupType).to.equal("symbol");
+        expect(err.message).to.include("UNKNOWN");
+        expect(err.message).to.include("usd");
+      }
+    });
+
+    it("throws when CG returns the symbol but not the requested currency", async () => {
+      // CG has the token, just not in the requested vs_currency.
+      fetchStub.resolves(jsonResponse({ usdc: { eth: 0.0003, last_updated_at: 1000 } }));
+
+      try {
+        await cg.getCurrentPriceBySymbol("USDC", "usd");
+        expect.fail("Expected CoingeckoPriceNotFoundError");
+      } catch (e) {
+        expect(e).to.be.instanceOf(CoingeckoPriceNotFoundError);
+        expect((e as CoingeckoPriceNotFoundError).lookupType).to.equal("symbol");
+        expect((e as CoingeckoPriceNotFoundError).currency).to.equal("usd");
+      }
+    });
+
+    it("returns the price normally on a valid CG response (no behavior change)", async () => {
+      const ts = msToS(Date.now());
+      fetchStub.resolves(jsonResponse({ usdc: { usd: 0.9998, last_updated_at: ts } }));
+
+      const [timestamp, price] = await cg.getCurrentPriceBySymbol("USDC", "usd");
+      expect(price).to.equal(0.9998);
+      expect(timestamp).to.equal(ts.toString());
+    });
+  });
+
+  describe("CoingeckoPriceNotFoundError class", () => {
+    it("populates identifier, currency, and lookupType fields", () => {
+      const err = new CoingeckoPriceNotFoundError({
+        identifier: "USDC",
+        currency: "usd",
+        lookupType: "symbol",
+      });
+      expect(err.identifier).to.equal("USDC");
+      expect(err.currency).to.equal("usd");
+      expect(err.lookupType).to.equal("symbol");
+      expect(err.name).to.equal("CoingeckoPriceNotFoundError");
+      expect(err).to.be.instanceOf(Error);
+    });
+
+    it("preserves the cause when provided", () => {
+      const cause = new Error("upstream");
+      const err = new CoingeckoPriceNotFoundError({
+        identifier: "X",
+        currency: "usd",
+        lookupType: "id",
+        cause,
+      });
+      expect(err.cause).to.equal(cause);
+    });
+  });
+});

--- a/test/Coingecko.test.ts
+++ b/test/Coingecko.test.ts
@@ -1,6 +1,7 @@
 import winston from "winston";
 import { Coingecko, msToS } from "../src/coingecko/Coingecko";
 import { CoingeckoPriceNotFoundError } from "../src/coingecko/CoingeckoErrors";
+import { HttpError, isHttpError } from "../src/utils";
 import { expect, sinon } from "./utils";
 
 // Bypass the singleton + protected constructor so each test gets isolated state.
@@ -23,6 +24,37 @@ const jsonResponse = (body: unknown, status = 200): Response =>
     headers: { "content-type": "application/json" },
   });
 
+// Symbols that real callers (and prod logs) send. None of these contain
+// reserved URL characters — verifying they pass through `encodeURIComponent`
+// byte-identical is the regression guard that the encoding fix doesn't
+// silently change the wire format for the happy path.
+const PASSTHROUGH_SYMBOLS = [
+  // Common majors
+  "USDC",
+  "USDT",
+  "DAI",
+  "ETH",
+  "WETH",
+  "WBTC",
+  "USDE",
+  // Native / wrapped natives across chains
+  "MATIC",
+  "POL",
+  "SOL",
+  "ARB",
+  "OP",
+  // Stables and remappings actually exercised by quote-api
+  "USDC.e",
+  "USDH-SPOT",
+  "PATHUSD",
+  // Symbols seen failing in prod logs (ASCII — not the encoding bug, but
+  // the not-found path) — these must still hit fetch with the literal
+  // symbol so CG can answer authoritatively.
+  "CENT",
+];
+
+const PASSTHROUGH_CURRENCIES = ["usd", "eth", "sol", "btc"];
+
 describe("Coingecko", () => {
   let cg: TestGecko;
   let fetchStub: sinon.SinonStub;
@@ -37,37 +69,40 @@ describe("Coingecko", () => {
   });
 
   describe("URL encoding (getCurrentPriceBySymbol)", () => {
-    it("does not change the URL for normal ASCII symbols", async () => {
+    for (const symbol of PASSTHROUGH_SYMBOLS) {
+      it(`leaves '${symbol}' byte-identical in the request URL`, async () => {
+        // Stub returns a valid response so the call completes when CG knows
+        // the symbol, and an empty body when it doesn't — neither case
+        // should affect what URL was sent.
+        fetchStub.resolves(jsonResponse({}));
+        await cg.getCurrentPriceBySymbol(symbol, "usd").catch(() => undefined);
+        expect(fetchStub.calledOnce).to.equal(true);
+        const calledUrl = fetchStub.firstCall.args[0] as string;
+        expect(calledUrl).to.include(`symbols=${symbol}`);
+      });
+    }
+
+    for (const currency of PASSTHROUGH_CURRENCIES) {
+      it(`leaves currency '${currency}' byte-identical in the request URL`, async () => {
+        fetchStub.resolves(jsonResponse({}));
+        await cg.getCurrentPriceBySymbol("USDC", currency).catch(() => undefined);
+        const calledUrl = fetchStub.firstCall.args[0] as string;
+        expect(calledUrl).to.include(`vs_currencies=${currency}`);
+      });
+    }
+
+    it("emits no percent-escapes at all for purely alphanumeric inputs", async () => {
       fetchStub.resolves(jsonResponse({ usdc: { usd: 0.999, last_updated_at: msToS(Date.now()) } }));
-
       await cg.getCurrentPriceBySymbol("USDC", "usd");
-
       const calledUrl = fetchStub.firstCall.args[0] as string;
-      expect(calledUrl).to.include("symbols=USDC");
-      expect(calledUrl).to.include("vs_currencies=usd");
-      // No percent-escapes for purely ASCII alphanumeric inputs.
       expect(calledUrl).to.not.include("%");
     });
 
-    it("preserves '.' and '-' in symbols (USDC.e, USDH-SPOT) without encoding", async () => {
+    it("percent-encodes non-ASCII symbols and reaches fetch (regression: '熊猫头')", async () => {
+      // Pre-fix: Node's http would throw `Request path contains unescaped characters`
+      // *before* fetch was ever called — observed in prod for `?symbol=熊猫头`.
       fetchStub.resolves(jsonResponse({}));
-
-      await cg.getCurrentPriceBySymbol("USDC.e", "usd").catch(() => undefined);
-      expect(fetchStub.firstCall.args[0] as string).to.include("symbols=USDC.e");
-
-      fetchStub.resetHistory();
-      fetchStub.resolves(jsonResponse({}));
-      await cg.getCurrentPriceBySymbol("USDH-SPOT", "usd").catch(() => undefined);
-      expect(fetchStub.firstCall.args[0] as string).to.include("symbols=USDH-SPOT");
-    });
-
-    it("percent-encodes non-ASCII symbols and reaches fetch (regression)", async () => {
-      // Pre-fix this would throw TypeError: Request path contains unescaped characters
-      // *before* fetch was ever called.
-      fetchStub.resolves(jsonResponse({}));
-
       await cg.getCurrentPriceBySymbol("熊猫头", "usd").catch(() => undefined);
-
       expect(fetchStub.calledOnce).to.equal(true);
       const calledUrl = fetchStub.firstCall.args[0] as string;
       expect(calledUrl).to.include("symbols=%E7%86%8A%E7%8C%AB%E5%A4%B4");
@@ -80,16 +115,47 @@ describe("Coingecko", () => {
     });
   });
 
-  describe("CoingeckoPriceNotFoundError", () => {
-    it("throws when CG returns no entry for the symbol", async () => {
-      fetchStub.resolves(jsonResponse({}));
+  describe("URL encoding (getContractPrices)", () => {
+    const ETH_USDC = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+    const ETH_DAI = "0x6b175474e89094c44da98b954eedeac495271d0f";
 
+    it("does not encode hex contract addresses or standard platform ids", async () => {
+      fetchStub.resolves(jsonResponse({}));
+      await cg.getContractPrices([ETH_USDC, ETH_DAI], "usd", "ethereum").catch(() => undefined);
+      const calledUrl = fetchStub.firstCall.args[0] as string;
+      // Expect both addresses joined by the literal %2C separator (CG's own format),
+      // with no further percent-escapes anywhere in the path/query.
+      expect(calledUrl).to.include(`contract_addresses=${ETH_USDC}%2C${ETH_DAI}`);
+      expect(calledUrl).to.include("simple/token_price/ethereum?");
+      expect(calledUrl).to.include("vs_currencies=usd");
+    });
+
+    it("does not encode hyphenated platform ids (polygon-pos, arbitrum-one)", async () => {
+      for (const platform of ["polygon-pos", "arbitrum-one", "optimistic-ethereum", "base"]) {
+        fetchStub.resetHistory();
+        fetchStub.resolves(jsonResponse({}));
+        await cg.getContractPrices([ETH_USDC], "usd", platform).catch(() => undefined);
+        const calledUrl = fetchStub.firstCall.args[0] as string;
+        expect(calledUrl).to.include(`simple/token_price/${platform}?`);
+      }
+    });
+  });
+
+  describe("CoingeckoPriceNotFoundError vs upstream errors", () => {
+    // Callers (e.g. quote-api's handleErrorCondition) need to distinguish:
+    //   - "Coingecko has no price for this token"  -> 404 to the user
+    //   - "Coingecko / network is unhealthy"        -> 502 to the user
+    // Both used to surface as opaque thrown Errors. These tests pin down
+    // that the typed error is ONLY thrown for the not-found case.
+
+    it("throws CoingeckoPriceNotFoundError when CG returns no entry for the symbol", async () => {
+      fetchStub.resolves(jsonResponse({}));
       try {
         await cg.getCurrentPriceBySymbol("UNKNOWN", "usd");
         expect.fail("Expected CoingeckoPriceNotFoundError");
       } catch (e) {
         expect(e).to.be.instanceOf(CoingeckoPriceNotFoundError);
-        expect(e).to.be.instanceOf(Error);
+        expect(isHttpError(e)).to.equal(false);
         const err = e as CoingeckoPriceNotFoundError;
         expect(err.identifier).to.equal("UNKNOWN");
         expect(err.currency).to.equal("usd");
@@ -99,24 +165,74 @@ describe("Coingecko", () => {
       }
     });
 
-    it("throws when CG returns the symbol but not the requested currency", async () => {
+    it("throws CoingeckoPriceNotFoundError when CG omits the requested currency", async () => {
       // CG has the token, just not in the requested vs_currency.
-      fetchStub.resolves(jsonResponse({ usdc: { eth: 0.0003, last_updated_at: 1000 } }));
-
+      fetchStub.resolves(jsonResponse({ usdc: { eth: 0.0003, last_updated_at: msToS(Date.now()) } }));
       try {
         await cg.getCurrentPriceBySymbol("USDC", "usd");
         expect.fail("Expected CoingeckoPriceNotFoundError");
       } catch (e) {
         expect(e).to.be.instanceOf(CoingeckoPriceNotFoundError);
-        expect((e as CoingeckoPriceNotFoundError).lookupType).to.equal("symbol");
-        expect((e as CoingeckoPriceNotFoundError).currency).to.equal("usd");
+        expect(isHttpError(e)).to.equal(false);
+      }
+    });
+
+    it("propagates HttpError on CG 5xx — NOT CoingeckoPriceNotFoundError", async () => {
+      fetchStub.resolves(new Response(JSON.stringify({ error: "internal" }), { status: 500 }));
+      try {
+        await cg.getCurrentPriceBySymbol("USDC", "usd");
+        expect.fail("Expected HttpError");
+      } catch (e) {
+        expect(e).to.be.instanceOf(HttpError);
+        expect(e).to.not.be.instanceOf(CoingeckoPriceNotFoundError);
+        expect(isHttpError(e)).to.equal(true);
+        expect((e as HttpError).status).to.equal(500);
+      }
+    });
+
+    it("propagates HttpError on CG 429 (rate limit) — NOT CoingeckoPriceNotFoundError", async () => {
+      fetchStub.resolves(new Response(JSON.stringify({ error: "rate limited" }), { status: 429 }));
+      try {
+        await cg.getCurrentPriceBySymbol("USDC", "usd");
+        expect.fail("Expected HttpError");
+      } catch (e) {
+        expect(e).to.be.instanceOf(HttpError);
+        expect(e).to.not.be.instanceOf(CoingeckoPriceNotFoundError);
+        expect((e as HttpError).status).to.equal(429);
+      }
+    });
+
+    it("propagates network failure (fetch rejects) — NOT CoingeckoPriceNotFoundError", async () => {
+      const networkErr = new Error("ENOTFOUND test.example");
+      fetchStub.rejects(networkErr);
+      try {
+        await cg.getCurrentPriceBySymbol("USDC", "usd");
+        expect.fail("Expected fetch rejection to propagate");
+      } catch (e) {
+        expect(e).to.equal(networkErr);
+        expect(e).to.not.be.instanceOf(CoingeckoPriceNotFoundError);
+      }
+    });
+
+    it("propagates a parse error on a non-JSON CG response — NOT CoingeckoPriceNotFoundError", async () => {
+      fetchStub.resolves(
+        new Response("<html>upstream proxy error</html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        })
+      );
+      try {
+        await cg.getCurrentPriceBySymbol("USDC", "usd");
+        expect.fail("Expected a non-JSON parse error");
+      } catch (e) {
+        expect(e).to.be.instanceOf(Error);
+        expect(e).to.not.be.instanceOf(CoingeckoPriceNotFoundError);
       }
     });
 
     it("returns the price normally on a valid CG response (no behavior change)", async () => {
       const ts = msToS(Date.now());
       fetchStub.resolves(jsonResponse({ usdc: { usd: 0.9998, last_updated_at: ts } }));
-
       const [timestamp, price] = await cg.getCurrentPriceBySymbol("USDC", "usd");
       expect(price).to.equal(0.9998);
       expect(timestamp).to.equal(ts.toString());


### PR DESCRIPTION
## Summary

Two bugs in the Coingecko client surfaced as opaque 500s in `quote-api`'s `/api/coingecko`. Datadog traces:

```
Error: Request path contains unescaped characters     // symbol contained CJK chars
AssertionError [ERR_ASSERTION]: false == true         // assert(tokenPrice !== undefined) for unknown symbol
```

### Fixes

1. **URL encoding.** `encodeURIComponent` user-controlled URL components in all six fetch paths (`getCurrentPriceBySymbol`/`ById`/`ByContract`, `getContractPrices`, `getContractDetails`, `getHistoricContractPrices`, `getContractHistoricDayPrice`). No-op for every real identifier (alphanumeric + `.` + `-`); only encodes pathological inputs (CJK, `/`, `&`, `+`, …).

2. **`CoingeckoPriceNotFoundError`** carrying `{ identifier, currency, lookupType: "symbol" | "address" | "id" }`. Thrown from all three lookup variants, replacing the generic `throw new Error(...)` *and* the downstream `assert(tokenPrice !== undefined)`. Exported from the `coingecko` namespace so callers can `instanceof`-detect it and map to a 404 instead of a 500. **`HttpError` (5xx/429), network failures, and parse errors are deliberately not caught** — callers can distinguish "token has no price" from "Coingecko is unhealthy".

### Tests

`test/Coingecko.test.ts` — 34 tests, fully offline via `sinon.stub(globalThis, "fetch")`:

- **Encoding no-op** (parameterized): every common token (`USDC`/`USDT`/`DAI`/`ETH`/`WETH`/`WBTC`/`USDE`/`MATIC`/`POL`/`SOL`/`ARB`/`OP`/`USDC.e`/`USDH-SPOT`/`PATHUSD`/`CENT`) and currency (`usd`/`eth`/`sol`/`btc`) reaches fetch byte-identical. `getContractPrices` URLs also unchanged for hex addresses and hyphenated platform ids (`polygon-pos`, `arbitrum-one`, …).
- **Encoding active**: `熊猫头` → `%E7%86%8A%E7%8C%AB%E5%A4%B4`, `BTC/USD` → `BTC%2FUSD`, both reach fetch.
- **Error discrimination**: empty CG body and wrong-currency response throw `CoingeckoPriceNotFoundError`; CG 5xx/429 throw `HttpError`; `fetch` rejection propagates as-is; non-JSON throws generic `Error`. None of the upstream-error cases are `instanceof CoingeckoPriceNotFoundError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
