### PR TITLE
fix: short-circuit Solana fallback on sendTransaction preflight failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.158",
+  "version": "4.3.159",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/src/providers/solana/utils.ts
+++ b/src/providers/solana/utils.ts
@@ -82,10 +82,7 @@ export function shouldFailImmediate(method: string, error: unknown): boolean {
       // No block at the requested slot. This may not be correct for blocks > 1 year old.
       return [SVM_SLOT_SKIPPED, SVM_LONG_TERM_STORAGE_SLOT_SKIPPED].includes(code);
     case "sendTransaction":
-      // Preflight simulates the tx against current chain state. A failure here is deterministic across
-      // providers: any other validator-backed RPC will simulate the same tx the same way and reject it
-      // for the same reason. Walking the rest of the fallback chain only succeeds when a provider
-      // bypasses preflight (e.g. skipPreflight), which lets objectively-broken txs land on chain.
+      // Preflight failures are deterministic across providers; falling back only succeeds on RPCs that skip preflight.
       return code === SVM_TRANSACTION_PREFLIGHT_FAILURE;
     default:
       return false;

--- a/src/providers/solana/utils.ts
+++ b/src/providers/solana/utils.ts
@@ -1,6 +1,11 @@
 import { RpcTransport } from "@solana/rpc-spec";
 import { SolanaRpcApi } from "@solana/kit";
-import { isSolanaError, SVM_SLOT_SKIPPED, SVM_LONG_TERM_STORAGE_SLOT_SKIPPED } from "../../arch/svm";
+import {
+  isSolanaError,
+  SVM_SLOT_SKIPPED,
+  SVM_LONG_TERM_STORAGE_SLOT_SKIPPED,
+  SVM_TRANSACTION_PREFLIGHT_FAILURE,
+} from "../../arch/svm";
 
 /**
  * This is the type we pass to define a Solana RPC request "task".
@@ -76,6 +81,12 @@ export function shouldFailImmediate(method: string, error: unknown): boolean {
     case "getBlockTime":
       // No block at the requested slot. This may not be correct for blocks > 1 year old.
       return [SVM_SLOT_SKIPPED, SVM_LONG_TERM_STORAGE_SLOT_SKIPPED].includes(code);
+    case "sendTransaction":
+      // Preflight simulates the tx against current chain state. A failure here is deterministic across
+      // providers: any other validator-backed RPC will simulate the same tx the same way and reject it
+      // for the same reason. Walking the rest of the fallback chain only succeeds when a provider
+      // bypasses preflight (e.g. skipPreflight), which lets objectively-broken txs land on chain.
+      return code === SVM_TRANSACTION_PREFLIGHT_FAILURE;
     default:
       return false;
   }

--- a/test/providers/solana/utils.test.ts
+++ b/test/providers/solana/utils.test.ts
@@ -2,9 +2,9 @@ import {
   SVM_LONG_TERM_STORAGE_SLOT_SKIPPED,
   SVM_SLOT_SKIPPED,
   SVM_TRANSACTION_PREFLIGHT_FAILURE,
-} from "../src/arch/svm/provider";
-import { shouldFailImmediate } from "../src/providers/solana/utils";
-import { expect } from "./utils";
+} from "../../../src/arch/svm/provider";
+import { shouldFailImmediate } from "../../../src/providers/solana/utils";
+import { expect } from "../../utils";
 
 const solanaError = (code: number, context: Record<string, unknown> = {}) => ({
   name: "SolanaError",

--- a/test/shouldFailImmediate.test.ts
+++ b/test/shouldFailImmediate.test.ts
@@ -1,0 +1,70 @@
+import {
+  SVM_LONG_TERM_STORAGE_SLOT_SKIPPED,
+  SVM_SLOT_SKIPPED,
+  SVM_TRANSACTION_PREFLIGHT_FAILURE,
+} from "../src/arch/svm/provider";
+import { shouldFailImmediate } from "../src/providers/solana/utils";
+import { expect } from "./utils";
+
+const solanaError = (code: number, context: Record<string, unknown> = {}) => ({
+  name: "SolanaError",
+  context: { __code: code, ...context },
+});
+
+describe("shouldFailImmediate", () => {
+  it("returns false for non-Solana errors", () => {
+    expect(shouldFailImmediate("sendTransaction", new Error("network down"))).to.be.false;
+    expect(shouldFailImmediate("getBlock", { foo: "bar" })).to.be.false;
+  });
+
+  describe("getBlock / getBlockTime", () => {
+    for (const method of ["getBlock", "getBlockTime"] as const) {
+      it(`${method}: short-circuits on SVM_SLOT_SKIPPED`, () => {
+        expect(shouldFailImmediate(method, solanaError(SVM_SLOT_SKIPPED))).to.be.true;
+      });
+
+      it(`${method}: short-circuits on SVM_LONG_TERM_STORAGE_SLOT_SKIPPED`, () => {
+        expect(shouldFailImmediate(method, solanaError(SVM_LONG_TERM_STORAGE_SLOT_SKIPPED))).to.be.true;
+      });
+
+      it(`${method}: does not short-circuit on other codes`, () => {
+        expect(shouldFailImmediate(method, solanaError(SVM_TRANSACTION_PREFLIGHT_FAILURE))).to.be.false;
+        expect(shouldFailImmediate(method, solanaError(-32000))).to.be.false;
+      });
+    }
+  });
+
+  describe("sendTransaction", () => {
+    it("short-circuits on preflight simulation failure", () => {
+      // Mirrors the production payload: outer SolanaError with __code = -32002 and a full
+      // preflight context (accounts, fee, logs, etc.).
+      const preflightError = solanaError(SVM_TRANSACTION_PREFLIGHT_FAILURE, {
+        accounts: null,
+        fee: null,
+        innerInstructions: null,
+        loadedAccountsDataSize: 0,
+        loadedAddresses: null,
+        logs: [],
+        postBalances: null,
+        postTokenBalances: null,
+        preBalances: null,
+        preTokenBalances: null,
+        replacementBlockhash: null,
+        returnData: null,
+        unitsConsumed: "0",
+      });
+      expect(shouldFailImmediate("sendTransaction", preflightError)).to.be.true;
+    });
+
+    it("does not short-circuit on other Solana errors", () => {
+      // E.g. transport-level errors should still walk the fallback chain.
+      expect(shouldFailImmediate("sendTransaction", solanaError(SVM_SLOT_SKIPPED))).to.be.false;
+      expect(shouldFailImmediate("sendTransaction", solanaError(-32000))).to.be.false;
+    });
+  });
+
+  it("returns false for unhandled methods", () => {
+    expect(shouldFailImmediate("getAccountInfo", solanaError(SVM_TRANSACTION_PREFLIGHT_FAILURE))).to.be.false;
+    expect(shouldFailImmediate("getSlot", solanaError(SVM_SLOT_SKIPPED))).to.be.false;
+  });
+});

--- a/test/shouldFailImmediate.test.ts
+++ b/test/shouldFailImmediate.test.ts
@@ -36,28 +36,10 @@ describe("shouldFailImmediate", () => {
 
   describe("sendTransaction", () => {
     it("short-circuits on preflight simulation failure", () => {
-      // Mirrors the production payload: outer SolanaError with __code = -32002 and a full
-      // preflight context (accounts, fee, logs, etc.).
-      const preflightError = solanaError(SVM_TRANSACTION_PREFLIGHT_FAILURE, {
-        accounts: null,
-        fee: null,
-        innerInstructions: null,
-        loadedAccountsDataSize: 0,
-        loadedAddresses: null,
-        logs: [],
-        postBalances: null,
-        postTokenBalances: null,
-        preBalances: null,
-        preTokenBalances: null,
-        replacementBlockhash: null,
-        returnData: null,
-        unitsConsumed: "0",
-      });
-      expect(shouldFailImmediate("sendTransaction", preflightError)).to.be.true;
+      expect(shouldFailImmediate("sendTransaction", solanaError(SVM_TRANSACTION_PREFLIGHT_FAILURE))).to.be.true;
     });
 
     it("does not short-circuit on other Solana errors", () => {
-      // E.g. transport-level errors should still walk the fallback chain.
       expect(shouldFailImmediate("sendTransaction", solanaError(SVM_SLOT_SKIPPED))).to.be.false;
       expect(shouldFailImmediate("sendTransaction", solanaError(-32000))).to.be.false;
     });


### PR DESCRIPTION
## Summary

- For \`sendTransaction\`, treat a JSON-RPC \`-32002\` (\`SVM_TRANSACTION_PREFLIGHT_FAILURE\`) error as terminal so \`QuorumFallbackSolanaRpcFactory\` stops walking the fallback chain (and \`RetrySolanaRpcFactory\` stops retrying within a provider).
- Adds a focused test suite \`test/shouldFailImmediate.test.ts\` covering existing \`getBlock\`/\`getBlockTime\` behavior plus the new \`sendTransaction\` case (with a payload mirroring the one observed in production).

## Why

A Solana spoke for the Across L2 executor (\`zion-across-l2-executor-solana\`) repeatedly hit the hub's 720s call timeout. Investigation traced this to the SDK's behavior in \`src/providers/solana/quorumFallbackRpcFactory.ts\`:

1. \`_getQuorum\` returns \`1\` for every method except \`getBlock\`/\`getBlockTime\`, so \`sendTransaction\` runs with \`requiredFactories.slice(0,1)\` and the remainder go into the sequential fallback chain inside \`tryWithFallback\`.
2. \`shouldFailImmediate\` only short-circuits for \`getBlock\`/\`getBlockTime\`. For \`sendTransaction\` it returns \`false\`, so every preflight rejection walks the full provider list — ~10–15s per tx in production with 5 providers and the retry layer's backoff on top of that.
3. The on-chain failures we observed (\`SystemError::AccountAlreadyInUse\` returned from the System Program inside \`InitializeInstructionParams\`) were objectively deterministic — every honest validator's preflight rejected them — and only landed on chain via the one provider in the bot's chain that effectively bypassed preflight. That preflight-bypassing provider was last in the order, so every tx paid the full fallback walk *and* still landed a confirmed-but-failed tx in a slot.

In short: walking the fallback chain on preflight failures cannot recover; it can only mask correct provider behavior with the one provider that skips simulation. The fix tells the SDK to stop on preflight failure so the application layer can either (a) refresh blockhash / fix state and retry with a new tx, or (b) surface a clear failure quickly. This also keeps the per-call cost bounded so long-running spoke flows fit inside their hub-call timeout.

## Behavior changes

- For \`sendTransaction\`:
  - \`QuorumFallbackSolanaRpcFactory\` no longer falls back to subsequent providers when the first provider's preflight rejects the tx with \`-32002\`. It throws the underlying error immediately.
  - \`RetrySolanaRpcFactory\` no longer retries within a single provider on \`-32002\`.
- All other methods (\`getBlock\`/\`getBlockTime\` + everything else) are unchanged.

## Test plan

- [x] \`yarn lint-check\` clean
- [x] \`yarn tsc --noEmit -p tsconfig.build.json\` clean
- [x] \`npx hardhat test test/shouldFailImmediate.test.ts test/isSolanaError.test.ts test/SvmGasPriceOracle.test.ts test/Solana.EventData.test.ts test/BigNumberUtils.test.ts test/providers.test.ts\` — 45 passing, including the new 10 cases
- [ ] CI green on this PR
- [ ] After merge: bot pickup + observe whether the executor spoke runs return inside 720s and whether on-chain \`Custom: 0\` failures on \`InitializeInstructionParams\` stop appearing for \`7EWJi5iv3r1nSje43TUdpUuViZvGPc4Ls9cKGbZtC9mZ\`

## Notes

- Out of scope but related: there's a leaked \`InstructionParams\` PDA (\`6D1RB6xn17rMBPUhAcXMstdS6bADKm9YtFXoGqJU6NDu\`) from a previous timed-out run that should be closed manually to unblock today's runs. The SDK fix alone won't clear that state; it just prevents the SDK from masking the failure and lets the bot's higher-level recovery path see it.
- The \`at:\` field in the QuorumFallback log message still hardcodes the old \`FallbackSolanaRpcFactory#...\` class name (the class was renamed). Left untouched here to keep this PR minimal; happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)