### PR TITLE
improve(svm): add describeSolanaError helper

### DIFF
--- a/src/arch/svm/provider.ts
+++ b/src/arch/svm/provider.ts
@@ -54,3 +54,61 @@ export interface SolanaErrorLike {
 export function isSolanaError(error: unknown): error is SolanaErrorLike {
   return _isSolanaError(error) || is(error, SolanaErrorStruct);
 }
+
+/**
+ * Structured description of a SolanaError suitable for logging.
+ *
+ * `code` and `context` mirror the underlying SolanaError's `context.__code` and `context` —
+ * `context` carries the rich diagnostic payload for typed errors (e.g. for
+ * `SVM_TRANSACTION_PREFLIGHT_FAILURE`, the `RpcSimulateTransactionResult` with `logs[]`,
+ * `accounts`, `returnData`, `unitsConsumed`). `cause` is recursively described when the
+ * underlying cause is itself a SolanaError (e.g. the `TransactionError` /
+ * `InstructionError` wrapped inside a preflight failure).
+ */
+export type SolanaErrorDescription = {
+  name: string;
+  message?: string;
+  code: number;
+  context: SolanaErrorLike["context"];
+  cause?: SolanaErrorDescription | { message: string };
+};
+
+/**
+ * Extract a structured, log-friendly description of a SolanaError. Returns `{}` for
+ * anything that isn't a SolanaError so callers can spread the result unconditionally.
+ *
+ * Motivation: most JSON logger formatters either (a) replace an `Error` field with its
+ * `.stack` string or (b) JSON.stringify it, which drops `context` and `cause` on
+ * SolanaErrors because those are own enumerable properties on the SolanaError instance
+ * but the loggers consult `.stack`/`.message` instead. This helper produces a plain
+ * object holding the fields you actually need to diagnose an SVM failure (program logs,
+ * underlying instruction error, etc.) that survives any standard serializer.
+ *
+ * @example
+ * try { await sendAndConfirmSolanaTransaction(tx, provider); }
+ * catch (err) {
+ *   logger.error({ at: "...", message: "...", error: err, ...describeSolanaError(err) });
+ * }
+ */
+export function describeSolanaError(err: unknown): { solanaError?: SolanaErrorDescription } {
+  if (!isSolanaError(err)) {
+    return {};
+  }
+  const solanaError: SolanaErrorDescription = {
+    name: err.name,
+    code: err.context.__code,
+    context: err.context,
+  };
+  if (err instanceof Error) {
+    solanaError.message = err.message;
+  }
+  if (err.cause !== undefined) {
+    const describedCause = describeSolanaError(err.cause);
+    if (describedCause.solanaError) {
+      solanaError.cause = describedCause.solanaError;
+    } else if (err.cause instanceof Error) {
+      solanaError.cause = { message: err.cause.message };
+    }
+  }
+  return { solanaError };
+}

--- a/src/arch/svm/provider.ts
+++ b/src/arch/svm/provider.ts
@@ -1,7 +1,10 @@
 import { isSolanaError as _isSolanaError } from "@solana/kit";
 import { is, type, number, string } from "superstruct";
 
-// SVM RPC provider error codes. https://www.quicknode.com/docs/solana/error-references
+/**
+ * SVM RPC provider error codes
+ * See https://www.quicknode.com/docs/solana/error-references
+ */
 export {
   SOLANA_ERROR__JSON_RPC__SERVER_ERROR_BLOCK_NOT_AVAILABLE as SVM_BLOCK_NOT_AVAILABLE,
   SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SLOT_SKIPPED as SVM_SLOT_SKIPPED,
@@ -9,7 +12,11 @@ export {
   SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE as SVM_TRANSACTION_PREFLIGHT_FAILURE,
 } from "@solana/kit";
 
-// Structural shape check for SolanaErrors that lost their prototype (e.g. JSON round-trip).
+/**
+ * Superstruct schema for validating SolanaError structure.
+ * Handles serialized errors that have lost their prototype chain.
+ * Uses partial validation to allow additional properties in the context object.
+ */
 const SolanaErrorStruct = type({
   name: string(),
   context: type({
@@ -17,6 +24,10 @@ const SolanaErrorStruct = type({
   }),
 });
 
+/**
+ * Type definition for SolanaError structure.
+ * Includes common context properties for better type inference.
+ */
 export interface SolanaErrorLike {
   name: string;
   context: {
@@ -28,7 +39,18 @@ export interface SolanaErrorLike {
   cause?: unknown;
 }
 
-// Falls back to structural check so deserialized SolanaErrors (no prototype) still match.
+/**
+ * Enhanced type guard to check if an error is a SolanaError.
+ *
+ * This function uses a two-tier approach:
+ * 1. First attempts the official instanceof-based check from @solana/kit
+ * 2. Falls back to structural validation using superstruct for errors that have been
+ *    serialized/deserialized (e.g., when crossing async boundaries or through JSON parsing)
+ *
+ * @param error The error to check
+ * @param code Optional error code to match against context.__code
+ * @returns True if the error is a SolanaError (or has valid SolanaError structure)
+ */
 export function isSolanaError(error: unknown): error is SolanaErrorLike {
   return _isSolanaError(error) || is(error, SolanaErrorStruct);
 }

--- a/src/arch/svm/provider.ts
+++ b/src/arch/svm/provider.ts
@@ -1,10 +1,7 @@
 import { isSolanaError as _isSolanaError } from "@solana/kit";
 import { is, type, number, string } from "superstruct";
 
-/**
- * SVM RPC provider error codes
- * See https://www.quicknode.com/docs/solana/error-references
- */
+// SVM RPC provider error codes. https://www.quicknode.com/docs/solana/error-references
 export {
   SOLANA_ERROR__JSON_RPC__SERVER_ERROR_BLOCK_NOT_AVAILABLE as SVM_BLOCK_NOT_AVAILABLE,
   SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SLOT_SKIPPED as SVM_SLOT_SKIPPED,
@@ -12,11 +9,7 @@ export {
   SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE as SVM_TRANSACTION_PREFLIGHT_FAILURE,
 } from "@solana/kit";
 
-/**
- * Superstruct schema for validating SolanaError structure.
- * Handles serialized errors that have lost their prototype chain.
- * Uses partial validation to allow additional properties in the context object.
- */
+// Structural shape check for SolanaErrors that lost their prototype (e.g. JSON round-trip).
 const SolanaErrorStruct = type({
   name: string(),
   context: type({
@@ -24,10 +17,6 @@ const SolanaErrorStruct = type({
   }),
 });
 
-/**
- * Type definition for SolanaError structure.
- * Includes common context properties for better type inference.
- */
 export interface SolanaErrorLike {
   name: string;
   context: {
@@ -39,32 +28,11 @@ export interface SolanaErrorLike {
   cause?: unknown;
 }
 
-/**
- * Enhanced type guard to check if an error is a SolanaError.
- *
- * This function uses a two-tier approach:
- * 1. First attempts the official instanceof-based check from @solana/kit
- * 2. Falls back to structural validation using superstruct for errors that have been
- *    serialized/deserialized (e.g., when crossing async boundaries or through JSON parsing)
- *
- * @param error The error to check
- * @param code Optional error code to match against context.__code
- * @returns True if the error is a SolanaError (or has valid SolanaError structure)
- */
+// Falls back to structural check so deserialized SolanaErrors (no prototype) still match.
 export function isSolanaError(error: unknown): error is SolanaErrorLike {
   return _isSolanaError(error) || is(error, SolanaErrorStruct);
 }
 
-/**
- * Structured description of a SolanaError suitable for logging.
- *
- * `code` and `context` mirror the underlying SolanaError's `context.__code` and `context` —
- * `context` carries the rich diagnostic payload for typed errors (e.g. for
- * `SVM_TRANSACTION_PREFLIGHT_FAILURE`, the `RpcSimulateTransactionResult` with `logs[]`,
- * `accounts`, `returnData`, `unitsConsumed`). `cause` is recursively described when the
- * underlying cause is itself a SolanaError (e.g. the `TransactionError` /
- * `InstructionError` wrapped inside a preflight failure).
- */
 export type SolanaErrorDescription = {
   name: string;
   message?: string;
@@ -74,21 +42,13 @@ export type SolanaErrorDescription = {
 };
 
 /**
- * Extract a structured, log-friendly description of a SolanaError. Returns `{}` for
- * anything that isn't a SolanaError so callers can spread the result unconditionally.
+ * Extract a log-friendly description of a SolanaError. Returns `{}` for non-SolanaError
+ * inputs so callers can spread unconditionally:
+ *   logger.error({ at, message, error: err, ...describeSolanaError(err) });
  *
- * Motivation: most JSON logger formatters either (a) replace an `Error` field with its
- * `.stack` string or (b) JSON.stringify it, which drops `context` and `cause` on
- * SolanaErrors because those are own enumerable properties on the SolanaError instance
- * but the loggers consult `.stack`/`.message` instead. This helper produces a plain
- * object holding the fields you actually need to diagnose an SVM failure (program logs,
- * underlying instruction error, etc.) that survives any standard serializer.
- *
- * @example
- * try { await sendAndConfirmSolanaTransaction(tx, provider); }
- * catch (err) {
- *   logger.error({ at: "...", message: "...", error: err, ...describeSolanaError(err) });
- * }
+ * Most JSON loggers serialize Errors via `.stack`/`.message`, dropping SolanaError's
+ * `context` (program logs, accounts, unitsConsumed) and `cause` (wrapped TransactionError /
+ * InstructionError). This produces a plain object that survives any standard serializer.
  */
 export function describeSolanaError(err: unknown): { solanaError?: SolanaErrorDescription } {
   if (!isSolanaError(err)) {

--- a/test/describeSolanaError.test.ts
+++ b/test/describeSolanaError.test.ts
@@ -1,0 +1,100 @@
+import { describeSolanaError, SVM_TRANSACTION_PREFLIGHT_FAILURE, SVM_SLOT_SKIPPED } from "../src/arch/svm/provider";
+import { expect } from "./utils";
+
+describe("describeSolanaError", () => {
+  it("returns an empty object for non-Solana errors", () => {
+    expect(describeSolanaError(new Error("regular"))).to.deep.equal({});
+    expect(describeSolanaError("oops")).to.deep.equal({});
+    expect(describeSolanaError(undefined)).to.deep.equal({});
+    expect(describeSolanaError(null)).to.deep.equal({});
+    expect(describeSolanaError({ random: "object" })).to.deep.equal({});
+  });
+
+  it("extracts name, code, and context from a SolanaError-like object", () => {
+    const err = {
+      name: "SolanaError",
+      context: {
+        __code: SVM_TRANSACTION_PREFLIGHT_FAILURE,
+        logs: ["Program log: refund leaf already executed"],
+        accounts: null,
+        unitsConsumed: 4321,
+      },
+    };
+
+    const result = describeSolanaError(err);
+    expect(result.solanaError).to.not.be.undefined;
+    expect(result.solanaError?.name).to.equal("SolanaError");
+    expect(result.solanaError?.code).to.equal(SVM_TRANSACTION_PREFLIGHT_FAILURE);
+    expect(result.solanaError?.context).to.deep.equal(err.context);
+    // message field is only populated for real Error instances; the plain object form omits it.
+    expect(result.solanaError?.message).to.be.undefined;
+  });
+
+  it("populates `message` when the input is an Error instance", () => {
+    class FakeSolanaError extends Error {
+      readonly name = "SolanaError";
+      readonly context = { __code: SVM_SLOT_SKIPPED };
+    }
+    const err = new FakeSolanaError("Slot was skipped");
+
+    const result = describeSolanaError(err);
+    expect(result.solanaError?.message).to.equal("Slot was skipped");
+  });
+
+  it("recursively describes a SolanaError cause", () => {
+    const inner = {
+      name: "SolanaError",
+      context: { __code: 4615001, index: 3 },
+    };
+    const outer = {
+      name: "SolanaError",
+      context: { __code: SVM_TRANSACTION_PREFLIGHT_FAILURE, logs: ["Program log: x"] },
+      cause: inner,
+    };
+
+    const result = describeSolanaError(outer);
+    expect(result.solanaError?.cause).to.deep.equal({
+      name: "SolanaError",
+      code: 4615001,
+      context: inner.context,
+    });
+  });
+
+  it("falls back to { message } when the cause is a non-Solana Error", () => {
+    const outer = {
+      name: "SolanaError",
+      context: { __code: SVM_TRANSACTION_PREFLIGHT_FAILURE },
+      cause: new Error("network blip"),
+    };
+
+    const result = describeSolanaError(outer);
+    expect(result.solanaError?.cause).to.deep.equal({ message: "network blip" });
+  });
+
+  it("omits cause when the SolanaError has no cause", () => {
+    const err = {
+      name: "SolanaError",
+      context: { __code: SVM_SLOT_SKIPPED },
+    };
+
+    const result = describeSolanaError(err);
+    expect(result.solanaError?.cause).to.be.undefined;
+  });
+
+  it("survives JSON serialization round-trips (structurally cloned error)", () => {
+    const err = JSON.parse(
+      JSON.stringify({
+        name: "SolanaError",
+        context: { __code: SVM_TRANSACTION_PREFLIGHT_FAILURE, logs: ["a", "b"] },
+        cause: {
+          name: "SolanaError",
+          context: { __code: 4615001 },
+        },
+      })
+    );
+
+    const result = describeSolanaError(err);
+    expect(result.solanaError?.code).to.equal(SVM_TRANSACTION_PREFLIGHT_FAILURE);
+    expect(result.solanaError?.cause).to.deep.include({ code: 4615001 });
+  });
+});

--- a/test/providers/solana/describeSolanaError.test.ts
+++ b/test/providers/solana/describeSolanaError.test.ts
@@ -1,5 +1,9 @@
-import { describeSolanaError, SVM_TRANSACTION_PREFLIGHT_FAILURE, SVM_SLOT_SKIPPED } from "../src/arch/svm/provider";
-import { expect } from "./utils";
+import {
+  describeSolanaError,
+  SVM_TRANSACTION_PREFLIGHT_FAILURE,
+  SVM_SLOT_SKIPPED,
+} from "../../../src/arch/svm/provider";
+import { expect } from "../../utils";
 
 describe("describeSolanaError", () => {
   it("returns an empty object for non-Solana errors", () => {


### PR DESCRIPTION
## Summary

Add `describeSolanaError(err)` next to `isSolanaError` in `src/arch/svm/provider.ts`. Pure transform; returns a plain object holding the SolanaError diagnostic fields (`name`, optional `message`, `code`, `context`, recursively-described `cause`) that JSON loggers would otherwise drop, and `{}` for anything that isn't a SolanaError so callers can spread it unconditionally:

```ts
catch (err) {
  logger.error({ at: "...", message: "...", error: err, ...describeSolanaError(err) });
}
```

### Why

A `SolanaError` keeps the rich diagnostics (program `logs[]`, `accounts`, `unitsConsumed`, plus the wrapped `TransactionError` / `InstructionError`) on its `context` and `cause` fields. Most JSON loggers either replace an `Error` value with `.stack` (e.g. `@risk-labs/logger`'s `errorStackTracerFormatter`) or `JSON.stringify` it — and `Error.stack`/`Error.message`/`Error.name` are non-enumerable on the prototype, so the structured payload that SolanaError adds gets silently dropped. The relayer dataworker is hitting this today on SVM refund-leaf execution failures: prod logs read only `SolanaError: Transaction simulation failed at /across-relayer/node_modules/@solana/rpc-transformers/dist/index.node.cjs:332:22 …`, with no way to tell whether it was a benign already-executed race, a stale blockhash, a custom program error, or RPC flake.

A private copy of this helper landed in `across-protocol/relayer#3422` to unblock prod visibility. Moving it down to the SDK so the other consumers (`indexer`, `relayer-madrid`, `quote-api`, anything calling `arch.svm.*`) can share it. The relayer-side follow-up will swap its local copy for this SDK export.

### Shape

For a preflight-failure SolanaError, `describeSolanaError(err)` now returns (in addition to whatever the logger does with `error: err`):

```json
{
  "solanaError": {
    "name": "SolanaError",
    "message": "Transaction simulation failed",
    "code": -32002,
    "context": {
      "__code": -32002,
      "logs": ["Program log: refund leaf already executed"],
      "accounts": null,
      "unitsConsumed": 4321
    },
    "cause": {
      "name": "SolanaError",
      "code": 4615001,
      "context": { "__code": 4615001, "index": 3 }
    }
  }
}
```

Mirrors the structural-clone resilience that `isSolanaError` already has: the helper works whether the input is a live `SolanaError` instance or a JSON round-tripped object that lost its prototype chain.

## Test plan

- [x] `yarn lint-check` (clean)
- [x] `npx hardhat test test/describeSolanaError.test.ts` (7 new unit tests pass — covers non-Solana inputs, plain SolanaError-like objects, Error subclasses, nested SolanaError causes, non-Solana Error causes, no-cause case, JSON serialization round-trips)
- [ ] Wire into relayer (#3422 follow-up); confirm the new payload appears in `bots-across-3839` Cloud Run logs after deploy

Thread: [#bot-monitoring 1779869895.829509](https://risklabs.slack.com/archives/C03GHT4RV42/p1779869895829509)

🤖 Generated with [Claude Code](https://claude.com/claude-code)