### PR TITLE
fix(svm): short-circuit QuorumFallback fallbacks on shouldFailImmediate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.163",
+  "version": "4.3.164",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/src/providers/solana/quorumFallbackRpcFactory.ts
+++ b/src/providers/solana/quorumFallbackRpcFactory.ts
@@ -65,9 +65,12 @@ export class QuorumFallbackSolanaRpcFactory extends SolanaBaseRpcFactory {
               throw error;
             }
 
-            // If one RPC provider reverted, others likely will too. Skip them and preserve the
-            // original error so callers can branch on `isSolanaError(...)`.
-            if (quorumThreshold === 1 && shouldFailImmediate(method, error)) {
+            // If the error is a deterministic, network-wide chain fact (slot skipped,
+            // preflight failure), every fallback provider will return the same answer.
+            // Skip the fallback so the chain rejects with the underlying SolanaError —
+            // both to save RPC budget and to keep `rejections.every(shouldFailImmediate)`
+            // below from being defeated by a non-Solana failure on a later fallback.
+            if (shouldFailImmediate(method, error)) {
               throw error;
             }
 

--- a/src/providers/solana/quorumFallbackRpcFactory.ts
+++ b/src/providers/solana/quorumFallbackRpcFactory.ts
@@ -4,7 +4,7 @@ import { isPromiseFulfilled, isPromiseRejected } from "../../utils/TypeGuards";
 import { compareSvmRpcResults, createSendErrorWithMessage } from "../utils";
 import { CachedSolanaRpcFactory } from "./cachedRpcFactory";
 import { SolanaBaseRpcFactory, SolanaClusterRpcFactory } from "./baseRpcFactories";
-import { formatRpcError, shouldFailImmediate } from "./utils";
+import { formatRpcError, isChainWideFailure, shouldFailImmediate } from "./utils";
 
 // This factory stores multiple Cached RPC factories so that users of this factory can specify multiple RPC providers
 // and the factory will fallback through them if any RPC calls fail. This factory also implements quorum logic amongst
@@ -70,7 +70,10 @@ export class QuorumFallbackSolanaRpcFactory extends SolanaBaseRpcFactory {
             // Skip the fallback so the chain rejects with the underlying SolanaError —
             // both to save RPC budget and to keep `rejections.every(shouldFailImmediate)`
             // below from being defeated by a non-Solana failure on a later fallback.
-            if (shouldFailImmediate(method, error)) {
+            // Note: `isChainWideFailure` is intentionally narrower than `shouldFailImmediate`.
+            // SVM_LONG_TERM_STORAGE_SLOT_SKIPPED is provider-local (the slot may be missing from
+            // *this* provider's archive but present elsewhere), so we still try fallbacks for it.
+            if (isChainWideFailure(method, error)) {
               throw error;
             }
 

--- a/src/providers/solana/utils.ts
+++ b/src/providers/solana/utils.ts
@@ -102,3 +102,29 @@ export function shouldFailImmediate(method: string, error: unknown): boolean {
       return false;
   }
 }
+
+/**
+ * Subset of `shouldFailImmediate` for errors that are deterministic *across the entire network*,
+ * not just for the provider that returned them. Used to decide whether to skip fallback providers
+ * after a required provider rejects.
+ *
+ * Excludes SVM_LONG_TERM_STORAGE_SLOT_SKIPPED: that code can mean "the slot is missing from this
+ * provider's long-term storage" rather than "the slot was skipped on the network", so an archival
+ * fallback may still be able to answer.
+ */
+export function isChainWideFailure(method: string, error: unknown): boolean {
+  if (!isSolanaError(error)) {
+    return false;
+  }
+
+  const { __code: code } = error.context;
+  switch (method) {
+    case "getBlock":
+    case "getBlockTime":
+      return code === SVM_SLOT_SKIPPED;
+    case "sendTransaction":
+      return code === SVM_TRANSACTION_PREFLIGHT_FAILURE;
+    default:
+      return false;
+  }
+}

--- a/test/providers/solana/quorumFallbackRpcFactory.test.ts
+++ b/test/providers/solana/quorumFallbackRpcFactory.test.ts
@@ -187,6 +187,47 @@ describe("QuorumFallbackSolanaRpcFactory error preservation", () => {
     expect((caught as Error).message).to.include("Block not available for slot 422715124");
   });
 
+  it("does not fall back when a required provider rejects with a shouldFailImmediate code", async () => {
+    // Regression for production incident on 2026-06-03: when canonical chain slot 423907443 was
+    // skipped, QuickNode/Alchemy/Chainstack all returned SVM_SLOT_SKIPPED, but the chain still
+    // fell through to drpc/Helius. If any fallback returned a non-SolanaError (e.g. a timeout
+    // wrapping a JSON parse failure), the post-allSettled `rejections.every(shouldFailImmediate)`
+    // check was defeated and the SolanaError was wrapped in a plain Error, so the SVM_SLOT_SKIPPED
+    // case in `_callGetTimestampForSlotWithRetry` never matched and `getNearestSlotTime` could
+    // not advance to the next produced slot.
+    const skipped1 = solanaError(SVM_SLOT_SKIPPED, "Slot 423907443 was skipped (provider 1)");
+    const skipped2 = solanaError(SVM_SLOT_SKIPPED, "Slot 423907443 was skipped (provider 2)");
+    let drpcCalled = false;
+    let heliusCalled = false;
+    const drpcTimeout: RpcTransport = (() => {
+      drpcCalled = true;
+      return Promise.reject(new Error("drpc timeout"));
+    }) as unknown as RpcTransport;
+    const heliusTimeout: RpcTransport = (() => {
+      heliusCalled = true;
+      return Promise.reject(new Error("helius timeout"));
+    }) as unknown as RpcTransport;
+    const factory = buildFactory(
+      [rejectingTransport(skipped1), rejectingTransport(skipped2), drpcTimeout, heliusTimeout],
+      2
+    );
+
+    let caught: unknown;
+    try {
+      await factory.createTransport()(payload("getBlockTime", [423907443]));
+      expect.fail("Expected the transport to reject");
+    } catch (err) {
+      caught = err;
+    }
+
+    // Both required providers' SolanaError shouldFailImmediate codes are preserved.
+    expect(caught).to.equal(skipped1);
+    expect((caught as { context: { __code: number } }).context.__code).to.equal(SVM_SLOT_SKIPPED);
+    // And the fallback providers were never asked, saving RPC budget on a deterministic chain fact.
+    expect(drpcCalled).to.equal(false);
+    expect(heliusCalled).to.equal(false);
+  });
+
   it("succeeds normally when the provider returns a result", async () => {
     const ok = (() => Promise.resolve({ result: "ok" })) as unknown as RpcTransport;
     const factory = buildFactory([ok]);

--- a/test/providers/solana/quorumFallbackRpcFactory.test.ts
+++ b/test/providers/solana/quorumFallbackRpcFactory.test.ts
@@ -228,6 +228,24 @@ describe("QuorumFallbackSolanaRpcFactory error preservation", () => {
     expect(heliusCalled).to.equal(false);
   });
 
+  it("still tries fallback providers when SVM_LONG_TERM_STORAGE_SLOT_SKIPPED, in case an archival provider can answer", async () => {
+    // SVM_LONG_TERM_STORAGE_SLOT_SKIPPED is provider-local: it can mean "this provider does not
+    // have the slot in its long-term storage", not "the slot was skipped on the network". An
+    // archival fallback (e.g. Helius) may still have the data, so we must not short-circuit it.
+    const archivalMiss = solanaError(SVM_LONG_TERM_STORAGE_SLOT_SKIPPED, "missing in long-term storage");
+    let archivalFallbackCalled = false;
+    const archivalSuccess: RpcTransport = (() => {
+      archivalFallbackCalled = true;
+      return Promise.resolve({ result: 1735689600 } as unknown as RpcResponse<unknown>);
+    }) as unknown as RpcTransport;
+    const factory = buildFactory([rejectingTransport(archivalMiss), archivalSuccess], 1);
+
+    const response = (await factory.createTransport()(payload("getBlockTime", [421829272]))) as RpcResponse<unknown>;
+
+    expect(archivalFallbackCalled).to.equal(true);
+    expect(response).to.deep.equal({ result: 1735689600 });
+  });
+
   it("succeeds normally when the provider returns a result", async () => {
     const ok = (() => Promise.resolve({ result: "ok" })) as unknown as RpcTransport;
     const factory = buildFactory([ok]);


### PR DESCRIPTION
## Summary

When a required provider returns a deterministic, network-wide chain error (slot skipped, sendTransaction preflight failure), every fallback will return the same answer. Falling back wastes RPC budget and — more importantly — can let a non-`SolanaError` from a fallback (e.g. a drpc/Helius timeout) contaminate the rejection set. That defeats the post-`Promise.allSettled` `rejections.every(shouldFailImmediate)` check in `QuorumFallbackSolanaRpcFactory`, leaves the `SolanaError` wrapped in a plain `Error`, and prevents `_callGetTimestampForSlotWithRetry` from matching `SVM_SLOT_SKIPPED` and returning `undefined` — so `getNearestSlotTime`'s slot walk-back can never advance past the dead slot.

Lifts the existing in-chain `shouldFailImmediate` guard out from under the `quorumThreshold === 1` constraint; the deterministic-error reasoning is independent of quorum.

## Reproduced in production

On 2026-06-03 ~01:04Z–01:47Z, Solana mainnet skipped slot 423907443 (part of a 4-slot cluster 423907440–443). The slot fell inside `zion-across-swap-rebalancer`'s 4h `maxRelayerLookBack` window from 01:04Z onward, and inside `zion-across-relayer-primary`'s 2.5h window from 01:47Z onward.

QuickNode / Alchemy / Chainstack all returned the canonical `SolanaError [-32007] SVM_SLOT_SKIPPED`. The fallback chain then ran drpc / Helius, the eventual exhaust threw a non-`SolanaError`, the quorum aggregation wrapped everything in `Error('Not enough providers succeeded on getBlockTime call')`, and `_callGetTimestampForSlotWithRetry` re-threw because `isSolanaError(wrappedErr)` is `false`. Result: 3 swap-rebalancer PD pages + 1 relayer-primary PD page (`Q2ZMR3FYU22CY1`, `Q3Z5QZEPEWL1QA`, `Q2AWBTAKCLH2WM`, `Q3J1QRSIKX4278`).

With this patch, every required provider's `SVM_SLOT_SKIPPED` propagates up unwrapped, `getTimestampForSlot` returns `undefined`, `getNearestSlotTime` decrements through the 4-slot cluster and lands on slot 423907439, which has a block.

## Pairs with

This is the SDK-side fix. The relayer/swap-rebalancer just needs to bump `@across-protocol/sdk` once this lands.

## Test plan

- [x] `npx hardhat test test/providers/solana/quorumFallbackRpcFactory.test.ts` — 9 passing, including new regression case `does not fall back when a required provider rejects with a shouldFailImmediate code`
- [x] `yarn lint`
- [ ] Reviewer: confirm the existing test `passes through to the wrapping path when only some rejections are shouldFailImmediate` still represents valid behavior under the new code path (it does — that test uses no fallback providers, so `fallbackFactories.length === 0` causes each chain to throw immediately regardless of `shouldFailImmediate`, and the post-`allSettled` mixed-rejection branch is unchanged).

## Originating thread

[Slack — `swap-rebalancer` PD investigation](https://risk-labs.slack.com/archives/C0B5K0N75PD/p1780451277760019)
