### PR TITLE
fix: Clamp SpokePool search to deploymentBlock

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.156",
+  "version": "4.3.157",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/src/clients/SpokePoolClient/EVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/EVMSpokePoolClient.ts
@@ -67,12 +67,9 @@ export class EVMSpokePoolClient extends SpokePoolClient {
   }
 
   public override getMaxFillDeadlineInRange(startBlock: number, endBlock: number): Promise<number> {
-    // Clamp startBlock to this SpokePool's activation block; state before
-    // that belongs to a prior contract and is not reachable from this instance.
-    const activationBlock = this.spokePoolAddress
-      ? this.hubPoolClient?.getSpokePoolActivationBlock(this.chainId, this.spokePoolAddress)
-      : undefined;
-    const effectiveStartBlock = Math.max(startBlock, activationBlock ?? 0);
+    // Clamp startBlock to the SpokePool's deployment block; reading state at
+    // an earlier block reverts because the contract did not yet exist.
+    const effectiveStartBlock = Math.max(startBlock, this.deploymentBlock);
 
     const maxFillDeadlineInRangeHandler = this.tvm ? getMaxFillDeadlineTvm : getMaxFillDeadline;
     return maxFillDeadlineInRangeHandler(this.spokePool, effectiveStartBlock, endBlock);

--- a/test/SpokePoolClient.findDeposits.ts
+++ b/test/SpokePoolClient.findDeposits.ts
@@ -214,11 +214,7 @@ describe("SpokePoolClient: Find Deposits", function () {
   describe("getMaxFillDeadlineInRange", function () {
     // Without the clamp, the EVM helper would call fillDeadlineBuffer({ blockTag: 0 })
     // against a contract that did not exist yet and revert.
-    it("clamps startBlock to the SpokePool activation block", async function () {
-      // MockHubPoolClient._update bypasses on-chain CrossChainContractsSet
-      // events, so seed the activation block directly.
-      hubPoolClient.setCrossChainContracts(originChainId, spokePool_1.address, spokePool1DeploymentBlock);
-
+    it("clamps startBlock to the SpokePool deployment block", async function () {
       const latestBlock = await spokePool_1.provider.getBlockNumber();
       const expected = Number(await spokePool_1.fillDeadlineBuffer());
 


### PR DESCRIPTION
The existing code clamped to a mainnet block; this doesn't work for an L2. This passes in test because a single chain pretends to be multiple chains.