### PR TITLE
fix(svm): treat BLOCK_NOT_AVAILABLE like SLOT_SKIPPED for getBlock/getBlockTime

### DIFF
--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -86,7 +86,12 @@ import {
   toSvmRelayData,
 } from "./";
 import { SvmCpiEventsClient } from "./eventsClient";
-import { SVM_LONG_TERM_STORAGE_SLOT_SKIPPED, SVM_SLOT_SKIPPED, isSolanaError } from "./provider";
+import {
+  SVM_BLOCK_NOT_AVAILABLE,
+  SVM_LONG_TERM_STORAGE_SLOT_SKIPPED,
+  SVM_SLOT_SKIPPED,
+  isSolanaError,
+} from "./provider";
 import { AttestedCCTPMessage, SVMEventNames, SVMProvider, LatestBlockhash, SolanaTransaction } from "./types";
 import {
   getEmergencyDeleteRootBundleRootBundleId,
@@ -182,7 +187,12 @@ async function _callGetTimestampForSlotWithRetry(
     switch (code) {
       case SVM_SLOT_SKIPPED:
       case SVM_LONG_TERM_STORAGE_SLOT_SKIPPED:
+      case SVM_BLOCK_NOT_AVAILABLE:
         // No block available for this slot; caller must decide on how to handle this.
+        // BLOCK_NOT_AVAILABLE is treated as equivalent to SLOT_SKIPPED here because third-party
+        // RPCs (QuickNode, Chainstack) return -32004 for skipped slots once the local blockstore
+        // marker has been pruned, where canonical Solana RPCs return -32007. The back-walk in
+        // getNearestSlotTime relies on undefined being returned for either case.
         return undefined;
 
       default: {

--- a/src/providers/solana/utils.ts
+++ b/src/providers/solana/utils.ts
@@ -2,6 +2,7 @@ import { RpcTransport } from "@solana/rpc-spec";
 import { SolanaRpcApi } from "@solana/kit";
 import {
   isSolanaError,
+  SVM_BLOCK_NOT_AVAILABLE,
   SVM_SLOT_SKIPPED,
   SVM_LONG_TERM_STORAGE_SLOT_SKIPPED,
   SVM_TRANSACTION_PREFLIGHT_FAILURE,
@@ -79,8 +80,12 @@ export function shouldFailImmediate(method: string, error: unknown): boolean {
   switch (method) {
     case "getBlock":
     case "getBlockTime":
-      // No block at the requested slot. This may not be correct for blocks > 1 year old.
-      return [SVM_SLOT_SKIPPED, SVM_LONG_TERM_STORAGE_SLOT_SKIPPED].includes(code);
+      // No block at the requested slot. Some third-party RPCs (e.g. QuickNode, Chainstack) return
+      // BLOCK_NOT_AVAILABLE for skipped slots whose marker has been pruned from the local blockstore
+      // — the same physical condition canonical Solana RPCs surface as SLOT_SKIPPED. Treat all three
+      // codes as deterministic across providers so the quorum layer short-circuits instead of
+      // re-trying every fallback and wrapping the result in a "Not enough providers succeeded" error.
+      return [SVM_BLOCK_NOT_AVAILABLE, SVM_SLOT_SKIPPED, SVM_LONG_TERM_STORAGE_SLOT_SKIPPED].includes(code);
     case "sendTransaction":
       // Preflight failures are deterministic across providers; falling back only succeeds on RPCs that skip preflight.
       return code === SVM_TRANSACTION_PREFLIGHT_FAILURE;

--- a/test/providers/solana/quorumFallbackRpcFactory.test.ts
+++ b/test/providers/solana/quorumFallbackRpcFactory.test.ts
@@ -1,7 +1,11 @@
 import { RpcResponse, RpcTransport } from "@solana/kit";
 import { expect } from "chai";
 import winston from "winston";
-import { SVM_SLOT_SKIPPED, SVM_LONG_TERM_STORAGE_SLOT_SKIPPED } from "../../../src/arch/svm/provider";
+import {
+  SVM_BLOCK_NOT_AVAILABLE,
+  SVM_SLOT_SKIPPED,
+  SVM_LONG_TERM_STORAGE_SLOT_SKIPPED,
+} from "../../../src/arch/svm/provider";
 import { CachedSolanaRpcFactory } from "../../../src/providers/solana/cachedRpcFactory";
 import { QuorumFallbackSolanaRpcFactory } from "../../../src/providers/solana/quorumFallbackRpcFactory";
 
@@ -91,6 +95,25 @@ describe("QuorumFallbackSolanaRpcFactory error preservation", () => {
     }
 
     expect(caught).to.equal(skipped);
+  });
+
+  it("rethrows the underlying SolanaError for SVM_BLOCK_NOT_AVAILABLE on getBlockTime", async () => {
+    // Third-party RPCs (QuickNode, Chainstack) return BLOCK_NOT_AVAILABLE for skipped slots
+    // whose blockstore marker has been pruned. The quorum layer should treat this the same
+    // as SLOT_SKIPPED so callers can branch on isSolanaError(...).
+    const notAvailable = solanaError(SVM_BLOCK_NOT_AVAILABLE, "Block not available for slot 422715124");
+    const factory = buildFactory([rejectingTransport(notAvailable)]);
+
+    let caught: unknown;
+    try {
+      await factory.createTransport()(payload("getBlockTime", [422715124]));
+      expect.fail("Expected the transport to reject");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).to.equal(notAvailable);
+    expect((caught as { context: { __code: number } }).context.__code).to.equal(SVM_BLOCK_NOT_AVAILABLE);
   });
 
   it("rethrows the SolanaError when every required-provider rejection is shouldFailImmediate", async () => {

--- a/test/providers/solana/utils.test.ts
+++ b/test/providers/solana/utils.test.ts
@@ -1,4 +1,5 @@
 import {
+  SVM_BLOCK_NOT_AVAILABLE,
   SVM_LONG_TERM_STORAGE_SLOT_SKIPPED,
   SVM_SLOT_SKIPPED,
   SVM_TRANSACTION_PREFLIGHT_FAILURE,
@@ -25,6 +26,10 @@ describe("shouldFailImmediate", () => {
 
       it(`${method}: short-circuits on SVM_LONG_TERM_STORAGE_SLOT_SKIPPED`, () => {
         expect(shouldFailImmediate(method, solanaError(SVM_LONG_TERM_STORAGE_SLOT_SKIPPED))).to.be.true;
+      });
+
+      it(`${method}: short-circuits on SVM_BLOCK_NOT_AVAILABLE`, () => {
+        expect(shouldFailImmediate(method, solanaError(SVM_BLOCK_NOT_AVAILABLE))).to.be.true;
       });
 
       it(`${method}: does not short-circuit on other codes`, () => {


### PR DESCRIPTION
## Summary

- The relayer's `inventoryManager` crashed on a skipped Solana slot with `Not enough providers succeeded on getBlockTime call. ... Block not available for slot 422715124`. The root cause is an RPC error-code mismatch: third-party RPCs (QuickNode, Chainstack) return `-32004 BLOCK_NOT_AVAILABLE` for skipped slots whose blockstore marker has been pruned locally, while canonical Solana RPCs surface the same physical condition as `-32007 SLOT_SKIPPED`. The SDK only treated the `SLOT_SKIPPED` codes as "no block, move on", so the back-walk in `getNearestSlotTime` threw and the quorum layer wrapped the failure instead of short-circuiting.
- Fix: extend `shouldFailImmediate` (`getBlock` / `getBlockTime` arms) and the `_callGetTimestampForSlotWithRetry` switch to also recognize `SVM_BLOCK_NOT_AVAILABLE`. Constant is already re-exported from `arch/svm/provider`.
- Scoped change: only these two RPC methods. The "slot not yet rooted" semantics of `BLOCK_NOT_AVAILABLE` are preserved everywhere else (it can also be raised by `check_blockstore_root` when `slot >= blockstore.max_root()` per [agave/rpc/src/rpc.rs](https://github.com/anza-xyz/agave/blob/master/rpc/src/rpc.rs)), but for `getBlock` / `getBlockTime` lookups the SDK's callers (`getNearestSlotTime` back-walk, `SVMBlockFinder.getBlock`) treat "no block" as expected and walk back a slot.

## Context

- Triggering incident: relayer error in Slack, slot 422715124 on Solana mainnet.
- Verified directly against `api.mainnet-beta.solana.com`: that slot returns `-32007 SLOT_SKIPPED` ("Slot 422715124 was skipped, or missing due to ledger jump to recent snapshot") — confirming the slot is genuinely skipped, not pruned/missing.
- Canonical error definitions: [`anza-xyz/agave/rpc-client-api/src/custom_error.rs`](https://github.com/anza-xyz/agave/blob/master/rpc-client-api/src/custom_error.rs). `JSON_RPC_SERVER_ERROR_BLOCK_NOT_AVAILABLE = -32004`, `JSON_RPC_SERVER_ERROR_SLOT_SKIPPED = -32007`, `JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_SLOT_SKIPPED = -32009`. They are not synonyms canonically — but on the lookup paths that hit `get_block` / `get_block_time`, both `SLOT_SKIPPED` and `BLOCK_NOT_AVAILABLE` indicate "no block here" from the SDK's perspective.
- Companion to #1443, which previously added the `shouldFailImmediate` plumbing for `SLOT_SKIPPED` so callers can branch on `isSolanaError(...)`.

## Test plan

- [x] `yarn hardhat test test/providers/solana/utils.test.ts test/providers/solana/quorumFallbackRpcFactory.test.ts` — 20 passing including three new cases (`shouldFailImmediate` short-circuits on `BLOCK_NOT_AVAILABLE` for `getBlock` and `getBlockTime`; quorum fallback rethrows the underlying `SolanaError` for `BLOCK_NOT_AVAILABLE` on `getBlockTime`).
- [x] `yarn lint-check` clean.
- [x] `yarn build` clean.
- [ ] Bump SDK in `across-protocol/relayer` after release to land in `zion-across-inventory-manager-primary`.
