### PR TITLE
fix(svm): lower-bound quorum for getSlot to reject single-provider tip lag

### DIFF
--- a/src/providers/solana/quorumFallbackRpcFactory.ts
+++ b/src/providers/solana/quorumFallbackRpcFactory.ts
@@ -40,6 +40,17 @@ export class QuorumFallbackSolanaRpcFactory extends SolanaBaseRpcFactory {
   public createTransport(): RpcTransport {
     return async <TResponse>(...args: Parameters<RpcTransport>): Promise<RpcResponse<TResponse>> => {
       const { method, params } = args[0].payload as { method: string; params?: unknown[] };
+
+      // Methods whose results converge across providers but never agree exactly at the chain head
+      // (e.g. `getSlot`) cannot use strict-equality quorum. Use a lower-bound quorum instead:
+      // query all providers and return the K-th highest value, i.e. the highest value that at least
+      // K providers report the chain has reached. This rejects a single lagging provider when N>K
+      // and forces a single outlier-high provider to have at least one ally to influence the result.
+      // Guarded on `nodeQuorumThreshold > 1` so quorum=1 bots keep the single-provider fast path.
+      if (LOWER_BOUND_QUORUM_METHODS.includes(method) && this.nodeQuorumThreshold > 1) {
+        return this._lowerBoundQuorumCall<TResponse>(method, params ?? [], ...args);
+      }
+
       const quorumThreshold = this._getQuorum(method, params ?? []);
       const requiredFactories = this.rpcFactories.slice(0, quorumThreshold);
       const fallbackFactories = [...this.rpcFactories.slice(quorumThreshold)];
@@ -255,8 +266,86 @@ export class QuorumFallbackSolanaRpcFactory extends SolanaBaseRpcFactory {
     // All other calls should use quorum 1 to avoid errors due to sync differences.
     return 1;
   }
+
+  // Aggregate a chain-tip query under a "lower-bound quorum": query every configured provider in
+  // parallel, sort the successful bigint responses descending, and return the value at index
+  // (nodeQuorumThreshold - 1). Semantically: "at least nodeQuorumThreshold providers report the
+  // chain has reached at least this slot." The K-th highest is rejected only if all providers
+  // above it are colluding (or simply wrong in the same direction).
+  private async _lowerBoundQuorumCall<TResponse>(
+    method: string,
+    params: unknown[],
+    ...args: Parameters<RpcTransport>
+  ): Promise<RpcResponse<TResponse>> {
+    const errors: [SolanaClusterRpcFactory, string][] = [];
+
+    const settled = await Promise.allSettled(
+      this.rpcFactories.map((factory) =>
+        factory
+          .transport<TResponse>(...args)
+          .then((value): [SolanaClusterRpcFactory, RpcResponse<TResponse>] => [factory.rpcFactory, value])
+          .catch((error) => {
+            errors.push([factory.rpcFactory, formatRpcError(error)]);
+            throw error;
+          })
+      )
+    );
+
+    const successful = settled.filter(isPromiseFulfilled).map((r) => r.value);
+
+    if (successful.length < this.nodeQuorumThreshold) {
+      const errorTexts = errors.map(
+        ([factory, errorText]) => `Provider ${factory.clusterUrl} failed to call ${method} with error ${errorText}`
+      );
+      const successfulProviderUrls = successful.map(([factory]) => factory.clusterUrl);
+      throw createSendErrorWithMessage(
+        `Not enough providers succeeded on ${method} call to reach lower-bound quorum ` +
+          `(${successful.length}/${this.nodeQuorumThreshold}). Errors:\n${errorTexts.join("\n")}\n` +
+          `Successful Providers:\n${successfulProviderUrls.join("\n")}`,
+        settled.find(isPromiseRejected)?.reason
+      );
+    }
+
+    // Sort successful responses by their underlying bigint value, highest first.
+    const ranked = successful
+      .map(([factory, value]) => ({ factory, value: value as unknown as bigint }))
+      .sort((a, b) => (a.value === b.value ? 0 : a.value < b.value ? 1 : -1));
+    const quorumValue = ranked[this.nodeQuorumThreshold - 1].value;
+    const quorumResult = quorumValue as unknown as RpcResponse<TResponse>;
+
+    const divergentProviders = ranked
+      .filter(({ value }) => value !== quorumValue)
+      .map(({ factory }) => factory.clusterUrl);
+    if (divergentProviders.length > 0 || errors.length > 0) {
+      this.logger.warn({
+        at: "FallbackSolanaRpcFactory#createTransport",
+        message: `[${method}] Lower-bound quorum: some providers diverged from the quorum value or failed 🚸`,
+        notificationPath: "across-warn",
+        method,
+        params: JSON.stringify(params),
+        quorumValue: Number(quorumValue),
+        providerValues: ranked.map(({ factory, value }) => ({
+          provider: factory.clusterUrl,
+          value: Number(value),
+        })),
+        divergentProviders,
+        successfulProviders: ranked.map(({ factory }) => factory.clusterUrl),
+        erroringProviders: errors.map(
+          ([factory, errorText]) => `Provider ${factory.clusterUrl} failed with error ${errorText}`
+        ),
+      });
+    }
+
+    return quorumResult;
+  }
 }
 
 // These methods return a bigint and their results are loggable because they are succinct and can further assist
 // quorum debugging.
 const METHODS_RETURNING_BIGINT = ["getBlockTime", "getSlot"];
+
+// Methods whose results converge but never agree exactly across providers when queried at the head
+// of the chain. These cannot use strict-equality quorum and instead use lower-bound quorum
+// (Kth-highest aggregation) inside `_lowerBoundQuorumCall`. The underlying response must be a
+// bigint so the values are linearly orderable.
+const LOWER_BOUND_QUORUM_METHODS = ["getSlot"];

--- a/test/providers/solana/quorumFallbackRpcFactory.test.ts
+++ b/test/providers/solana/quorumFallbackRpcFactory.test.ts
@@ -61,6 +61,10 @@ function rejectingTransport(error: unknown): RpcTransport {
   return (() => Promise.reject(error)) as unknown as RpcTransport;
 }
 
+function resolvingTransport(value: unknown): RpcTransport {
+  return (() => Promise.resolve(value)) as unknown as RpcTransport;
+}
+
 function payload(method: string, params: unknown[] = []): Parameters<RpcTransport>[0] {
   return { payload: { method, params } } as unknown as Parameters<RpcTransport>[0];
 }
@@ -193,5 +197,86 @@ describe("QuorumFallbackSolanaRpcFactory error preservation", () => {
 
     const response = (await factory.createTransport()(payload("getBlockTime", [421829272]))) as RpcResponse<unknown>;
     expect(response).to.deep.equal({ result: "ok" });
+  });
+});
+
+describe("QuorumFallbackSolanaRpcFactory lower-bound quorum on getSlot", () => {
+  it("returns the K-th highest slot across N providers (rejects one lagging provider)", async () => {
+    // Three providers, two of which agree the chain has reached at least 105_000.
+    // Lower-bound quorum value should be 105_000 even though one provider lags at 100_000.
+    const factory = buildFactory(
+      [resolvingTransport(110_000n), resolvingTransport(105_000n), resolvingTransport(100_000n)],
+      2
+    );
+
+    const response = await factory.createTransport()(payload("getSlot", [{ commitment: "finalized" }]));
+    expect(response).to.equal(105_000n);
+  });
+
+  it("rejects an outlier-high single provider when quorum is 2", async () => {
+    // One provider reports a fake-high; two honest providers agree on the real tip.
+    const factory = buildFactory(
+      [resolvingTransport(9_000_000_000n), resolvingTransport(105_000n), resolvingTransport(104_998n)],
+      2
+    );
+
+    const response = await factory.createTransport()(payload("getSlot", [{ commitment: "finalized" }]));
+    expect(response).to.equal(105_000n);
+  });
+
+  it("returns the min when only quorum providers respond successfully", async () => {
+    // Quorum=2, three providers, but one errors out. The two successful responses both contribute,
+    // and the K-th highest is the minimum of those two.
+    const factory = buildFactory(
+      [resolvingTransport(110_000n), resolvingTransport(105_000n), rejectingTransport(new Error("rpc down"))],
+      2
+    );
+
+    const response = await factory.createTransport()(payload("getSlot", [{ commitment: "finalized" }]));
+    expect(response).to.equal(105_000n);
+  });
+
+  it("throws when fewer than quorum providers respond successfully", async () => {
+    // Quorum=2 but only one provider succeeds — lower-bound quorum cannot be reached.
+    const networkError = new Error("network down");
+    const factory = buildFactory(
+      [resolvingTransport(110_000n), rejectingTransport(networkError), rejectingTransport(networkError)],
+      2
+    );
+
+    let caught: unknown;
+    try {
+      await factory.createTransport()(payload("getSlot", [{ commitment: "finalized" }]));
+      expect.fail("Expected the transport to reject");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).to.be.instanceOf(Error);
+    expect((caught as Error).message).to.match(/lower-bound quorum/i);
+    expect((caught as Error).message).to.include("1/2");
+  });
+
+  it("returns identical-value agreement directly without divergence logging", async () => {
+    // All providers agree exactly — the K-th highest is the single agreed-upon value.
+    const factory = buildFactory(
+      [resolvingTransport(105_000n), resolvingTransport(105_000n), resolvingTransport(105_000n)],
+      2
+    );
+
+    const response = await factory.createTransport()(payload("getSlot", [{ commitment: "finalized" }]));
+    expect(response).to.equal(105_000n);
+  });
+
+  it("preserves the single-provider fast path when quorum is 1", async () => {
+    // With quorum=1, lower-bound quorum is skipped — the first provider's response is returned
+    // even if a later provider would have reported a higher slot.
+    const factory = buildFactory(
+      [resolvingTransport(100_000n), resolvingTransport(110_000n), resolvingTransport(105_000n)],
+      1
+    );
+
+    const response = await factory.createTransport()(payload("getSlot", [{ commitment: "finalized" }]));
+    expect(response).to.equal(100_000n);
   });
 });


### PR DESCRIPTION
## Summary

`QuorumFallbackSolanaRpcFactory._getQuorum` only enforces quorum for `getBlock` / `getBlockTime`; `getSlot` falls through to quorum 1. The dataworker disputer's chain-tip read is therefore single-provider even when configured with `NODE_QUORUM=2`. On 2026-05-29 a transient Chainstack lag drove the disputer's `latestHeightSearched` below the previous bundle's end slot — `getWidestPossibleExpectedBlockRange` soft-paused, `validatePendingRootBundle` then fired its "end block > expected + buffer" dispute on the proposer's (healthy) bundle.

Strict-equality quorum cannot apply to `getSlot` — providers' tip values converge but never agree exactly at the head of the chain. This PR adds **lower-bound quorum** semantics for `getSlot`: query all configured providers in parallel, sort successful bigint responses descending, and return the value at index `K-1`. Semantically: "at least K providers report the chain has reached at least this slot."

- Rejects one lagging provider when N > K (the laggard drops out of the top-K window).
- Forces a single outlier-high provider to have at least one ally to influence the result.
- Guarded on `nodeQuorumThreshold > 1` so quorum=1 bots keep the single-provider fast path (no extra RPC load on relayer fills).
- Throws with the existing wrap format when fewer than K providers respond successfully.

Logs `divergentProviders` plus per-provider tip values when providers disagree, mirroring the strict-equality path's mismatch warn.

## Precondition

For a bot configured with `NODE_QUORUM=2`, the rejection of a single lagging provider only kicks in when `N ≥ 3` providers are configured. Solana RPC lists in `bot-configs` already exceed this in practice (quicknode/quicknode_jito + alchemy + chainstack + helius), so no config change is needed to realize the benefit.

## Why this is safe

- The new path is only taken for `method === "getSlot"` with `nodeQuorumThreshold > 1`. Every other method retains the existing equality-quorum + fallback flow, byte-for-byte.
- The K-th highest is a deterministic, well-defined point on the sorted distribution; it can only equal a value some real provider returned.
- Failure mode preserved: when `< K` providers succeed, the call throws with the same `createSendErrorWithMessage` wrap shape (`Not enough providers succeeded on getSlot call to reach lower-bound quorum (X/K)`), so callers handle it identically.
- No SDK consumer relies on `getSlot` returning the *single highest* provider's value — `getNearestSlotTime` walks back from whatever slot it receives, so a slightly lower tip is harmless.

## Out of scope / follow-ups

This PR scopes narrowly to `getSlot`. The same pattern applies cleanly to `getBlockHeight` and (with shape-specific aggregation) to `getLatestBlockhash`; I'd handle each in a follow-up PR once we've validated lower-bound quorum in production for `getSlot` first.

## Test plan

- [x] `yarn hardhat test test/providers/solana/quorumFallbackRpcFactory.test.ts` — 14/14 (6 new lower-bound cases: K-th-highest selection, outlier-high rejection, fewer-than-K failure, all-equal short-circuit, single-provider fast path on quorum=1, exact min-of-K when only K succeed).
- [x] `yarn tsc --noEmit -p tsconfig.build.json` clean.
- [x] `yarn lint-check` clean.
- [ ] Watch a disputer run on `zion-across-disputer` after SDK bump lands and confirm no false dispute on `getSlot` divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)