### PR TITLE
fix(tvm): account for Tron bandwidth in relayer profitability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.165",
+  "version": "4.3.166-alpha.0",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.166-alpha.0",
+  "version": "4.3.166",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/src/arch/tvm/MessageUtils.ts
+++ b/src/arch/tvm/MessageUtils.ts
@@ -1,0 +1,45 @@
+import { RelayData } from "../../interfaces";
+import { BigNumber, bnZero, isMessageEmpty, toBN } from "../../utils";
+
+// Tron prices each byte of a transaction's serialized raw_data + signature at this many
+// SUN of bandwidth when the relayer's free bandwidth allowance has been exhausted. The
+// rate is set by Tron governance; refresh from `wallet/getchainparameters` if it drifts.
+const TVM_BANDWIDTH_SUN_PER_BYTE = 1000;
+
+// Tron raw_data envelope (contract type, ref_block, timestamp, expiration, fee_limit)
+// plus a single ECDSA signature. Measured empirically against `fillRelay` transactions
+// emitted by the production relayer; varies by ~10 bytes between calls.
+const TVM_RAW_DATA_OVERHEAD_BYTES = 290;
+
+// `fillRelay(V3RelayData, uint256 repaymentChainId, bytes32 repaymentAddress)` ABI
+// encoding, excluding the `message` payload (which is dynamic).
+//   4   selector
+//  96   top-level head: offset(V3RelayData) + repaymentChainId + repaymentAddress
+// 384   V3RelayData struct head: 11 static fields inline + 1 offset(message)
+//  32   message length header
+const TVM_FILL_RELAY_FIXED_CALLDATA_BYTES = 4 + 96 + 384 + 32;
+
+/**
+ * Estimate the bandwidth cost (in SUN) of a Tron fill for `deposit`.
+ *
+ * On Tron, transaction bytes consume bandwidth — distinct from energy (paid via the tx
+ * fee limit and modeled in `nativeGasCost`). When the relayer has no free bandwidth
+ * staked, every byte burns 1,000 SUN. For message-bearing fills this is non-trivial:
+ * the message dominates calldata size, so the cost scales linearly with message length.
+ *
+ * The estimate is conservative — it assumes zero free bandwidth (worst case). Relayers
+ * that stake TRX for bandwidth pay 0 onchain; this still represents the true marginal
+ * cost of consuming that staked allowance.
+ */
+export function getAuxiliaryNativeTokenCost(deposit: RelayData): BigNumber {
+  const messageBytes = isMessageEmpty(deposit.message) ? 0 : Math.max(0, Math.floor((deposit.message.length - 2) / 2));
+  const paddedMessageBytes = Math.ceil(messageBytes / 32) * 32;
+
+  const calldataBytes = TVM_FILL_RELAY_FIXED_CALLDATA_BYTES + paddedMessageBytes;
+  const txBytes = TVM_RAW_DATA_OVERHEAD_BYTES + calldataBytes;
+
+  return toBN(txBytes).mul(TVM_BANDWIDTH_SUN_PER_BYTE);
+}
+
+// Re-export so other arches can reference the zero default if needed.
+export const tvmBandwidthCostZero = bnZero;

--- a/src/arch/tvm/MessageUtils.ts
+++ b/src/arch/tvm/MessageUtils.ts
@@ -1,5 +1,5 @@
-import { RelayData } from "../../interfaces";
-import { BigNumber, bnZero, isMessageEmpty, toBN } from "../../utils";
+import { RelayData, SpeedUpCommon } from "../../interfaces";
+import { BigNumber, bnZero, isDefined, isMessageEmpty, toBN } from "../../utils";
 
 // Tron prices each byte of a transaction's serialized raw_data + signature at this many
 // SUN of bandwidth when the relayer's free bandwidth allowance has been exhausted. The
@@ -19,6 +19,23 @@ const TVM_RAW_DATA_OVERHEAD_BYTES = 290;
 //  32   message length header
 const TVM_FILL_RELAY_FIXED_CALLDATA_BYTES = 4 + 96 + 384 + 32;
 
+// Extra ABI footprint when a speed-up signature is present and the relayer must call
+// `fillRelayWithUpdatedDeposit(V3RelayData, ..., uint256 updatedOutputAmount, bytes32
+// updatedRecipient, bytes updatedMessage, bytes speedUpSignature)`. The original
+// `message` still lives inside V3RelayData and is already counted above; this constant
+// captures only what's *additional* to the plain `fillRelay` encoding.
+//  128   4 extra head slots: updatedOutputAmount + updatedRecipient + offset(updatedMessage) + offset(speedUpSignature)
+//   32   updatedMessage length header (the padded body is added per-call below)
+//   32   speedUpSignature length header
+//   96   65-byte ECDSA signature padded to 3 EVM words
+const TVM_SPEED_UP_FIXED_CALLDATA_EXTRA_BYTES = 128 + 32 + 32 + 96;
+
+function paddedMessageByteLength(message: string | undefined): number {
+  if (!isDefined(message) || isMessageEmpty(message)) return 0;
+  const bytes = Math.max(0, Math.floor((message.length - 2) / 2));
+  return Math.ceil(bytes / 32) * 32;
+}
+
 /**
  * Estimate the bandwidth cost (in SUN) of a Tron fill for `deposit`.
  *
@@ -27,15 +44,25 @@ const TVM_FILL_RELAY_FIXED_CALLDATA_BYTES = 4 + 96 + 384 + 32;
  * staked, every byte burns 1,000 SUN. For message-bearing fills this is non-trivial:
  * the message dominates calldata size, so the cost scales linearly with message length.
  *
+ * Sped-up deposits (those carrying a `speedUpSignature`) are filled via
+ * `fillRelayWithUpdatedDeposit`, which carries the original `V3RelayData` *and*
+ * `updatedMessage`/`speedUpSignature` as additional ABI args. Both messages are charged.
+ *
  * The estimate is conservative — it assumes zero free bandwidth (worst case). Relayers
  * that stake TRX for bandwidth pay 0 onchain; this still represents the true marginal
  * cost of consuming that staked allowance.
  */
-export function getAuxiliaryNativeTokenCost(deposit: RelayData): BigNumber {
-  const messageBytes = isMessageEmpty(deposit.message) ? 0 : Math.max(0, Math.floor((deposit.message.length - 2) / 2));
-  const paddedMessageBytes = Math.ceil(messageBytes / 32) * 32;
+export function getAuxiliaryNativeTokenCost(
+  deposit: RelayData & Partial<SpeedUpCommon> & { speedUpSignature?: string }
+): BigNumber {
+  const paddedMessageBytes = paddedMessageByteLength(deposit.message);
 
-  const calldataBytes = TVM_FILL_RELAY_FIXED_CALLDATA_BYTES + paddedMessageBytes;
+  let speedUpExtraBytes = 0;
+  if (isDefined(deposit.speedUpSignature) && deposit.speedUpSignature !== "0x") {
+    speedUpExtraBytes = TVM_SPEED_UP_FIXED_CALLDATA_EXTRA_BYTES + paddedMessageByteLength(deposit.updatedMessage);
+  }
+
+  const calldataBytes = TVM_FILL_RELAY_FIXED_CALLDATA_BYTES + paddedMessageBytes + speedUpExtraBytes;
   const txBytes = TVM_RAW_DATA_OVERHEAD_BYTES + calldataBytes;
 
   return toBN(txBytes).mul(TVM_BANDWIDTH_SUN_PER_BYTE);

--- a/src/arch/tvm/index.ts
+++ b/src/arch/tvm/index.ts
@@ -1,2 +1,3 @@
 export * from "./SpokeUtils";
 export * from "./TransactionUtils";
+export * from "./MessageUtils";

--- a/src/relayFeeCalculator/chain-queries/factory.ts
+++ b/src/relayFeeCalculator/chain-queries/factory.ts
@@ -4,12 +4,13 @@ import { getDeployedAddress } from "@across-protocol/contracts";
 import { asL2Provider } from "@eth-optimism/sdk";
 import { providers } from "ethers";
 import { CUSTOM_GAS_TOKENS } from "../../constants";
-import { chainIsEvm, chainIsOPStack, isDefined, chainIsSvm, SvmAddress } from "../../utils";
+import { chainIsEvm, chainIsOPStack, isDefined, chainIsSvm, chainIsTvm, SvmAddress } from "../../utils";
 import { QueryBase } from "./baseQuery";
 import { SVMProvider as svmProvider } from "../../arch/svm";
 import { DEFAULT_LOGGER, getDefaultRelayer, Logger } from "../relayFeeCalculator";
 import { CustomGasTokenQueries } from "./customGasToken";
 import { SvmQuery } from "./svmQuery";
+import { TvmQuery } from "./tvmQuery";
 
 /**
  * Some chains have a fixed gas price that is applied to the gas estimates. We should override
@@ -35,7 +36,12 @@ export class QueryBase__factory {
     const customGasTokenSymbol = CUSTOM_GAS_TOKENS[chainId];
     if (chainIsEvm(chainId) && isDefined(customGasTokenSymbol)) {
       assert(relayerAddress.isEVM());
-      return new CustomGasTokenQueries({
+      // TVM chains route through TvmQuery so that bandwidth — a Tron-native cost the
+      // EVM compatibility layer's `eth_estimateGas` does not surface — is included in
+      // `auxiliaryNativeTokenCost`. Otherwise fall back to the EVM-flavoured custom gas
+      // token query.
+      const QueryCtor = chainIsTvm(chainId) ? TvmQuery : CustomGasTokenQueries;
+      return new QueryCtor({
         queryBaseArgs: [
           provider as providers.Provider,
           symbolMapping,

--- a/src/relayFeeCalculator/chain-queries/index.ts
+++ b/src/relayFeeCalculator/chain-queries/index.ts
@@ -2,3 +2,4 @@ export * from "./baseQuery";
 export * from "./factory";
 export * from "./customGasToken";
 export * from "./svmQuery";
+export * from "./tvmQuery";

--- a/src/relayFeeCalculator/chain-queries/tvmQuery.ts
+++ b/src/relayFeeCalculator/chain-queries/tvmQuery.ts
@@ -1,0 +1,20 @@
+import { arch } from "../..";
+import { RelayData } from "../../interfaces";
+import { BigNumber } from "../../utils";
+import { CustomGasTokenQueries } from "./customGasToken";
+
+/**
+ * TVM (TRON) query implementation. Extends `CustomGasTokenQueries` to add bandwidth
+ * accounting via `getAuxiliaryNativeTokenCost`, which the base EVM path returns 0 for.
+ *
+ * Energy (Tron's analogue of gas) is already estimated by `voidSigner.estimateGas`
+ * against the EVM-compat RPC and surfaces in `tokenGasCost`. Bandwidth is a separate
+ * Tron-native resource that the EVM compatibility layer does not surface, so we
+ * estimate it here from the deposit's `message` length and a fixed `fillRelay`
+ * calldata footprint.
+ */
+export class TvmQuery extends CustomGasTokenQueries {
+  override getAuxiliaryNativeTokenCost(deposit: RelayData): BigNumber {
+    return arch.tvm.getAuxiliaryNativeTokenCost(deposit);
+  }
+}

--- a/test/relayFeeCalculator.test.ts
+++ b/test/relayFeeCalculator.test.ts
@@ -858,6 +858,38 @@ describe("getAuxiliaryNativeTokenCost", function () {
       const deltaPct = Math.abs(fee.toNumber() - observedSun) / observedSun;
       expect(deltaPct).to.be.lessThan(0.01);
     });
+
+    it("adds the fillRelayWithUpdatedDeposit overhead when a speed-up signature is present", function () {
+      // Speed-up fills carry 4 extra ABI head slots (128) + updatedMessage length
+      // header (32) + speedUpSignature length header (32) + padded 65-byte sig (96)
+      // = 288 fixed extra bytes, plus the padded updatedMessage body.
+      const SPEED_UP_FIXED_EXTRA_SUN = 288 * 1000;
+      const speedUpSignature = "0x" + "11".repeat(65);
+
+      // Empty original + empty updated message: only the fixed speed-up extra applies.
+      const emptySpeedUp = {
+        ...makeDeposit(EMPTY_MESSAGE),
+        updatedRecipient: EvmAddress.from(ZERO_ADDRESS),
+        updatedOutputAmount: BigNumber.from(1),
+        updatedMessage: EMPTY_MESSAGE,
+        speedUpSignature,
+      };
+      const emptyFee = tvmArch.getAuxiliaryNativeTokenCost(emptySpeedUp);
+      expect(emptyFee.eq(FIXED_BANDWIDTH_SUN + SPEED_UP_FIXED_EXTRA_SUN)).to.equal(true);
+
+      // 48-byte updated message → pads to 64 bytes (two 32-byte words).
+      const updatedMessage = "0x" + "ab".repeat(48);
+      const withUpdatedMessage = { ...emptySpeedUp, updatedMessage };
+      const updatedFee = tvmArch.getAuxiliaryNativeTokenCost(withUpdatedMessage);
+      expect(updatedFee.eq(FIXED_BANDWIDTH_SUN + SPEED_UP_FIXED_EXTRA_SUN + 64 * 1000)).to.equal(true);
+
+      // Original message bytes are still charged on top, since V3RelayData still carries
+      // the original `message` field inside fillRelayWithUpdatedDeposit.
+      const originalMessage = "0x" + "cd".repeat(32);
+      const both = { ...withUpdatedMessage, message: originalMessage };
+      const bothFee = tvmArch.getAuxiliaryNativeTokenCost(both);
+      expect(bothFee.eq(FIXED_BANDWIDTH_SUN + SPEED_UP_FIXED_EXTRA_SUN + 64 * 1000 + 32 * 1000)).to.equal(true);
+    });
   });
 
   it("factory returns a TvmQuery for TRON", function () {

--- a/test/relayFeeCalculator.test.ts
+++ b/test/relayFeeCalculator.test.ts
@@ -36,7 +36,8 @@ import assert from "assert";
 import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "@across-protocol/constants";
 import { EMPTY_MESSAGE, ZERO_ADDRESS } from "../src/constants";
 import { SpokePool } from "@across-protocol/contracts";
-import { QueryBase, QueryBase__factory, DEFAULT_LOGGER, SvmQuery } from "../src/relayFeeCalculator";
+import { QueryBase, QueryBase__factory, DEFAULT_LOGGER, SvmQuery, TvmQuery } from "../src/relayFeeCalculator";
+import * as tvmArch from "../src/arch/tvm";
 import { getDefaultProvider } from "ethers";
 import { MockedProvider } from "../src/providers/mocks";
 import { getAcrossPlusMessageEncoder, SVM_DEFAULT_ADDRESS } from "../src/arch/svm";
@@ -797,5 +798,70 @@ describe("getAuxiliaryNativeTokenCost", function () {
     };
 
     expect(() => svmQueries.getAuxiliaryNativeTokenCost(deposit)).to.throw();
+  });
+
+  describe("TVM bandwidth cost", function () {
+    // Tron bandwidth burns at 1000 SUN/byte. The fixed-tx cost (no message) is the
+    // raw-data envelope + the static portion of the fillRelay ABI calldata: 290 + 4 +
+    // 96 + 384 + 32 = 806 bytes → 806,000 SUN.
+    const FIXED_BANDWIDTH_SUN = 806_000;
+
+    function makeDeposit(message: string): RelayData {
+      return {
+        originChainId: 1,
+        depositor: EvmAddress.from(ZERO_ADDRESS),
+        recipient: EvmAddress.from(ZERO_ADDRESS),
+        depositId: BigNumber.from(1),
+        inputToken: EvmAddress.from(ZERO_ADDRESS),
+        inputAmount: BigNumber.from(1),
+        outputToken: EvmAddress.from(ZERO_ADDRESS),
+        outputAmount: BigNumber.from(1),
+        message,
+        fillDeadline: 0,
+        exclusiveRelayer: EvmAddress.from(ZERO_ADDRESS),
+        exclusivityDeadline: 0,
+      };
+    }
+
+    it("returns fixed envelope cost for empty-message deposits", function () {
+      const fee = tvmArch.getAuxiliaryNativeTokenCost(makeDeposit(EMPTY_MESSAGE));
+      expect(fee.eq(FIXED_BANDWIDTH_SUN)).to.equal(true);
+    });
+
+    it("returns fixed envelope cost for 0x deposits", function () {
+      const fee = tvmArch.getAuxiliaryNativeTokenCost(makeDeposit("0x"));
+      expect(fee.eq(FIXED_BANDWIDTH_SUN)).to.equal(true);
+    });
+
+    it("scales linearly with padded message length", function () {
+      // Two 16-byte payloads should each pad up to a single 32-byte word.
+      const sixteenBytes = "0x" + "ab".repeat(16);
+      const oneWordFee = tvmArch.getAuxiliaryNativeTokenCost(makeDeposit(sixteenBytes));
+      expect(oneWordFee.eq(FIXED_BANDWIDTH_SUN + 32 * 1000)).to.equal(true);
+
+      // 64 bytes spans exactly two 32-byte words → +64 * 1000 SUN.
+      const sixtyFourBytes = "0x" + "ab".repeat(64);
+      const twoWordFee = tvmArch.getAuxiliaryNativeTokenCost(makeDeposit(sixtyFourBytes));
+      expect(twoWordFee.eq(FIXED_BANDWIDTH_SUN + 64 * 1000)).to.equal(true);
+    });
+
+    it("matches the observed onchain bandwidth for a 2112-byte multicall message", function () {
+      // Reproduces the fill for deposit #3984372 (Mainnet → Tron). Onchain net_fee was
+      // 2,908,000 SUN; our estimate should be within ~1% of that.
+      const messageBytes = 2112;
+      const message = "0x" + "00".repeat(messageBytes);
+      const fee = tvmArch.getAuxiliaryNativeTokenCost(makeDeposit(message));
+      const expected = FIXED_BANDWIDTH_SUN + messageBytes * 1000;
+      expect(fee.eq(expected)).to.equal(true);
+      // Match to actual onchain 2,908,000 SUN within 1%.
+      const observedSun = 2_908_000;
+      const deltaPct = Math.abs(fee.toNumber() - observedSun) / observedSun;
+      expect(deltaPct).to.be.lessThan(0.01);
+    });
+  });
+
+  it("factory returns a TvmQuery for TRON", function () {
+    const queries = QueryBase__factory.create(CHAIN_IDs.TRON, getDefaultProvider());
+    expect(queries).to.be.instanceOf(TvmQuery);
   });
 });


### PR DESCRIPTION
## Summary

`getAuxiliaryNativeTokenCost` returned 0 for TRON, so the relayer's profitability check modeled energy only and missed the \`net_fee\` (bandwidth) component. On message-bearing fills routed through the multicall handler, bandwidth is the dominant overhead — a 2.1KB-message fill burned ~\$0.93 of TRX in bandwidth against a ~\$10 total cost.

This PR adds a TVM-specific QueryBase that estimates serialized tx bytes from the deposit's message length plus a fixed \`fillRelay\` calldata footprint, then prices that at the current 1,000 SUN/byte bandwidth rate. The factory routes Tron through the new \`TvmQuery\` so the bandwidth surfaces in \`auxiliaryNativeTokenCost\` exactly the same way SVM does for message value transfer.

## Motivation

Observed against deposit #3984372 (Mainnet → Tron, USDT swap-via-multicall):

| component | estimate (pre-PR) | actual onchain | delta |
|---|---|---|---|
| energy | 30.56 TRX | 29.64 TRX | +3% over |
| bandwidth | **0** | **2.91 TRX** | **−100%** |
| total | \$9.82 | \$10.45 | −6.5% under |

That ~6.5% raw under-estimate flipped a borderline-positive fill into "unprofitable" in the primary relayer for ~3 minutes, until the sweeper bot (which zeros gasMultiplier) picked it up. The bandwidth absolute error scales linearly with message size, so flat % padding can't track it.

## Approach

- New \`src/arch/tvm/MessageUtils.ts\` with sync \`getAuxiliaryNativeTokenCost(deposit)\` returning bandwidth in SUN.
- New \`TvmQuery\` extending \`CustomGasTokenQueries\`, overriding \`getAuxiliaryNativeTokenCost\` to delegate to the arch helper.
- Factory routes \`chainIsTvm\` chains through \`TvmQuery\` instead of plain \`CustomGasTokenQueries\`.
- Estimate assumes zero free bandwidth (worst case). Relayers that stake TRX for bandwidth pay 0 onchain — the value still represents the marginal cost of consuming staked allowance, which is what the profitability check should weigh.

Formula:
\`\`\`
calldataBytes = 4 (selector) + 96 (top-level head) + 384 (V3RelayData struct head)
              + 32 (message length header) + paddedMessageBytes
txBytes       = 290 (Tron raw_data envelope + signature) + calldataBytes
bandwidthSun  = txBytes * 1000
\`\`\`

## Verification

Against deposit #3984372 (message: 2112 bytes):
- Estimated bandwidth: **2,918,000 SUN**
- Actual onchain net_fee: **2,908,000 SUN** (within 0.3%)

## Test plan

- [x] Unit tests for the bandwidth formula (empty / 0x / scaling / observed-onchain regression)
- [x] Factory routing test confirming TRON returns a TvmQuery
- [x] \`yarn build\` + \`yarn lint-check\` clean
- [ ] Reviewer: smoke-check in relayer staging or with shadow-mode logging

## Follow-ups (not in this PR)

- The Tron bandwidth rate (1,000 SUN/byte) is set by governance. Worth surfacing as a constant or chain parameter fetch if it drifts.
- Operationally, staking TRX for bandwidth/energy on the relayer wallets would make most of this irrelevant — the estimator becomes a safety net rather than primary protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)