### PR TITLE
fix(providers): preserve Error prototype and cause across quorum failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.159",
+  "version": "4.3.160",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/src/providers/solana/quorumFallbackRpcFactory.ts
+++ b/src/providers/solana/quorumFallbackRpcFactory.ts
@@ -66,9 +66,12 @@ export class QuorumFallbackSolanaRpcFactory extends SolanaBaseRpcFactory {
               throw error;
             }
 
-            // If one RPC provider reverted, others likely will too. Skip them.
+            // If one RPC provider reverted, others likely will too. Skip them. Preserve the
+            // underlying RPC error (e.g. the SolanaError carrying the preflight `__code` and
+            // `__serverMessage`) on `cause` so downstream callers and error loggers can still
+            // surface it.
             if (quorumThreshold === 1 && shouldFailImmediate(method, error)) {
-              throw new Error(`RPC provider reverted for method ${method}`);
+              throw new Error(`RPC provider reverted for method ${method}`, { cause: error });
             }
 
             const currentFactory = factory.rpcFactory.clusterUrl;

--- a/src/providers/solana/quorumFallbackRpcFactory.ts
+++ b/src/providers/solana/quorumFallbackRpcFactory.ts
@@ -66,10 +66,7 @@ export class QuorumFallbackSolanaRpcFactory extends SolanaBaseRpcFactory {
               throw error;
             }
 
-            // If one RPC provider reverted, others likely will too. Skip them. Preserve the
-            // underlying RPC error (e.g. the SolanaError carrying the preflight `__code` and
-            // `__serverMessage`) on `cause` so downstream callers and error loggers can still
-            // surface it.
+            // If one RPC provider reverted, others likely will too. Skip them.
             if (quorumThreshold === 1 && shouldFailImmediate(method, error)) {
               throw new Error(`RPC provider reverted for method ${method}`, { cause: error });
             }

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -141,9 +141,21 @@ export function formatProviderError(provider: providers.StaticJsonRpcProvider, r
   return `Provider ${getOriginFromURL(provider.connection.url)} failed with error: ${rawErrorText}`;
 }
 
-export function createSendErrorWithMessage(message: string, sendError: Record<string, unknown>) {
-  const error = new Error(message);
-  return { ...sendError, ...error };
+/**
+ * Wraps an underlying RPC failure into a standard Error whose message is the caller's summary
+ * (which providers failed, which succeeded, etc.) and whose `cause` is the original rejection
+ * reason. Use this when surfacing a quorum/fallback failure: consumers can match on
+ * `instanceof Error`, read the wrapper context from `.message` / `.stack`, and traverse to the
+ * underlying RPC error via `.cause`.
+ *
+ * The previous implementation returned `{ ...sendError, ...new Error(message) }`, which silently
+ * stripped the Error prototype (so `instanceof Error` failed downstream) and -- because Error's
+ * own `message` / `stack` properties are non-enumerable -- discarded the wrapper message entirely.
+ * The net effect was an unintrospectable plain object propagating up through `throw`, which
+ * masked the underlying RPC failure shape from every caller and from every error logger.
+ */
+export function createSendErrorWithMessage(message: string, sendError: unknown): Error {
+  return new Error(message, { cause: sendError });
 }
 
 /**

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -141,19 +141,8 @@ export function formatProviderError(provider: providers.StaticJsonRpcProvider, r
   return `Provider ${getOriginFromURL(provider.connection.url)} failed with error: ${rawErrorText}`;
 }
 
-/**
- * Wraps an underlying RPC failure into a standard Error whose message is the caller's summary
- * (which providers failed, which succeeded, etc.) and whose `cause` is the original rejection
- * reason. Use this when surfacing a quorum/fallback failure: consumers can match on
- * `instanceof Error`, read the wrapper context from `.message` / `.stack`, and traverse to the
- * underlying RPC error via `.cause`.
- *
- * The previous implementation returned `{ ...sendError, ...new Error(message) }`, which silently
- * stripped the Error prototype (so `instanceof Error` failed downstream) and -- because Error's
- * own `message` / `stack` properties are non-enumerable -- discarded the wrapper message entirely.
- * The net effect was an unintrospectable plain object propagating up through `throw`, which
- * masked the underlying RPC failure shape from every caller and from every error logger.
- */
+// `{ cause }` keeps the wrapper an actual Error (was a spread-collapsed plain object) and keeps
+// the underlying rejection reason reachable for callers and loggers.
 export function createSendErrorWithMessage(message: string, sendError: unknown): Error {
   return new Error(message, { cause: sendError });
 }

--- a/test/providers/utils.test.ts
+++ b/test/providers/utils.test.ts
@@ -6,8 +6,6 @@ describe("createSendErrorWithMessage", () => {
 
   it("returns an actual Error instance", () => {
     const wrapped = createSendErrorWithMessage(wrapperMessage, new Error("inner"));
-    // Regression: previously returned a plain object via `{ ...sendError, ...new Error(message) }`,
-    // which failed downstream `instanceof Error` checks and degraded error logging.
     expect(wrapped).to.be.instanceOf(Error);
   });
 
@@ -24,18 +22,12 @@ describe("createSendErrorWithMessage", () => {
   });
 
   it("propagates non-Error rejection reasons on `cause`", () => {
-    // The rejection reasons fed in from `Promise.allSettled` need not be Error instances --
-    // e.g. SolanaError-like plain objects, primitives, etc. They must still survive on `.cause`.
     const reason = { name: "SolanaError", context: { __code: -32000, __serverMessage: "boom" } };
     const wrapped = createSendErrorWithMessage(wrapperMessage, reason);
     expect(wrapped.cause).to.equal(reason);
   });
 
   it("does not silently drop properties of an Error rejection reason", () => {
-    // The previous implementation spread `{ ...sendError, ...new Error(message) }`. Because
-    // Error's own `message`/`stack`/`name` are non-enumerable in V8, spreading them yielded
-    // `{}` -- which combined with a generic `new Error(...)` rejection reason produced a fully
-    // empty thrown object. Make sure we keep enough context to debug from now on.
     const inner = new Error("RPC provider reverted for method sendTransaction");
     const wrapped = createSendErrorWithMessage(wrapperMessage, inner);
     expect(wrapped.message).to.equal(wrapperMessage);

--- a/test/providers/utils.test.ts
+++ b/test/providers/utils.test.ts
@@ -12,7 +12,9 @@ describe("createSendErrorWithMessage", () => {
   it("preserves the wrapper message and stack", () => {
     const wrapped = createSendErrorWithMessage(wrapperMessage, new Error("inner"));
     expect(wrapped.message).to.equal(wrapperMessage);
-    expect(wrapped.stack).to.be.a("string").and.satisfy((stack: string) => stack.includes(wrapperMessage));
+    expect(wrapped.stack)
+      .to.be.a("string")
+      .and.satisfy((stack: string) => stack.includes(wrapperMessage));
   });
 
   it("propagates the underlying error on `cause`", () => {

--- a/test/providers/utils.test.ts
+++ b/test/providers/utils.test.ts
@@ -1,0 +1,44 @@
+import { createSendErrorWithMessage } from "../../src/providers/utils";
+import { expect } from "../utils";
+
+describe("createSendErrorWithMessage", () => {
+  const wrapperMessage = "Not enough providers succeeded.";
+
+  it("returns an actual Error instance", () => {
+    const wrapped = createSendErrorWithMessage(wrapperMessage, new Error("inner"));
+    // Regression: previously returned a plain object via `{ ...sendError, ...new Error(message) }`,
+    // which failed downstream `instanceof Error` checks and degraded error logging.
+    expect(wrapped).to.be.instanceOf(Error);
+  });
+
+  it("preserves the wrapper message and stack", () => {
+    const wrapped = createSendErrorWithMessage(wrapperMessage, new Error("inner"));
+    expect(wrapped.message).to.equal(wrapperMessage);
+    expect(wrapped.stack).to.be.a("string").and.satisfy((stack: string) => stack.includes(wrapperMessage));
+  });
+
+  it("propagates the underlying error on `cause`", () => {
+    const inner = new Error("inner");
+    const wrapped = createSendErrorWithMessage(wrapperMessage, inner);
+    expect(wrapped.cause).to.equal(inner);
+  });
+
+  it("propagates non-Error rejection reasons on `cause`", () => {
+    // The rejection reasons fed in from `Promise.allSettled` need not be Error instances --
+    // e.g. SolanaError-like plain objects, primitives, etc. They must still survive on `.cause`.
+    const reason = { name: "SolanaError", context: { __code: -32000, __serverMessage: "boom" } };
+    const wrapped = createSendErrorWithMessage(wrapperMessage, reason);
+    expect(wrapped.cause).to.equal(reason);
+  });
+
+  it("does not silently drop properties of an Error rejection reason", () => {
+    // The previous implementation spread `{ ...sendError, ...new Error(message) }`. Because
+    // Error's own `message`/`stack`/`name` are non-enumerable in V8, spreading them yielded
+    // `{}` -- which combined with a generic `new Error(...)` rejection reason produced a fully
+    // empty thrown object. Make sure we keep enough context to debug from now on.
+    const inner = new Error("RPC provider reverted for method sendTransaction");
+    const wrapped = createSendErrorWithMessage(wrapperMessage, inner);
+    expect(wrapped.message).to.equal(wrapperMessage);
+    expect((wrapped.cause as Error).message).to.equal(inner.message);
+  });
+});


### PR DESCRIPTION
## Summary

`createSendErrorWithMessage` returned `{ ...sendError, ...new Error(message) }`. Spread loses the Error prototype, and Error's own `message`/`stack` are non-enumerable in V8, so the wrapper collapsed to a plain object — usually `{}` when the rejection reason was itself a generic `Error`. Downstream `instanceof Error` failed and error loggers surfaced `"could not extract error from 'Object' instance {}"` instead of the underlying RPC failure.

Switch to `new Error(message, { cause: sendError })`. Wrapper is a real Error; original reason reachable via `.cause`.

Companion: the SVM short-circuit at `quorumFallbackRpcFactory.ts:71` now also passes `{ cause: error }`, so the underlying `SolanaError` (preflight `__code` / `__serverMessage`) survives the climb.

## Scope

Both EVM (`retryProvider.ts:116`) and SVM (`quorumFallbackRpcFactory.ts:101`) quorum/fallback paths run through the helper. One-line fix each.

## Caller-visible behavior change

Callers can no longer rely on enumerable props of the rejection reason leaking onto the wrapper (e.g. `(error as any).context` for `SolanaError`). Walk `.cause` instead. No such callers in this repo.

## Test plan

- [x] `test/providers/utils.test.ts`: `instanceof Error`, message/stack preservation, `.cause` for Error and non-Error rejection reasons.
- [ ] CI lint + type-check (`Error(message, { cause })` requires Node ≥16.9 / TS lib `es2022`; already in use).

## Related

- Investigation: PD-325142 — https://risk-labs.pagerduty.com/incidents/Q2WQ66XKTQ8YIU
- Relayer companion PR (conditional PDA reuse, the proximal fix for the dataworker page): https://github.com/across-protocol/relayer/pull/3406
- Commit that started triggering this code path more often: e8ab986