### PR TITLE
fix(relayFeeCalculator): keep minDeposit finite when aux native cost is non-zero

### DIFF
--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -594,10 +594,11 @@ export class RelayFeeCalculator {
     // fees are taken out. Kept in per-amount terms for backwards compatibility with
     // callers that display it as a live percentage.
     const maxGasFeePercent = max(
-      toBNWei(this.feeLimitPercent / 100)
+      toBNWei(this.feeLimitPercent)
+        .div(100)
         .sub(capitalFeePercent)
         .sub(auxNativeFeePercent),
-      toBN(0)
+      bnZero
     );
 
     // `minDeposit` is the smallest `outputAmount` for which gas, capital, and
@@ -617,7 +618,7 @@ export class RelayFeeCalculator {
     // to `MAX_BIG_INT` for any small simulation amount on chains with non-zero
     // auxiliary cost (e.g. Tron bandwidth) — even though a real deposit would have
     // been feasible. Computing it directly from absolute aux cost avoids that.
-    const minDepositBudget = max(toBNWei(this.feeLimitPercent / 100).sub(capitalFeePercent), bnZero);
+    const minDepositBudget = max(toBNWei(this.feeLimitPercent).div(100).sub(capitalFeePercent), bnZero);
     let minDeposit: BigNumber, isAmountTooLow: boolean;
     if (minDepositBudget.eq(bnZero)) {
       // Capital fee alone has exhausted the budget; no deposit amount can satisfy

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -299,17 +299,19 @@ export class RelayFeeCalculator {
   }
 
   /**
-   * Calculate the auxiliary native token fee as a % of the amount to relay.
+   * Resolve the auxiliary native token fee in absolute output-token units and as a
+   * percentage of `outputAmount`. The absolute form is amount-invariant (it depends
+   * only on the deposit and price), so callers reasoning about `minDeposit` should
+   * prefer it over the percent — the percent diverges as `outputAmount → 0`.
+   *
    * Treats auxiliary native outlay as value forwarded to user, reported separately.
    */
-  async auxNativeFeePercent(
+  protected async resolveAuxNativeFee(
     deposit: RelayData & { destinationChainId: number },
     outputAmount: BigNumberish,
     outputTokenInfo: TokenInfo,
     _tokenPrice?: number
-  ): Promise<BigNumber> {
-    if (toBN(outputAmount).eq(bnZero)) return MAX_BIG_INT;
-
+  ): Promise<{ auxFeesInToken: BigNumber; auxNativeFeePercent: BigNumber }> {
     let auxNativeCost = bnZero;
     try {
       auxNativeCost = this.queries.getAuxiliaryNativeTokenCost(deposit);
@@ -325,8 +327,26 @@ export class RelayFeeCalculator {
     }
 
     const tokenPrice = await this.resolveTokenPrice(outputTokenInfo, _tokenPrice, deposit);
-    const auxFeesInToken = nativeToToken(auxNativeCost, tokenPrice, outputTokenInfo.decimals, this.nativeTokenDecimals);
-    return percent(auxFeesInToken, outputAmount);
+    const auxFeesInToken = toBN(
+      nativeToToken(auxNativeCost, tokenPrice, outputTokenInfo.decimals, this.nativeTokenDecimals)
+    );
+    const auxNativeFeePercent = toBN(outputAmount).eq(bnZero) ? MAX_BIG_INT : percent(auxFeesInToken, outputAmount);
+    return { auxFeesInToken, auxNativeFeePercent };
+  }
+
+  /**
+   * Calculate the auxiliary native token fee as a % of the amount to relay.
+   * Treats auxiliary native outlay as value forwarded to user, reported separately.
+   */
+  async auxNativeFeePercent(
+    deposit: RelayData & { destinationChainId: number },
+    outputAmount: BigNumberish,
+    outputTokenInfo: TokenInfo,
+    _tokenPrice?: number
+  ): Promise<BigNumber> {
+    if (toBN(outputAmount).eq(bnZero)) return MAX_BIG_INT;
+    const { auxNativeFeePercent } = await this.resolveAuxNativeFee(deposit, outputAmount, outputTokenInfo, _tokenPrice);
+    return auxNativeFeePercent;
   }
 
   // Note: these variables are unused now, but may be needed in future versions of this function that are more complex.
@@ -554,7 +574,13 @@ export class RelayFeeCalculator {
     );
     const capitalFeeTotal = capitalFeePercent.mul(outToInDecimals(outputAmount.toString())).div(fixedPointAdjustment);
 
-    const auxNativeFeePercent = await this.auxNativeFeePercent(deposit, outputAmount, outputTokenInfo, tokenPrice);
+    const { auxFeesInToken, auxNativeFeePercent } = await this.resolveAuxNativeFee(
+      deposit,
+      outputAmount,
+      outputTokenInfo,
+      tokenPrice
+    );
+    const auxFeesInInputDecimals = toBN(outToInDecimals(auxFeesInToken.toString()));
     const auxNativeFeeTotal = auxNativeFeePercent
       .mul(outToInDecimals(outputAmount.toString()))
       .div(fixedPointAdjustment);
@@ -563,26 +589,43 @@ export class RelayFeeCalculator {
     const relayFeePercent = gasFeePercent.add(capitalFeePercent).add(auxNativeFeePercent);
     const relayFeeTotal = gasFeeTotal.add(capitalFeeTotal).add(auxNativeFeeTotal);
 
-    // We don't want the relayer to incur an excessive gas fee charge as a % of the deposited total. The maximum
-    // gas fee % charged is equal to the remaining fee % leftover after subtracting the capital fee % and aux fee %
-    // from the fee limit %. We then compute the minimum deposited amount required to not exceed the maximum
-    // gas fee %: maxGasFeePercent = gasFeeTotal / minDeposit. Refactor this to figure out the minDeposit:
-    // minDeposit = gasFeeTotal / maxGasFeePercent, and subsequently determine
-    // isAmountTooLow = amountToRelay < minDeposit.
+    // `maxGasFeePercent` reports the remaining fee budget at the given `outputAmount`:
+    // what fraction of the input can still be spent on gas after capital and auxiliary
+    // fees are taken out. Kept in per-amount terms for backwards compatibility with
+    // callers that display it as a live percentage.
     const maxGasFeePercent = max(
       toBNWei(this.feeLimitPercent / 100)
         .sub(capitalFeePercent)
         .sub(auxNativeFeePercent),
       toBN(0)
     );
-    // If maxGasFee % is 0, then the min deposit should be infinite because there is no deposit amount that would
-    // incur a non zero gas fee % charge. In this case, isAmountTooLow should always be true.
+
+    // `minDeposit` is the smallest `outputAmount` for which gas, capital, and
+    // auxiliary fees together stay under `feeLimitPercent`. Solving with the variable
+    // costs in absolute terms (gas + aux scale as constant_cost / amount; capital is
+    // ~constant near the bound):
+    //
+    //   (gasFeeTotal + auxFeesInInputDecimals) / minDeposit + capitalFeePercent
+    //     <= feeLimitPercent
+    //
+    //   ⇒ minDeposit = (gasFeeTotal + auxFeesInInputDecimals) /
+    //                  (feeLimitPercent − capitalFeePercent)
+    //
+    // The earlier closed-form derived `minDeposit` from the per-amount
+    // `maxGasFeePercent`, which incorporated `auxNativeFeePercent = auxCost /
+    // outputAmount`. That ratio diverges as `outputAmount → 0`, pinning `minDeposit`
+    // to `MAX_BIG_INT` for any small simulation amount on chains with non-zero
+    // auxiliary cost (e.g. Tron bandwidth) — even though a real deposit would have
+    // been feasible. Computing it directly from absolute aux cost avoids that.
+    const minDepositBudget = max(toBNWei(this.feeLimitPercent / 100).sub(capitalFeePercent), toBN(0));
     let minDeposit: BigNumber, isAmountTooLow: boolean;
-    if (maxGasFeePercent.eq(toBN(0))) {
+    if (minDepositBudget.eq(toBN(0))) {
+      // Capital fee alone has exhausted the budget; no deposit amount can satisfy
+      // the limit.
       minDeposit = MAX_BIG_INT;
       isAmountTooLow = true;
     } else {
-      minDeposit = gasFeeTotal.mul(fixedPointAdjustment).div(maxGasFeePercent);
+      minDeposit = gasFeeTotal.add(auxFeesInInputDecimals).mul(fixedPointAdjustment).div(minDepositBudget);
       isAmountTooLow = toBN(outputAmount).lt(minDeposit);
     }
 

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -617,9 +617,9 @@ export class RelayFeeCalculator {
     // to `MAX_BIG_INT` for any small simulation amount on chains with non-zero
     // auxiliary cost (e.g. Tron bandwidth) — even though a real deposit would have
     // been feasible. Computing it directly from absolute aux cost avoids that.
-    const minDepositBudget = max(toBNWei(this.feeLimitPercent / 100).sub(capitalFeePercent), toBN(0));
+    const minDepositBudget = max(toBNWei(this.feeLimitPercent / 100).sub(capitalFeePercent), bnZero);
     let minDeposit: BigNumber, isAmountTooLow: boolean;
-    if (minDepositBudget.eq(toBN(0))) {
+    if (minDepositBudget.eq(bnZero)) {
       // Capital fee alone has exhausted the budget; no deposit amount can satisfy
       // the limit.
       minDeposit = MAX_BIG_INT;

--- a/src/relayFeeCalculator/relayFeeCalculator.ts
+++ b/src/relayFeeCalculator/relayFeeCalculator.ts
@@ -594,10 +594,7 @@ export class RelayFeeCalculator {
     // fees are taken out. Kept in per-amount terms for backwards compatibility with
     // callers that display it as a live percentage.
     const maxGasFeePercent = max(
-      toBNWei(this.feeLimitPercent)
-        .div(100)
-        .sub(capitalFeePercent)
-        .sub(auxNativeFeePercent),
+      toBNWei(this.feeLimitPercent).div(100).sub(capitalFeePercent).sub(auxNativeFeePercent),
       bnZero
     );
 

--- a/test/relayFeeCalculator.test.ts
+++ b/test/relayFeeCalculator.test.ts
@@ -195,6 +195,49 @@ describe("RelayFeeCalculator", () => {
       true
     );
   });
+
+  it("relayerFeeDetails: minDeposit stays finite when aux native cost dominates a small simulation amount", async () => {
+    // Regression for the case reported by Melisa on quote-api#2779 against SDK 4.3.166:
+    // a /api/limits call without an `amount` falls back to a tiny simulation amount
+    // (100 raw units ≈ 1e-4 USDT). With Tron's non-zero `getAuxiliaryNativeTokenCost`,
+    // the legacy `auxNativeFeePercent` (= auxCost / outputAmount) exploded, clamping
+    // `maxGasFeePercent` to 0 and returning `minDeposit = MAX_BIG_INT` for an
+    // otherwise viable route. Solving for `minDeposit` directly from the absolute
+    // aux cost keeps the result finite.
+    class FixedAuxQueries extends ExampleQueries {
+      override getAuxiliaryNativeTokenCost(): BigNumber {
+        // Arbitrary non-zero native-token cost; magnitude is large enough to have
+        // exploded the legacy closed-form against the tiny outputAmount below.
+        return toBN("1000000000");
+      }
+    }
+
+    const auxQueries = new FixedAuxQueries();
+    const tinyAmount = 100; // matches the simulationAmount fallback in callers like /api/limits
+    const auxClient = new RelayFeeCalculator({
+      queries: auxQueries,
+      feeLimitPercent: 25,
+      capitalCostsConfig: testCapitalCostsConfig,
+    });
+    const details = await auxClient.relayerFeeDetails(
+      buildDepositForRelayerFeeTest(tinyAmount, "usdc", 1, 10),
+      tinyAmount
+    );
+
+    // minDeposit must be finite (not MAX_BIG_INT) — that's the regression.
+    assert.notEqual(details.minDeposit, Number.MAX_SAFE_INTEGER.toString());
+
+    // minDeposit should be invariant in the probe `outputAmount`: callers that probe
+    // with a throwaway amount should get the same value as callers that pass a real
+    // one. (The legacy formula folded `outputAmount` in via the per-amount
+    // `auxNativeFeePercent`, so the two would have differed.)
+    const probeDetails = await auxClient.relayerFeeDetails(
+      buildDepositForRelayerFeeTest(1000e6, "usdc", 1, 10),
+      1000e6
+    );
+    assert.equal(details.minDeposit, probeDetails.minDeposit);
+  });
+
   it("capitalFeePercent", () => {
     // Invalid capital cost configs throws on construction:
     assert.throws(


### PR DESCRIPTION
## Summary

\`relayerFeeDetails\` derived \`minDeposit\` from \`maxGasFeePercent = feeLimitPercent − capitalFeePercent − auxNativeFeePercent\`, where \`auxNativeFeePercent = auxNativeCost / outputAmount\` scales as 1 / outputAmount. Once 4.3.166 added Tron bandwidth via [\`TvmQuery\`](https://github.com/across-protocol/sdk/pull/1459), callers that pass a tiny probe amount started seeing the auxiliary percent explode, \`maxGasFeePercent\` clamp to 0, and \`minDeposit\` return \`MAX_BIG_INT\` for routes that were otherwise feasible.

Reported by @melisaguevara on across-protocol/quote-api#2779:

> GET /api/limits?...&destinationChainId=728126428          (no amount)
>   preview:  minDeposit = 508,066,351,383  ==  maxDeposit  ← route effectively closed
>   prod:     minDeposit =          22,068,563

Root cause: \`/api/limits\` falls back to \`simulationAmount = 100\` (1e-4 USDT) when no \`amount\` is provided. Against Tron's ~3 USDT bandwidth cost that drove \`auxNativeFeePercent\` past \`feeLimitPercent\`, then the closed-form for \`minDeposit\` collapsed.

## Fix

Solve for \`minDeposit\` directly from the absolute aux cost, in input-token decimals:

\`\`\`
minDeposit = (gasFeeTotal + auxFeesInInputDecimals)
           / max(feeLimitPercent − capitalFeePercent, 0)
\`\`\`

The result no longer depends on the probe \`outputAmount\`. When capital fee alone exhausts the fee budget, \`minDeposit = MAX_BIG_INT\` as before.

\`maxGasFeePercent\` is unchanged (still the per-amount remaining budget), so downstream consumers that surface it see no semantic shift.

Refactored aux cost computation into a \`resolveAuxNativeFee\` helper that returns both the absolute and percent forms; \`auxNativeFeePercent\` delegates to it.

## Why not patch quote-api alone

Quote-api shipped a workaround (across-protocol/quote-api#2779 commit \`76317ff8\`) that switches the simulation fallback to a 1000-token-worth amount for TVM destinations. That fixes the immediate \`/api/limits\` symptom but leaves the SDK's \`minDeposit\` math sensitive to caller-side probe sizing — any other consumer that probes with a small amount has the same trap. Fixing the SDK eliminates the foot-gun and lets quote-api drop the special case in a follow-up.

## Test plan

- [x] New unit test \`relayerFeeDetails: minDeposit stays finite when aux native cost dominates a small simulation amount\`:
  - With a query returning non-zero \`getAuxiliaryNativeTokenCost\` and a tiny probe amount, \`minDeposit\` is finite (not \`MAX_BIG_INT\`).
  - \`minDeposit\` returned for a tiny probe equals \`minDeposit\` returned for a real-sized probe — the value is invariant in the caller's amount.
- [x] All existing \`relayFeeCalculator.test.ts\` cases (incl. the canonical 10% fee-limit / 1000 USDC test) still pass — the zero-aux paths behave identically to the old formula.
- [x] \`yarn build\` clean, \`eslint\` + \`prettier\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)