### PR TITLE
improve(providers): add per-provider delta to quorum-mismatch warn log

### DIFF
--- a/src/providers/retryProvider.ts
+++ b/src/providers/retryProvider.ts
@@ -4,7 +4,13 @@ import { CHAIN_IDs } from "../constants";
 import { delay, isDefined, isPromiseFulfilled, isPromiseRejected } from "../utils";
 import { getOriginFromURL } from "../utils/NetworkUtils";
 import { CacheProvider } from "./cachedProvider";
-import { compareRpcResults, createSendErrorWithMessage, formatProviderError, parseJsonRpcError } from "./utils";
+import {
+  compareRpcResults,
+  createSendErrorWithMessage,
+  diffRpcResults,
+  formatProviderError,
+  parseJsonRpcError,
+} from "./utils";
 import { PROVIDER_CACHE_TTL } from "./constants";
 import { Logger } from "winston";
 
@@ -134,11 +140,22 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
         .map(([provider]) => getOriginFromURL(provider.connection.url));
     };
 
+    const getMismatchDetails = (values: [ethers.providers.StaticJsonRpcProvider, unknown][]) => {
+      const details: Record<string, unknown> = {};
+      for (const [provider, result] of values) {
+        if (!compareRpcResults(method, result, quorumResult)) {
+          details[getOriginFromURL(provider.connection.url)] = diffRpcResults(method, quorumResult, result);
+        }
+      }
+      return details;
+    };
+
     const logQuorumMismatchOrFailureDetails = (
       method: string,
       params: Array<unknown>,
       quorumProviders: string[],
       mismatchedProviders: string[],
+      mismatchDetails: Record<string, unknown>,
       errors: [ethers.providers.StaticJsonRpcProvider, string][]
     ) => {
       this.logger?.warn({
@@ -149,6 +166,9 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
         params: JSON.stringify(params),
         quorumProviders,
         mismatchedProviders,
+        // Per-provider diff vs the quorum result, keyed by RPC origin. Surfaces the exact
+        // log entries / fields that diverged so the warn alert is actionable on its own.
+        mismatchDetails,
         erroringProviders: errors.map(([provider, errorText]) => formatProviderError(provider, errorText)),
       });
     };
@@ -156,8 +176,17 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
     const throwQuorumError = (fallbackValues?: [ethers.providers.StaticJsonRpcProvider, unknown][]) => {
       const errorTexts = errors.map(([provider, errorText]) => formatProviderError(provider, errorText));
       const successfulProviderUrls = values.map(([provider]) => getOriginFromURL(provider.connection.url));
-      const mismatchedProviders = getMismatchedProviders([...values, ...(fallbackValues || [])]);
-      logQuorumMismatchOrFailureDetails(method, params, successfulProviderUrls, mismatchedProviders, errors);
+      const allValues = [...values, ...(fallbackValues || [])];
+      const mismatchedProviders = getMismatchedProviders(allValues);
+      const mismatchDetails = getMismatchDetails(allValues);
+      logQuorumMismatchOrFailureDetails(
+        method,
+        params,
+        successfulProviderUrls,
+        mismatchedProviders,
+        mismatchDetails,
+        errors
+      );
       throw new Error(
         "Not enough providers agreed to meet quorum.\n" +
           "Providers that errored:\n" +
@@ -220,12 +249,14 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
     }
 
     // If we've achieved quorum, then we should still log the providers that mismatched with the quorum result.
-    const mismatchedProviders = getMismatchedProviders([...values, ...fallbackValues]);
-    const quorumProviders = [...values, ...fallbackValues]
+    const allValues = [...values, ...fallbackValues];
+    const mismatchedProviders = getMismatchedProviders(allValues);
+    const quorumProviders = allValues
       .filter(([, result]) => compareRpcResults(method, result, quorumResult))
       .map(([provider]) => getOriginFromURL(provider.connection.url));
     if (mismatchedProviders.length > 0 || errors.length > 0) {
-      logQuorumMismatchOrFailureDetails(method, params, quorumProviders, mismatchedProviders, errors);
+      const mismatchDetails = getMismatchDetails(allValues);
+      logQuorumMismatchOrFailureDetails(method, params, quorumProviders, mismatchedProviders, mismatchDetails, errors);
     }
 
     return quorumResult;

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -118,6 +118,169 @@ const IGNORED_FIELDS = {
   eth_getLogs: ["blockTimestamp", "transactionLogIndex", "l1BatchNumber", "logType"],
 };
 
+// Cap on entries reported per bucket in an eth_getLogs delta, to keep log payloads bounded
+// when a provider returns thousands of stale or extra logs.
+const LOG_DIFF_MAX_ENTRIES = 5;
+
+export interface LogDiffEntry {
+  key: string;
+  entry?: Record<string, unknown>;
+  fieldDiffs?: Record<string, { a: unknown; b: unknown }>;
+}
+
+export interface LogDiff {
+  totalA: number;
+  totalB: number;
+  onlyInA: LogDiffEntry[];
+  onlyInB: LogDiffEntry[];
+  differing: LogDiffEntry[];
+  truncated?: { onlyInA?: number; onlyInB?: number; differing?: number };
+}
+
+function fieldDiff(
+  a: Record<string, unknown> | undefined,
+  b: Record<string, unknown> | undefined
+): Record<string, { a: unknown; b: unknown }> {
+  const diff: Record<string, { a: unknown; b: unknown }> = {};
+  const keys = new Set([...Object.keys(a ?? {}), ...Object.keys(b ?? {})]);
+  for (const key of keys) {
+    if (!isEqual(a?.[key], b?.[key])) {
+      diff[key] = { a: a?.[key], b: b?.[key] };
+    }
+  }
+  return diff;
+}
+
+function deepDiff(a: unknown, b: unknown): Record<string, { a: unknown; b: unknown }> {
+  const out: Record<string, { a: unknown; b: unknown }> = {};
+  const visit = (lhs: unknown, rhs: unknown, path: string) => {
+    if (isEqual(lhs, rhs)) {
+      return;
+    }
+    const lhsIsObj = isDefined(lhs) && typeof lhs === "object";
+    const rhsIsObj = isDefined(rhs) && typeof rhs === "object";
+    if (!lhsIsObj || !rhsIsObj || Array.isArray(lhs) !== Array.isArray(rhs)) {
+      out[path || "."] = { a: lhs, b: rhs };
+      return;
+    }
+    if (Array.isArray(lhs)) {
+      const arrA = lhs as unknown[];
+      const arrB = rhs as unknown[];
+      const len = Math.max(arrA.length, arrB.length);
+      for (let i = 0; i < len; i++) {
+        visit(arrA[i], arrB[i], `${path}[${i}]`);
+      }
+      return;
+    }
+    const oa = lhs as Record<string, unknown>;
+    const ob = rhs as Record<string, unknown>;
+    const keys = new Set([...Object.keys(oa), ...Object.keys(ob)]);
+    for (const k of keys) {
+      visit(oa[k], ob[k], path ? `${path}.${k}` : k);
+    }
+  };
+  visit(a, b, "");
+  return out;
+}
+
+function logKey(log: Record<string, unknown>): string {
+  return `${(log?.transactionHash as string) ?? "?"}:${(log?.logIndex as string | number) ?? "?"}`;
+}
+
+function diffLogResults(
+  ignoredKeys: string[],
+  rpcResultA: unknown[] | undefined,
+  rpcResultB: unknown[] | undefined
+): LogDiff {
+  const stripA = (rpcResultA ?? []).map(
+    (entry) => (deleteIgnoredKeys(ignoredKeys, entry as Record<string, unknown>) ?? {}) as Record<string, unknown>
+  );
+  const stripB = (rpcResultB ?? []).map(
+    (entry) => (deleteIgnoredKeys(ignoredKeys, entry as Record<string, unknown>) ?? {}) as Record<string, unknown>
+  );
+  const mapA = new Map(stripA.map((e) => [logKey(e), e]));
+  const mapB = new Map(stripB.map((e) => [logKey(e), e]));
+
+  const onlyInA: LogDiffEntry[] = [];
+  const onlyInB: LogDiffEntry[] = [];
+  const differing: LogDiffEntry[] = [];
+  let droppedOnlyInA = 0;
+  let droppedOnlyInB = 0;
+  let droppedDiffering = 0;
+
+  for (const [key, entry] of mapA) {
+    const other = mapB.get(key);
+    if (other === undefined) {
+      if (onlyInA.length < LOG_DIFF_MAX_ENTRIES) {
+        onlyInA.push({ key, entry });
+      } else {
+        droppedOnlyInA++;
+      }
+    } else if (!isEqual(entry, other)) {
+      if (differing.length < LOG_DIFF_MAX_ENTRIES) {
+        differing.push({ key, fieldDiffs: fieldDiff(entry, other) });
+      } else {
+        droppedDiffering++;
+      }
+    }
+  }
+  for (const [key, entry] of mapB) {
+    if (!mapA.has(key)) {
+      if (onlyInB.length < LOG_DIFF_MAX_ENTRIES) {
+        onlyInB.push({ key, entry });
+      } else {
+        droppedOnlyInB++;
+      }
+    }
+  }
+
+  const truncated: NonNullable<LogDiff["truncated"]> = {};
+  if (droppedOnlyInA) {
+    truncated.onlyInA = droppedOnlyInA;
+  }
+  if (droppedOnlyInB) {
+    truncated.onlyInB = droppedOnlyInB;
+  }
+  if (droppedDiffering) {
+    truncated.differing = droppedDiffering;
+  }
+
+  return {
+    totalA: stripA.length,
+    totalB: stripB.length,
+    onlyInA,
+    onlyInB,
+    differing,
+    ...(Object.keys(truncated).length > 0 ? { truncated } : {}),
+  };
+}
+
+/**
+ * Compact, JSON-safe diff between two RPC results for the same method. Strips the same fields
+ * `compareRpcResults` strips, so the diff only reflects mismatches that actually mattered to
+ * quorum. Intended for use after `compareRpcResults` has already determined the results disagree.
+ *
+ * - `eth_getLogs`: returns a `LogDiff` (per-log onlyInA / onlyInB / differing, capped at 5 entries
+ *   per bucket with a truncation counter).
+ * - `eth_getBlockByNumber`: returns a `{ key: { a, b }, ... }` map for non-ignored field diffs.
+ * - any other method: returns a path-keyed deep diff (e.g. `"receipt.logs[0].data": { a, b }`).
+ */
+export function diffRpcResults(method: string, rpcResultA: unknown, rpcResultB: unknown): unknown {
+  if (method === "eth_getLogs") {
+    return diffLogResults(
+      IGNORED_FIELDS.eth_getLogs,
+      rpcResultA as unknown[] | undefined,
+      rpcResultB as unknown[] | undefined
+    );
+  }
+  if (method === "eth_getBlockByNumber") {
+    const a = deleteIgnoredKeys(IGNORED_FIELDS.eth_getBlockByNumber, rpcResultA as Record<string, unknown>);
+    const b = deleteIgnoredKeys(IGNORED_FIELDS.eth_getBlockByNumber, rpcResultB as Record<string, unknown>);
+    return fieldDiff(a, b);
+  }
+  return deepDiff(rpcResultA, rpcResultB);
+}
+
 /**
  * This is the type we pass to define a request "task".
  */

--- a/test/providers/utils.test.ts
+++ b/test/providers/utils.test.ts
@@ -1,5 +1,119 @@
-import { createSendErrorWithMessage } from "../../src/providers/utils";
+import { createSendErrorWithMessage, diffRpcResults, LogDiff } from "../../src/providers/utils";
 import { expect } from "../utils";
+
+describe("diffRpcResults", () => {
+  describe("eth_getLogs", () => {
+    const baseLog = {
+      address: "0xef684c38f94f48775959ecf2012d7e864ffb9dd4",
+      blockHash: "0xabc",
+      blockNumber: "0x2beaad0",
+      data: "0xdeadbeef",
+      logIndex: "0x0",
+      removed: false,
+      topics: ["0xf4ad92585b1bc117fbdd644990adf0827bc4c95baeae8a23322af807b6d0020e"],
+      transactionHash: "0xfeedface",
+      transactionIndex: "0x1",
+    };
+
+    it("strips the same fields compareRpcResults strips", () => {
+      const a = [{ ...baseLog, blockTimestamp: "0x1", transactionLogIndex: "0x0" }];
+      const b = [{ ...baseLog, blockTimestamp: "0x2", transactionLogIndex: "0xff" }];
+      const diff = diffRpcResults("eth_getLogs", a, b) as LogDiff;
+      expect(diff.differing).to.deep.equal([]);
+      expect(diff.onlyInA).to.deep.equal([]);
+      expect(diff.onlyInB).to.deep.equal([]);
+    });
+
+    it("reports logs only present in one provider's result", () => {
+      const extra = { ...baseLog, transactionHash: "0xextra", logIndex: "0x2" };
+      const diff = diffRpcResults("eth_getLogs", [baseLog], [baseLog, extra]) as LogDiff;
+      expect(diff.onlyInB).to.have.lengthOf(1);
+      expect(diff.onlyInB[0].key).to.equal("0xextra:0x2");
+      expect(diff.onlyInA).to.deep.equal([]);
+      expect(diff.differing).to.deep.equal([]);
+      expect(diff.totalA).to.equal(1);
+      expect(diff.totalB).to.equal(2);
+    });
+
+    it("reports per-field differences for logs present in both", () => {
+      const a = [{ ...baseLog, data: "0xaa" }];
+      const b = [{ ...baseLog, data: "0xbb" }];
+      const diff = diffRpcResults("eth_getLogs", a, b) as LogDiff;
+      expect(diff.differing).to.have.lengthOf(1);
+      expect(diff.differing[0].key).to.equal(`${baseLog.transactionHash}:${baseLog.logIndex}`);
+      expect(diff.differing[0].fieldDiffs).to.deep.equal({ data: { a: "0xaa", b: "0xbb" } });
+    });
+
+    it("truncates and reports a dropped count when buckets exceed the cap", () => {
+      const many = Array.from({ length: 12 }, (_, i) => ({
+        ...baseLog,
+        transactionHash: `0x${i.toString(16).padStart(64, "0")}`,
+        logIndex: `0x${i.toString(16)}`,
+      }));
+      const diff = diffRpcResults("eth_getLogs", [], many) as LogDiff;
+      expect(diff.onlyInB).to.have.lengthOf(5);
+      expect(diff.truncated?.onlyInB).to.equal(7);
+    });
+
+    it("handles undefined inputs without throwing", () => {
+      const diff = diffRpcResults("eth_getLogs", undefined, [baseLog]) as LogDiff;
+      expect(diff.totalA).to.equal(0);
+      expect(diff.totalB).to.equal(1);
+      expect(diff.onlyInB).to.have.lengthOf(1);
+    });
+  });
+
+  describe("eth_getBlockByNumber", () => {
+    const baseBlock = {
+      number: "0x10",
+      hash: "0xblock",
+      parentHash: "0xparent",
+      transactions: ["0xtx"],
+      stateRoot: "0xstate",
+    };
+
+    it("returns an empty diff when only ignored fields differ", () => {
+      const a = { ...baseBlock, miner: "0x111", logsBloom: "0x0", totalDifficulty: "0x1" };
+      const b = { ...baseBlock, miner: "0x222", logsBloom: "0xff", totalDifficulty: "0x2" };
+      const diff = diffRpcResults("eth_getBlockByNumber", a, b) as Record<string, unknown>;
+      expect(diff).to.deep.equal({});
+    });
+
+    it("emits per-key { a, b } pairs for non-ignored differences", () => {
+      const a = { ...baseBlock, stateRoot: "0xstateA" };
+      const b = { ...baseBlock, stateRoot: "0xstateB", extraData: "0xextra" };
+      const diff = diffRpcResults("eth_getBlockByNumber", a, b) as Record<string, { a: unknown; b: unknown }>;
+      expect(diff).to.deep.equal({
+        stateRoot: { a: "0xstateA", b: "0xstateB" },
+        extraData: { a: undefined, b: "0xextra" },
+      });
+    });
+  });
+
+  describe("generic methods", () => {
+    it("returns an empty diff for equal values", () => {
+      const diff = diffRpcResults("eth_blockNumber", "0x1", "0x1") as Record<string, unknown>;
+      expect(diff).to.deep.equal({});
+    });
+
+    it("reports the path to a differing leaf", () => {
+      const a = { receipt: { status: "0x1", logs: [{ data: "0xaa" }] } };
+      const b = { receipt: { status: "0x1", logs: [{ data: "0xbb" }] } };
+      const diff = diffRpcResults("eth_getTransactionReceipt", a, b) as Record<string, { a: unknown; b: unknown }>;
+      expect(diff).to.deep.equal({ "receipt.logs[0].data": { a: "0xaa", b: "0xbb" } });
+    });
+
+    it("reports primitive disagreement at the root", () => {
+      const diff = diffRpcResults("eth_blockNumber", "0x1", "0x2") as Record<string, { a: unknown; b: unknown }>;
+      expect(diff).to.deep.equal({ ".": { a: "0x1", b: "0x2" } });
+    });
+
+    it("reports type mismatch between object and array", () => {
+      const diff = diffRpcResults("eth_getBalance", { x: 1 }, [1]) as Record<string, { a: unknown; b: unknown }>;
+      expect(diff).to.deep.equal({ ".": { a: { x: 1 }, b: [1] } });
+    });
+  });
+});
 
 describe("createSendErrorWithMessage", () => {
   const wrapperMessage = "Not enough providers succeeded.";


### PR DESCRIPTION
## Summary

Surface the exact source of provider disagreement when the RetryProvider's quorum check fails. The existing `Some providers mismatched with the quorum result or failed 🚸` warn only listed which RPC origins disagreed — operators had no signal about *what* differed. This PR adds a new `mismatchDetails` field to the warn payload mapping each mismatched provider's origin to a compact, JSON-safe delta vs the quorum result.

Per method:

- `eth_getLogs` — per-log `onlyInA` / `onlyInB` / `differing` (with `fieldDiffs: { field: { a, b } }`), keyed by `transactionHash:logIndex`. Strips the same `IGNORED_FIELDS` the equality check strips, so noise like `blockTimestamp` doesn't show up. Each bucket is capped at 5 entries with a `truncated` counter so payloads stay bounded even when a provider returns thousands of stale logs.
- `eth_getBlockByNumber` — per-key `{ a, b }` for non-ignored fields.
- any other method — path-keyed deep diff (e.g. `"receipt.logs[0].data": { a, b }`).

## Scope

Intentionally minimal — small, additive change to a load-bearing component:

- `compareRpcResults` keeps its `boolean` return type. No signature change, no caller updates beyond `retryProvider.ts`.
- `RetryProvider.send` keeps its current structure. The new code only adds a per-provider `getMismatchDetails(values)` helper alongside the existing `getMismatchedProviders(values)`, and threads the result into the existing `logQuorumMismatchOrFailureDetails` call as one new field.
- Existing fields (`quorumProviders`, `mismatchedProviders`, `erroringProviders`) are unchanged — `mismatchDetails` is purely additive for log consumers.

Production code change: `retryProvider.ts` +37 / -6, `utils.ts` purely additive.

## Performance

- **Equal path** (all-providers-agree, the hot path): zero overhead. The new code only runs inside the warn-emit branches, which only fire on mismatch or provider error.
- **Mismatch path**: one extra per-provider walk to build the delta. Bounded by provider count (typically 2-4) and capped output (5 entries / bucket for `eth_getLogs`). Fields that are equal don't appear in the output — only divergent ones.

## Test plan

- [x] `yarn hardhat test test/providers/utils.test.ts` — 16/16 passing (covers ignored-field handling, per-log diffs, truncation, undefined inputs, block-level diffs, generic deep diff, primitive root, type-mismatch).
- [x] `yarn lint-check` — clean.
- [ ] Confirm the next real quorum mismatch in `zion-across-relayer-primary` carries an actionable `mismatchDetails` payload.
