### PR TITLE
chore(svm): surface JSON-RPC error code in QuorumFallback wrap messages

### DIFF
--- a/src/providers/solana/quorumFallbackRpcFactory.ts
+++ b/src/providers/solana/quorumFallbackRpcFactory.ts
@@ -57,9 +57,7 @@ export class QuorumFallbackSolanaRpcFactory extends SolanaBaseRpcFactory {
           .transport<TResponse>(...args)
           .then((result): [SolanaClusterRpcFactory, RpcResponse<TResponse>] => [factory.rpcFactory, result])
           .catch((error) => {
-            // Append the provider and error to the error array. For SolanaErrors this surfaces
-            // the JSON-RPC error code so wrap-message readers can tell -32007/-32009 (canonical
-            // skip determinations) apart from -32004 (generic "couldn't return a block").
+            // Preserve the underlying JSON-RPC error code in the wrap message.
             errors.push([factory.rpcFactory, formatRpcError(error)]);
 
             // If all fallback providers fail, then return the last received error.

--- a/src/providers/solana/quorumFallbackRpcFactory.ts
+++ b/src/providers/solana/quorumFallbackRpcFactory.ts
@@ -4,7 +4,7 @@ import { isPromiseFulfilled, isPromiseRejected } from "../../utils/TypeGuards";
 import { compareSvmRpcResults, createSendErrorWithMessage } from "../utils";
 import { CachedSolanaRpcFactory } from "./cachedRpcFactory";
 import { SolanaBaseRpcFactory, SolanaClusterRpcFactory } from "./baseRpcFactories";
-import { shouldFailImmediate } from "./utils";
+import { formatRpcError, shouldFailImmediate } from "./utils";
 
 // This factory stores multiple Cached RPC factories so that users of this factory can specify multiple RPC providers
 // and the factory will fallback through them if any RPC calls fail. This factory also implements quorum logic amongst
@@ -57,9 +57,10 @@ export class QuorumFallbackSolanaRpcFactory extends SolanaBaseRpcFactory {
           .transport<TResponse>(...args)
           .then((result): [SolanaClusterRpcFactory, RpcResponse<TResponse>] => [factory.rpcFactory, result])
           .catch((error) => {
-            // Append the provider and error to the error array.
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            errors.push([factory.rpcFactory, (error as any)?.stack || error?.toString()]);
+            // Append the provider and error to the error array. For SolanaErrors this surfaces
+            // the JSON-RPC error code so wrap-message readers can tell -32007/-32009 (canonical
+            // skip determinations) apart from -32004 (generic "couldn't return a block").
+            errors.push([factory.rpcFactory, formatRpcError(error)]);
 
             // If all fallback providers fail, then return the last received error.
             if (fallbackFactories.length === 0) {
@@ -208,7 +209,7 @@ export class QuorumFallbackSolanaRpcFactory extends SolanaBaseRpcFactory {
             .transport<TResponse>(...args)
             .then((result): [SolanaClusterRpcFactory, TResponse] => [factory.rpcFactory, result])
             .catch((err) => {
-              errors.push([factory.rpcFactory, err?.stack || err?.toString()]);
+              errors.push([factory.rpcFactory, formatRpcError(err)]);
               throw new Error("Fallback RPC call failed while trying to reach quorum");
             });
         })

--- a/src/providers/solana/utils.ts
+++ b/src/providers/solana/utils.ts
@@ -64,6 +64,24 @@ export interface JitoInterface extends SolanaRpcApi {
 }
 
 /**
+ * Render an RPC error for inclusion in log/wrap messages. For SolanaErrors, surfaces the numeric
+ * JSON-RPC error code alongside the server message so downstream readers can distinguish canonical
+ * positive determinations (SLOT_SKIPPED, LONG_TERM_STORAGE_SLOT_SKIPPED) from generic catch-all
+ * codes (BLOCK_NOT_AVAILABLE) without parsing the message string. @solana/kit's default message
+ * template for these codes is `$__serverMessage` — pass-through — so the code is otherwise lost.
+ * Falls back to the stack/toString for non-Solana errors.
+ */
+export function formatRpcError(error: unknown): string {
+  if (isSolanaError(error)) {
+    const { __code: code, __serverMessage: serverMessage } = error.context;
+    const message = serverMessage ?? (error as { message?: string }).message ?? "";
+    return `SolanaError [${code}]: ${message}`;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (error as any)?.stack || (error as any)?.toString?.() || String(error);
+}
+
+/**
  * Determine whether a Solana RPC error indicates an unrecoverable error that should not be retried.
  * @param method RPC method name.
  * @param error Error object from the RPC call.

--- a/src/providers/solana/utils.ts
+++ b/src/providers/solana/utils.ts
@@ -64,12 +64,8 @@ export interface JitoInterface extends SolanaRpcApi {
 }
 
 /**
- * Render an RPC error for inclusion in log/wrap messages. For SolanaErrors, surfaces the numeric
- * JSON-RPC error code alongside the server message so downstream readers can distinguish canonical
- * positive determinations (SLOT_SKIPPED, LONG_TERM_STORAGE_SLOT_SKIPPED) from generic catch-all
- * codes (BLOCK_NOT_AVAILABLE) without parsing the message string. @solana/kit's default message
- * template for these codes is `$__serverMessage` — pass-through — so the code is otherwise lost.
- * Falls back to the stack/toString for non-Solana errors.
+ * Render an RPC error for log/wrap messages. For SolanaErrors, includes the numeric JSON-RPC
+ * code alongside the server message; otherwise falls back to stack/toString.
  */
 export function formatRpcError(error: unknown): string {
   if (isSolanaError(error)) {

--- a/test/providers/solana/quorumFallbackRpcFactory.test.ts
+++ b/test/providers/solana/quorumFallbackRpcFactory.test.ts
@@ -1,7 +1,11 @@
 import { RpcResponse, RpcTransport } from "@solana/kit";
 import { expect } from "chai";
 import winston from "winston";
-import { SVM_SLOT_SKIPPED, SVM_LONG_TERM_STORAGE_SLOT_SKIPPED } from "../../../src/arch/svm/provider";
+import {
+  SVM_BLOCK_NOT_AVAILABLE,
+  SVM_LONG_TERM_STORAGE_SLOT_SKIPPED,
+  SVM_SLOT_SKIPPED,
+} from "../../../src/arch/svm/provider";
 import { CachedSolanaRpcFactory } from "../../../src/providers/solana/cachedRpcFactory";
 import { QuorumFallbackSolanaRpcFactory } from "../../../src/providers/solana/quorumFallbackRpcFactory";
 
@@ -158,6 +162,29 @@ describe("QuorumFallbackSolanaRpcFactory error preservation", () => {
 
     expect(caught).to.be.instanceOf(Error);
     expect((caught as Error).message).to.match(/Not enough providers succeeded/);
+  });
+
+  it("includes the JSON-RPC error code in the wrap message for SolanaError rejections", async () => {
+    // Regression: the previous wrap used `error.stack || error.toString()`, which on @solana/kit
+    // SolanaErrors drops `context.__code` and only leaves the server message. When two providers
+    // both fail with the canonical "Block not available for slot N" message, downstream readers
+    // can't tell from the wrap whether the underlying code was -32004 (generic, inconclusive) or
+    // some other code rendered with the same server text. Surface the code explicitly.
+    const blockNotAvailable = solanaError(SVM_BLOCK_NOT_AVAILABLE, "Block not available for slot 422715124");
+    const factory = buildFactory([rejectingTransport(blockNotAvailable), rejectingTransport(blockNotAvailable)], 2);
+
+    let caught: unknown;
+    try {
+      await factory.createTransport()(payload("getBlockTime", [422715124]));
+      expect.fail("Expected the transport to reject");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).to.be.instanceOf(Error);
+    expect((caught as Error).message).to.match(/Not enough providers succeeded/);
+    expect((caught as Error).message).to.include(`SolanaError [${SVM_BLOCK_NOT_AVAILABLE}]`);
+    expect((caught as Error).message).to.include("Block not available for slot 422715124");
   });
 
   it("succeeds normally when the provider returns a result", async () => {

--- a/test/providers/solana/utils.test.ts
+++ b/test/providers/solana/utils.test.ts
@@ -1,9 +1,10 @@
 import {
+  SVM_BLOCK_NOT_AVAILABLE,
   SVM_LONG_TERM_STORAGE_SLOT_SKIPPED,
   SVM_SLOT_SKIPPED,
   SVM_TRANSACTION_PREFLIGHT_FAILURE,
 } from "../../../src/arch/svm/provider";
-import { shouldFailImmediate } from "../../../src/providers/solana/utils";
+import { formatRpcError, shouldFailImmediate } from "../../../src/providers/solana/utils";
 import { expect } from "../../utils";
 
 const solanaError = (code: number, context: Record<string, unknown> = {}) => ({
@@ -48,5 +49,38 @@ describe("shouldFailImmediate", () => {
   it("returns false for unhandled methods", () => {
     expect(shouldFailImmediate("getAccountInfo", solanaError(SVM_TRANSACTION_PREFLIGHT_FAILURE))).to.be.false;
     expect(shouldFailImmediate("getSlot", solanaError(SVM_SLOT_SKIPPED))).to.be.false;
+  });
+});
+
+describe("formatRpcError", () => {
+  it("includes the JSON-RPC code and server message for SolanaErrors", () => {
+    expect(formatRpcError(solanaError(SVM_SLOT_SKIPPED, { __serverMessage: "Slot 422715124 was skipped" }))).to.equal(
+      `SolanaError [${SVM_SLOT_SKIPPED}]: Slot 422715124 was skipped`
+    );
+    expect(
+      formatRpcError(
+        solanaError(SVM_LONG_TERM_STORAGE_SLOT_SKIPPED, {
+          __serverMessage: "Slot 422715124 was skipped, or missing in long-term storage",
+        })
+      )
+    ).to.equal(
+      `SolanaError [${SVM_LONG_TERM_STORAGE_SLOT_SKIPPED}]: Slot 422715124 was skipped, or missing in long-term storage`
+    );
+    expect(
+      formatRpcError(solanaError(SVM_BLOCK_NOT_AVAILABLE, { __serverMessage: "Block not available for slot 1" }))
+    ).to.equal(`SolanaError [${SVM_BLOCK_NOT_AVAILABLE}]: Block not available for slot 1`);
+  });
+
+  it("renders the code even when __serverMessage is missing, using the Error message", () => {
+    const err = { name: "SolanaError", context: { __code: SVM_SLOT_SKIPPED }, message: "fallback message" };
+    expect(formatRpcError(err)).to.equal(`SolanaError [${SVM_SLOT_SKIPPED}]: fallback message`);
+  });
+
+  it("falls back to stack/toString for non-Solana errors", () => {
+    const networkError = new Error("network down");
+    expect(formatRpcError(networkError)).to.include("network down");
+
+    expect(formatRpcError("plain string error")).to.equal("plain string error");
+    expect(formatRpcError(undefined)).to.equal("undefined");
   });
 });


### PR DESCRIPTION
## Summary

Surface the JSON-RPC error code in the wrap message produced by `QuorumFallbackSolanaRpcFactory` when no provider succeeds. Today the per-provider error is stringified with `error.stack || error.toString()`. For a `@solana/kit` `SolanaError`, `toString()` only carries the server message — the numeric code in `context.__code` is dropped, because the Kit's message template for `BLOCK_NOT_AVAILABLE` / `SLOT_SKIPPED` / `LONG_TERM_STORAGE_SLOT_SKIPPED` is the verbatim `$__serverMessage` pass-through ([`anza-xyz/kit/packages/errors/src/messages.ts`](https://github.com/anza-xyz/kit/blob/main/packages/errors/src/messages.ts)).

That means an operator reading a wrapped `Not enough providers succeeded` log can't tell `-32004` (generic "couldn't return a block", inconclusive) apart from `-32007` / `-32009` (canonical positive determinations of skip) when the server message overlaps or is otherwise ambiguous.

This is purely diagnostic — no behavior change.

## Motivation

We recently spent a thread debating whether two providers were systematically returning the wrong error code for a particular slot, based only on the server message text we had in a relayer log. Both providers turned out to be canonical when re-probed directly; the failing slot had hit a transient state-transition window. We'd have skipped the wrong-headed analysis if the wrap had carried the `__code` alongside the message.

## Changes

- New helper `formatRpcError(error: unknown): string` in `src/providers/solana/utils.ts`:
  - For `SolanaError`-shaped values, renders as `SolanaError [<code>]: <server-message>`.
  - Else falls back to the existing `error.stack || error.toString()` behavior.
- `src/providers/solana/quorumFallbackRpcFactory.ts`: use `formatRpcError` at both error-push sites (the per-slot fallback walk and the parallel quorum-fallback path). No other behavior change.

## Test plan

- [x] `yarn hardhat test test/providers/solana/utils.test.ts test/providers/solana/quorumFallbackRpcFactory.test.ts` — 21 passing.
  - Three new `formatRpcError` cases (code+server-message rendering for canonical-skip codes and BLOCK_NOT_AVAILABLE; fallback to `.message` when `__serverMessage` is absent; fallback to stack/toString for non-Solana errors).
  - One new regression in the quorum factory test that exercises the prod-shape scenario (two providers both rejecting with a `SolanaError`, quorum=2 → wrap path) and asserts the wrap message contains `SolanaError [<code>]: <server-message>`.
- [x] `yarn lint-check` clean.
- [x] `yarn build` clean.
