### PR TITLE
fix(svm): preserve SolanaError through QuorumFallback for shouldFailImmediate codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.160",
+  "version": "4.3.161",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/src/providers/solana/quorumFallbackRpcFactory.ts
+++ b/src/providers/solana/quorumFallbackRpcFactory.ts
@@ -66,9 +66,11 @@ export class QuorumFallbackSolanaRpcFactory extends SolanaBaseRpcFactory {
               throw error;
             }
 
-            // If one RPC provider reverted, others likely will too. Skip them.
+            // If one RPC provider reverted, others likely will too. Skip them and rethrow the original
+            // error so callers can branch on the underlying SolanaError code (e.g. SVM_SLOT_SKIPPED)
+            // via `isSolanaError(...)`.
             if (quorumThreshold === 1 && shouldFailImmediate(method, error)) {
-              throw new Error(`RPC provider reverted for method ${method}`, { cause: error });
+              throw error;
             }
 
             const currentFactory = factory.rpcFactory.clusterUrl;
@@ -95,6 +97,16 @@ export class QuorumFallbackSolanaRpcFactory extends SolanaBaseRpcFactory {
       };
 
       if (!results.every(isPromiseFulfilled)) {
+        // If every required-provider rejection encodes a deterministic chain-level failure
+        // (e.g. SVM_SLOT_SKIPPED on getBlockTime, preflight failure on sendTransaction),
+        // surface the underlying SolanaError so callers can branch on `isSolanaError(err)`
+        // and the matching `__code`. Wrapping it in a generic Error here would erase the
+        // SolanaError type and break `getNearestSlotTime`'s slot walk-back, among others.
+        const rejections = results.filter(isPromiseRejected);
+        if (rejections.length > 0 && rejections.every(({ reason }) => shouldFailImmediate(method, reason))) {
+          throw rejections[0].reason;
+        }
+
         // Format the error so that it's very clear which providers failed and succeeded.
         const errorTexts = getErrorStrings();
         const successfulProviderUrls = results.filter(isPromiseFulfilled).map((result) => result.value[0].clusterUrl);

--- a/src/providers/solana/quorumFallbackRpcFactory.ts
+++ b/src/providers/solana/quorumFallbackRpcFactory.ts
@@ -66,9 +66,8 @@ export class QuorumFallbackSolanaRpcFactory extends SolanaBaseRpcFactory {
               throw error;
             }
 
-            // If one RPC provider reverted, others likely will too. Skip them and rethrow the original
-            // error so callers can branch on the underlying SolanaError code (e.g. SVM_SLOT_SKIPPED)
-            // via `isSolanaError(...)`.
+            // If one RPC provider reverted, others likely will too. Skip them and preserve the
+            // original error so callers can branch on `isSolanaError(...)`.
             if (quorumThreshold === 1 && shouldFailImmediate(method, error)) {
               throw error;
             }
@@ -97,11 +96,8 @@ export class QuorumFallbackSolanaRpcFactory extends SolanaBaseRpcFactory {
       };
 
       if (!results.every(isPromiseFulfilled)) {
-        // If every required-provider rejection encodes a deterministic chain-level failure
-        // (e.g. SVM_SLOT_SKIPPED on getBlockTime, preflight failure on sendTransaction),
-        // surface the underlying SolanaError so callers can branch on `isSolanaError(err)`
-        // and the matching `__code`. Wrapping it in a generic Error here would erase the
-        // SolanaError type and break `getNearestSlotTime`'s slot walk-back, among others.
+        // If every rejection is shouldFailImmediate, rethrow the original so callers can branch
+        // on `isSolanaError(...)` rather than seeing a wrapped Error.
         const rejections = results.filter(isPromiseRejected);
         if (rejections.length > 0 && rejections.every(({ reason }) => shouldFailImmediate(method, reason))) {
           throw rejections[0].reason;

--- a/test/SolanaQuorumFallbackProvider.ts
+++ b/test/SolanaQuorumFallbackProvider.ts
@@ -1,0 +1,177 @@
+import { RpcResponse, RpcTransport } from "@solana/kit";
+import { expect } from "chai";
+import winston from "winston";
+import { SVM_SLOT_SKIPPED, SVM_LONG_TERM_STORAGE_SLOT_SKIPPED } from "../src/arch/svm/provider";
+import { CachedSolanaRpcFactory } from "../src/providers/solana/cachedRpcFactory";
+import { QuorumFallbackSolanaRpcFactory } from "../src/providers/solana/quorumFallbackRpcFactory";
+
+// Silent logger — these tests assert on thrown errors, not log output.
+const silentLogger = winston.createLogger({
+  silent: true,
+  transports: [new winston.transports.Console({ silent: true })],
+});
+
+const chainId = 1234567890;
+const providerCacheNamespace = "test-cache-ns";
+
+const solanaError = (code: number, serverMessage = "synthetic") => ({
+  name: "SolanaError",
+  context: { __code: code, __serverMessage: serverMessage },
+});
+
+type RpcFactoryEntry = {
+  transport: RpcTransport;
+  rpcClient: unknown;
+  rpcFactory: { clusterUrl: string };
+};
+
+// Build a QuorumFallbackSolanaRpcFactory and replace its internal rpcFactories with mocks that throw whatever
+// the caller wants. The real CachedSolanaRpcFactory chain is constructed but never invoked.
+function buildFactory(transports: RpcTransport[], quorumThreshold = 1) {
+  const logger = silentLogger;
+  const factoryParams = transports.map(
+    (_, i): ConstructorParameters<typeof CachedSolanaRpcFactory> => [
+      providerCacheNamespace,
+      undefined,
+      0, // retries
+      0, // retryDelaySeconds
+      1, // maxConcurrency
+      0, // pctRpcCallsLogged
+      logger,
+      `https://test${i}.example.com/`,
+      chainId,
+    ]
+  );
+
+  const factory = new QuorumFallbackSolanaRpcFactory(factoryParams, quorumThreshold, logger);
+
+  const replacement: RpcFactoryEntry[] = transports.map((transport, i) => ({
+    transport,
+    rpcClient: {},
+    rpcFactory: { clusterUrl: `https://test${i}.example.com/` },
+  }));
+  // rpcFactories is `readonly` only at the TS level; mutate the array to swap real factories for mocks.
+  (factory.rpcFactories as unknown as RpcFactoryEntry[]).length = 0;
+  (factory.rpcFactories as unknown as RpcFactoryEntry[]).push(...replacement);
+
+  return factory;
+}
+
+function rejectingTransport(error: unknown): RpcTransport {
+  return (() => Promise.reject(error)) as unknown as RpcTransport;
+}
+
+function payload(method: string, params: unknown[] = []): Parameters<RpcTransport>[0] {
+  return { payload: { method, params } } as unknown as Parameters<RpcTransport>[0];
+}
+
+describe("QuorumFallbackSolanaRpcFactory error preservation", () => {
+  it("rethrows the underlying SolanaError when the only rejection is SVM_SLOT_SKIPPED on getBlockTime", async () => {
+    const skipped = solanaError(SVM_SLOT_SKIPPED, "Slot 421829272 was skipped");
+    const factory = buildFactory([rejectingTransport(skipped)]);
+
+    let caught: unknown;
+    try {
+      await factory.createTransport()(payload("getBlockTime", [421829272]));
+      expect.fail("Expected the transport to reject");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).to.equal(skipped);
+    expect((caught as { context: { __code: number } }).context.__code).to.equal(SVM_SLOT_SKIPPED);
+  });
+
+  it("rethrows the underlying SolanaError for SVM_LONG_TERM_STORAGE_SLOT_SKIPPED on getBlock", async () => {
+    const skipped = solanaError(SVM_LONG_TERM_STORAGE_SLOT_SKIPPED, "ledger jump to recent snapshot");
+    const factory = buildFactory([rejectingTransport(skipped)]);
+
+    let caught: unknown;
+    try {
+      await factory.createTransport()(payload("getBlock", [421829272]));
+      expect.fail("Expected the transport to reject");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).to.equal(skipped);
+  });
+
+  it("rethrows the SolanaError when every required-provider rejection is shouldFailImmediate", async () => {
+    const skipped1 = solanaError(SVM_SLOT_SKIPPED, "from provider 1");
+    const skipped2 = solanaError(SVM_SLOT_SKIPPED, "from provider 2");
+    const factory = buildFactory([rejectingTransport(skipped1), rejectingTransport(skipped2)], 2);
+
+    let caught: unknown;
+    try {
+      await factory.createTransport()(payload("getBlockTime", [421829272]));
+      expect.fail("Expected the transport to reject");
+    } catch (err) {
+      caught = err;
+    }
+
+    // The first rejection's reason wins, matching Promise.allSettled ordering.
+    expect(caught).to.equal(skipped1);
+  });
+
+  it("still wraps the error when the failure is not shouldFailImmediate", async () => {
+    const networkError = new Error("network down");
+    const factory = buildFactory([rejectingTransport(networkError)]);
+
+    let caught: unknown;
+    try {
+      await factory.createTransport()(payload("getBlockTime", [421829272]));
+      expect.fail("Expected the transport to reject");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).to.be.instanceOf(Error);
+    expect((caught as Error).message).to.match(/Not enough providers succeeded/);
+    // Underlying rejection remains reachable via `.cause`.
+    expect((caught as Error).cause).to.equal(networkError);
+  });
+
+  it("still wraps the error for shouldFailImmediate codes on unrelated methods", async () => {
+    // SVM_SLOT_SKIPPED is only treated as fail-immediate for getBlock / getBlockTime, not e.g. getAccountInfo.
+    const skipped = solanaError(SVM_SLOT_SKIPPED, "not really a skipped slot");
+    const factory = buildFactory([rejectingTransport(skipped)]);
+
+    let caught: unknown;
+    try {
+      await factory.createTransport()(payload("getAccountInfo", ["someAddress"]));
+      expect.fail("Expected the transport to reject");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).to.be.instanceOf(Error);
+    expect((caught as Error).message).to.match(/Not enough providers succeeded/);
+    expect((caught as Error).cause).to.equal(skipped);
+  });
+
+  it("passes through to the wrapping path when only some rejections are shouldFailImmediate", async () => {
+    const skipped = solanaError(SVM_SLOT_SKIPPED, "skipped");
+    const network = new Error("network down");
+    const factory = buildFactory([rejectingTransport(skipped), rejectingTransport(network)], 2);
+
+    let caught: unknown;
+    try {
+      await factory.createTransport()(payload("getBlockTime", [421829272]));
+      expect.fail("Expected the transport to reject");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).to.be.instanceOf(Error);
+    expect((caught as Error).message).to.match(/Not enough providers succeeded/);
+  });
+
+  it("succeeds normally when the provider returns a result", async () => {
+    const ok = (() => Promise.resolve({ result: "ok" })) as unknown as RpcTransport;
+    const factory = buildFactory([ok]);
+
+    const response = (await factory.createTransport()(payload("getBlockTime", [421829272]))) as RpcResponse<unknown>;
+    expect(response).to.deep.equal({ result: "ok" });
+  });
+});

--- a/test/SolanaQuorumFallbackProvider.ts
+++ b/test/SolanaQuorumFallbackProvider.ts
@@ -5,7 +5,6 @@ import { SVM_SLOT_SKIPPED, SVM_LONG_TERM_STORAGE_SLOT_SKIPPED } from "../src/arc
 import { CachedSolanaRpcFactory } from "../src/providers/solana/cachedRpcFactory";
 import { QuorumFallbackSolanaRpcFactory } from "../src/providers/solana/quorumFallbackRpcFactory";
 
-// Silent logger — these tests assert on thrown errors, not log output.
 const silentLogger = winston.createLogger({
   silent: true,
   transports: [new winston.transports.Console({ silent: true })],
@@ -25,8 +24,6 @@ type RpcFactoryEntry = {
   rpcFactory: { clusterUrl: string };
 };
 
-// Build a QuorumFallbackSolanaRpcFactory and replace its internal rpcFactories with mocks that throw whatever
-// the caller wants. The real CachedSolanaRpcFactory chain is constructed but never invoked.
 function buildFactory(transports: RpcTransport[], quorumThreshold = 1) {
   const logger = silentLogger;
   const factoryParams = transports.map(
@@ -50,7 +47,6 @@ function buildFactory(transports: RpcTransport[], quorumThreshold = 1) {
     rpcClient: {},
     rpcFactory: { clusterUrl: `https://test${i}.example.com/` },
   }));
-  // rpcFactories is `readonly` only at the TS level; mutate the array to swap real factories for mocks.
   (factory.rpcFactories as unknown as RpcFactoryEntry[]).length = 0;
   (factory.rpcFactories as unknown as RpcFactoryEntry[]).push(...replacement);
 
@@ -110,7 +106,6 @@ describe("QuorumFallbackSolanaRpcFactory error preservation", () => {
       caught = err;
     }
 
-    // The first rejection's reason wins, matching Promise.allSettled ordering.
     expect(caught).to.equal(skipped1);
   });
 
@@ -128,12 +123,10 @@ describe("QuorumFallbackSolanaRpcFactory error preservation", () => {
 
     expect(caught).to.be.instanceOf(Error);
     expect((caught as Error).message).to.match(/Not enough providers succeeded/);
-    // Underlying rejection remains reachable via `.cause`.
     expect((caught as Error).cause).to.equal(networkError);
   });
 
   it("still wraps the error for shouldFailImmediate codes on unrelated methods", async () => {
-    // SVM_SLOT_SKIPPED is only treated as fail-immediate for getBlock / getBlockTime, not e.g. getAccountInfo.
     const skipped = solanaError(SVM_SLOT_SKIPPED, "not really a skipped slot");
     const factory = buildFactory([rejectingTransport(skipped)]);
 

--- a/test/providers/solana/quorumFallbackRpcFactory.test.ts
+++ b/test/providers/solana/quorumFallbackRpcFactory.test.ts
@@ -1,9 +1,9 @@
 import { RpcResponse, RpcTransport } from "@solana/kit";
 import { expect } from "chai";
 import winston from "winston";
-import { SVM_SLOT_SKIPPED, SVM_LONG_TERM_STORAGE_SLOT_SKIPPED } from "../src/arch/svm/provider";
-import { CachedSolanaRpcFactory } from "../src/providers/solana/cachedRpcFactory";
-import { QuorumFallbackSolanaRpcFactory } from "../src/providers/solana/quorumFallbackRpcFactory";
+import { SVM_SLOT_SKIPPED, SVM_LONG_TERM_STORAGE_SLOT_SKIPPED } from "../../../src/arch/svm/provider";
+import { CachedSolanaRpcFactory } from "../../../src/providers/solana/cachedRpcFactory";
+import { QuorumFallbackSolanaRpcFactory } from "../../../src/providers/solana/quorumFallbackRpcFactory";
 
 const silentLogger = winston.createLogger({
   silent: true,


### PR DESCRIPTION
## Summary

- `QuorumFallbackSolanaRpcFactory` wrapped the underlying `SolanaError` in a plain `Error` at two points (final aggregation via `createSendErrorWithMessage`, and the `quorumThreshold === 1 && shouldFailImmediate` short-circuit). Both wrappers erased the `SolanaError` type, so callers' `isSolanaError(err)` checks fell through to default error handling.
- The dataworker hit this on Solana mainnet: `provider.getBlockTime(421829272)` returned `SVM_SLOT_SKIPPED` (network-wide skipped slot, reproducible against the public RPC), but `_callGetTimestampForSlotWithRetry` saw a generic `Error` and re-threw instead of returning `undefined`. That broke `getNearestSlotTime`'s slot walk-back and crashed `zion-across-l2-executor-solana`.
- Both sites now rethrow the original error when `shouldFailImmediate(method, error)` is true. The final aggregation step still wraps with the descriptive `Not enough providers succeeded...` context whenever at least one rejection is a non-deterministic provider failure — that's the case where surfacing the provider URLs and successful peers is genuinely useful.

## Test plan

- [x] New unit tests in `test/SolanaQuorumFallbackProvider.ts` cover: single-rejection skipped slot rethrows the `SolanaError`; multi-provider all-skipped rethrows the first rejection; non-`shouldFailImmediate` failures keep the wrapping path with `cause`; `shouldFailImmediate` codes on unrelated methods still wrap; mixed failures fall through to the wrapper; successful responses still pass through.
- [x] `npx hardhat test test/SolanaQuorumFallbackProvider.ts test/providers/utils.test.ts test/providers/solana/utils.test.ts` — 22 passing.
- [x] `npx hardhat test test/SolanaCachedProvider.ts test/SolanaRateLimitedProvider.ts test/SolanaRetryProvider.ts` — 15 passing (no regressions in the surrounding factory chain).
- [x] `npx tsc --project tsconfig.build.json --noEmit` clean. `prettier --check` and `eslint` clean.

## Background

Surfaced in Slack thread; full diagnosis traced the error from the dataworker stack through `SVMBlockFinder.findBlock` → `getNearestSlotTime` → `getTimestampForSlot` → the `QuorumFallback` wrapping. Slot 421829272 was a real network-wide skipped slot — the dataworker recovers automatically on restart, but the same crash will recur whenever a skipped slot lands near the head until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)