### PR TITLE
refactor(svm): delete getLatestFinalizedSlotWithBlock, use getNearestSlotTime directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.162",
+  "version": "4.3.163",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -89,20 +89,6 @@ export async function getNearestSlotTime(
 }
 
 /**
- * Resolve the latest finalized slot that is backed by a block, capped at `maxSlot`.
- */
-export async function getLatestFinalizedSlotWithBlock(
-  provider: SVMProvider,
-  logger: winston.Logger,
-  maxSlot: bigint
-): Promise<number> {
-  const { slot: finalizedSlot } = await getNearestSlotTime(provider, { commitment: "finalized" }, logger);
-  if (finalizedSlot <= maxSlot) return Number(finalizedSlot);
-  const { slot } = await getNearestSlotTime(provider, { slot: maxSlot }, logger);
-  return Number(slot);
-}
-
-/**
  * Parses event data from a transaction.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -25,7 +25,7 @@ import assert from "assert";
 import bs58 from "bs58";
 import { ethers } from "ethers";
 import { FillType, RelayData, RelayDataWithMessageHash } from "../../interfaces";
-import { BigNumber, Address as SdkAddress, biMin, getMessageHash, isDefined, isUint8Array } from "../../utils";
+import { BigNumber, Address as SdkAddress, getMessageHash, isDefined, isUint8Array } from "../../utils";
 import { getTimestampForSlot, getSlot, getRelayDataHash } from "./SpokeUtils";
 import {
   AttestedCCTPMessage,
@@ -89,32 +89,16 @@ export async function getNearestSlotTime(
 }
 
 /**
- * Resolve the latest finalized slot, and then work backwards to find the nearest slot containing a block.
- * In most cases the first-resolved slot should also have a block. Avoid making arbitrary decisions about
- * how many slots to rotate through.
+ * Resolve the latest finalized slot that is backed by a block, capped at `maxSlot`.
  */
 export async function getLatestFinalizedSlotWithBlock(
   provider: SVMProvider,
   logger: winston.Logger,
-  maxSlot: bigint,
-  maxLookback = 1000
+  maxSlot: bigint
 ): Promise<number> {
-  const opts = { maxSupportedTransactionVersion: 0, transactionDetails: "none", rewards: false } as const;
   const { slot: finalizedSlot } = await getNearestSlotTime(provider, { commitment: "finalized" }, logger);
-  const endSlot = biMin(maxSlot, finalizedSlot);
-
-  let slot = endSlot;
-  do {
-    const block = await provider.getBlock(slot, opts).send();
-    if (isDefined(block) && [block.blockHeight, block.blockTime].every(isDefined)) {
-      break;
-    }
-  } while (--maxLookback > 0 && --slot > 0);
-
-  if (maxLookback === 0) {
-    throw new Error(`Unable to find Solana block between slots [${slot}, ${endSlot}]`);
-  }
-
+  if (finalizedSlot <= maxSlot) return Number(finalizedSlot);
+  const { slot } = await getNearestSlotTime(provider, { slot: maxSlot }, logger);
   return Number(slot);
 }
 

--- a/src/clients/BundleDataClient/utils/PoolRebalanceUtils.ts
+++ b/src/clients/BundleDataClient/utils/PoolRebalanceUtils.ts
@@ -2,7 +2,7 @@ import { MerkleTree } from "@across-protocol/contracts/dist/utils/MerkleTree";
 import { RunningBalances, PoolRebalanceLeaf, Clients, SpokePoolTargetBalance } from "../../../interfaces";
 import { isSVMSpokePoolClient, SpokePoolClient } from "../../SpokePoolClient";
 import { BigNumber, bnZero, chainIsEvm, chainIsSvm, compareAddresses, EvmAddress, isDefined } from "../../../utils";
-import { getLatestFinalizedSlotWithBlock } from "../../../arch/svm";
+import { getNearestSlotTime } from "../../../arch/svm";
 import { HubPoolClient } from "../../HubPoolClient";
 import { V3DepositWithBlock } from "./shims";
 import { AcrossConfigStoreClient } from "../../AcrossConfigStoreClient";
@@ -36,16 +36,17 @@ export async function getWidestPossibleExpectedBlockRange(
     Math.max(spokeClients[chainId].latestHeightSearched - endBlockBuffers[idx], 0);
 
   // Across bundles are bounded by slots on Solana. The UMIP requires that the bundle end slot is backed by a block.
-  const resolveSVMEndBlock = (chainId: number, idx: number): Promise<number> => {
+  const resolveSVMEndBlock = async (chainId: number, idx: number): Promise<number> => {
     const spokePoolClient = spokeClients[chainId];
     assert(isSVMSpokePoolClient(spokePoolClient));
 
-    const maxSlot = resolveEndBlock(chainId, idx); // Respect any configured buffer for Solana.
-    return getLatestFinalizedSlotWithBlock(
-      spokePoolClient.svmEventsClient.getRpc(),
-      spokePoolClient.logger,
-      BigInt(maxSlot)
-    );
+    const provider = spokePoolClient.svmEventsClient.getRpc();
+    const { logger } = spokePoolClient;
+    const maxSlot = BigInt(resolveEndBlock(chainId, idx)); // Respect any configured buffer for Solana.
+    const { slot: finalizedSlot } = await getNearestSlotTime(provider, { commitment: "finalized" }, logger);
+    if (finalizedSlot <= maxSlot) return Number(finalizedSlot);
+    const { slot } = await getNearestSlotTime(provider, { slot: maxSlot }, logger);
+    return Number(slot);
   };
 
   const latestPossibleBundleEndBlockNumbers = await Promise.all(

--- a/src/clients/BundleDataClient/utils/PoolRebalanceUtils.ts
+++ b/src/clients/BundleDataClient/utils/PoolRebalanceUtils.ts
@@ -43,9 +43,13 @@ export async function getWidestPossibleExpectedBlockRange(
     const provider = spokePoolClient.svmEventsClient.getRpc();
     const { logger } = spokePoolClient;
     const maxSlot = BigInt(resolveEndBlock(chainId, idx)); // Respect any configured buffer for Solana.
-    const { slot: finalizedSlot } = await getNearestSlotTime(provider, { commitment: "finalized" }, logger);
-    if (finalizedSlot <= maxSlot) return Number(finalizedSlot);
-    const { slot } = await getNearestSlotTime(provider, { slot: maxSlot }, logger);
+
+    let slot: bigint;
+    let opts: { slot: bigint } | { commitment: "finalized" } = { commitment: "finalized" };
+    do {
+      ({ slot } = await getNearestSlotTime(provider, opts, logger));
+      opts = { slot: maxSlot };
+    } while (slot > maxSlot);
     return Number(slot);
   };
 


### PR DESCRIPTION
## Summary

- `getLatestFinalizedSlotWithBlock` re-implemented the walk-back already provided by `getNearestSlotTime`, but over `getBlock` and without catching `SVM_SLOT_SKIPPED` / `SVM_LONG_TERM_STORAGE_SLOT_SKIPPED`. A single skipped slot — or a post-snapshot ledger gap on the RPC — crashed the dataworker run (seen in `zion-across-disputer` 2026-05-27, slot 422438019).
- This was the missing half of the refactor in #1137: that PR factored out `getNearestSlotTime` and migrated five other callers, but left the second `do/while` in `getLatestFinalizedSlotWithBlock` untouched, so the function never picked up the slot-skipped error handling it was supposed to.
- The function added no value over `getNearestSlotTime` once that abstraction existed, so it's deleted entirely. The four lines it would collapse to are inlined into the single caller (`getWidestPossibleExpectedBlockRange` in `PoolRebalanceUtils`).
- No external callers in `across-protocol/relayer` either.

## Test plan
- [x] `tsc --noEmit` (clean)
- [x] `yarn lint-check` (clean)
- [ ] Watch a dataworker run on `zion-across-disputer` once SDK bump lands and confirm the error stops recurring on snapshot/skip events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)