### PR TITLE
fix(tvm): paginate eth_getLogs from SpokePoolClient.eventSearchConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.167",
+  "version": "4.3.168",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/src/arch/evm/UpgradeUtils.ts
+++ b/src/arch/evm/UpgradeUtils.ts
@@ -6,13 +6,19 @@ import { paginatedEventQuery } from "../../utils";
  * @param contract A contract instance (must be a UUPS or transparent proxy that emits the Upgraded event).
  * @param startBlock Optional start of the block range (inclusive). Defaults to 0.
  * @param endBlock Optional end of the block range (inclusive). Defaults to latest.
+ * @param maxLookBack Optional eth_getLogs chunk size. Required on RPCs that cap the range (e.g. Chainstack Tron).
  * @returns An array of block numbers at which upgrades occurred, sorted ascending.
  */
-export async function get1967Upgrades(contract: Contract, startBlock?: number, endBlock?: number): Promise<number[]> {
+export async function get1967Upgrades(
+  contract: Contract,
+  startBlock?: number,
+  endBlock?: number,
+  maxLookBack?: number
+): Promise<number[]> {
   const from = startBlock ?? 0;
   const to = endBlock ?? (await contract.provider.getBlockNumber());
 
-  const events = await paginatedEventQuery(contract, contract.filters.Upgraded(), { from, to });
+  const events = await paginatedEventQuery(contract, contract.filters.Upgraded(), { from, to, maxLookBack });
 
   return events.map(({ blockNumber }) => blockNumber);
 }

--- a/src/arch/tvm/SpokeUtils.ts
+++ b/src/arch/tvm/SpokeUtils.ts
@@ -16,6 +16,12 @@ import {
 
 type BlockTag = providers.BlockTag;
 
+// Search config plumbed through TVM helpers so paginated event queries actually
+// chunk on RPCs that cap eth_getLogs ranges (Chainstack caps Tron at 5,000).
+// Mirrors the {from, maxLookBack} shape that the SpokePoolClient already
+// threads through its EVM event queries (see EVMSpokePoolClient.queryDepositEvents).
+type SearchConfig = { from?: number; maxLookBack?: number };
+
 // Re-export functions that work unchanged on TRON's JSON-RPC.
 export { populateV3Relay, getTimestampForBlock, fillStatusArray } from "../evm/SpokeUtils";
 
@@ -48,11 +54,12 @@ const FALLBACK_FILL_DEADLINE_BUFFER = 21600; // 6 hours in seconds
 export async function getMaxFillDeadlineInRange(
   spokePool: Contract,
   startBlock: number,
-  endBlock: number
+  endBlock: number,
+  eventSearchConfig?: SearchConfig
 ): Promise<number> {
   const [fillDeadlineBuffer, upgrades] = await Promise.all([
     spokePool.fillDeadlineBuffer(),
-    get1967Upgrades(spokePool, startBlock, endBlock),
+    get1967Upgrades(spokePool, startBlock, endBlock, eventSearchConfig?.maxLookBack),
   ]);
 
   const currentBuffer = Number(fillDeadlineBuffer);
@@ -80,7 +87,8 @@ export async function findDepositBlock(
   spokePool: Contract,
   depositId: BigNumber,
   lowBlock: number,
-  highBlock?: number
+  highBlock?: number,
+  eventSearchConfig?: SearchConfig
 ): Promise<number | undefined> {
   if (isUnsafeDepositId(depositId)) {
     throw new Error(`Cannot search for depositId ${depositId}`);
@@ -92,7 +100,7 @@ export async function findDepositBlock(
   const events = await paginatedEventQuery(
     spokePool,
     spokePool.filters.FundsDeposited(null, null, null, null, null, depositId),
-    { from: lowBlock, to: highBlock }
+    { from: lowBlock, to: highBlock, maxLookBack: eventSearchConfig?.maxLookBack }
   );
 
   if (events.length === 0) {
@@ -113,7 +121,8 @@ export async function relayFillStatus(
   spokePool: Contract,
   relayData: RelayData,
   blockTag: BlockTag = "latest",
-  destinationChainId?: number
+  destinationChainId?: number,
+  eventSearchConfig?: SearchConfig
 ): Promise<FillStatus> {
   if (blockTag === "latest") {
     return evmRelayFillStatus(spokePool, relayData, blockTag, destinationChainId);
@@ -132,14 +141,17 @@ export async function relayFillStatus(
     return FillStatus.Unfilled;
   }
 
-  // Reconstruct from events up to the requested block.
-  const fromBlock = 0;
+  // Reconstruct from events up to the requested block. Default fromBlock to 0
+  // when the caller did not supply one, but the SpokePoolClient passes the
+  // deployment block to keep the scan bounded — events cannot exist before then.
+  const fromBlock = eventSearchConfig?.from ?? 0;
   const toBlock = Number(blockTag);
+  const { maxLookBack } = eventSearchConfig ?? {};
 
   const fillEvents = await paginatedEventQuery(
     spokePool,
     spokePool.filters.FilledRelay(null, null, null, null, null, relayData.originChainId, relayData.depositId),
-    { from: fromBlock, to: toBlock }
+    { from: fromBlock, to: toBlock, maxLookBack }
   );
 
   if (fillEvents.length > 0) {
@@ -151,7 +163,7 @@ export async function relayFillStatus(
     const slowFillEvents = await paginatedEventQuery(
       spokePool,
       spokePool.filters.RequestedSlowFill(null, null, null, null, relayData.originChainId, relayData.depositId),
-      { from: fromBlock, to: toBlock }
+      { from: fromBlock, to: toBlock, maxLookBack }
     );
 
     if (slowFillEvents.length > 0) {
@@ -171,7 +183,8 @@ export async function findFillBlock(
   spokePool: Contract,
   relayData: RelayData,
   lowBlockNumber: number,
-  highBlockNumber?: number
+  highBlockNumber?: number,
+  eventSearchConfig?: SearchConfig
 ): Promise<number | undefined> {
   const { provider } = spokePool;
   highBlockNumber ??= await provider.getBlockNumber();
@@ -180,7 +193,7 @@ export async function findFillBlock(
   const events = await paginatedEventQuery(
     spokePool,
     spokePool.filters.FilledRelay(null, null, null, null, null, relayData.originChainId, relayData.depositId),
-    { from: lowBlockNumber, to: highBlockNumber }
+    { from: lowBlockNumber, to: highBlockNumber, maxLookBack: eventSearchConfig?.maxLookBack }
   );
 
   if (events.length === 0) {
@@ -198,7 +211,8 @@ export async function findFillEvent(
   spokePool: Contract,
   relayData: RelayData,
   lowBlockNumber: number,
-  highBlockNumber?: number
+  highBlockNumber?: number,
+  eventSearchConfig?: SearchConfig
 ): Promise<FillWithBlock | undefined> {
   const { provider } = spokePool;
   highBlockNumber ??= await provider.getBlockNumber();
@@ -206,7 +220,7 @@ export async function findFillEvent(
   const events = await paginatedEventQuery(
     spokePool,
     spokePool.filters.FilledRelay(null, null, null, null, null, relayData.originChainId, relayData.depositId),
-    { from: lowBlockNumber, to: highBlockNumber }
+    { from: lowBlockNumber, to: highBlockNumber, maxLookBack: eventSearchConfig?.maxLookBack }
   );
 
   if (events.length === 0) {

--- a/src/arch/tvm/SpokeUtils.ts
+++ b/src/arch/tvm/SpokeUtils.ts
@@ -16,10 +16,6 @@ import {
 
 type BlockTag = providers.BlockTag;
 
-// Search config plumbed through TVM helpers so paginated event queries actually
-// chunk on RPCs that cap eth_getLogs ranges (Chainstack caps Tron at 5,000).
-// Mirrors the {from, maxLookBack} shape that the SpokePoolClient already
-// threads through its EVM event queries (see EVMSpokePoolClient.queryDepositEvents).
 type SearchConfig = { from?: number; maxLookBack?: number };
 
 // Re-export functions that work unchanged on TRON's JSON-RPC.
@@ -141,9 +137,6 @@ export async function relayFillStatus(
     return FillStatus.Unfilled;
   }
 
-  // Reconstruct from events up to the requested block. Default fromBlock to 0
-  // when the caller did not supply one, but the SpokePoolClient passes the
-  // deployment block to keep the scan bounded — events cannot exist before then.
   const fromBlock = eventSearchConfig?.from ?? 0;
   const toBlock = Number(blockTag);
   const { maxLookBack } = eventSearchConfig ?? {};

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1379,8 +1379,18 @@ export class BundleDataClient {
         spokePoolClient.logger
       );
     } else if (isEVMSpokePoolClient(spokePoolClient)) {
-      const findFillEventHandler = chainIsTvm(spokePoolClient.chainId) ? findTvmFillEvent : findEvmFillEvent;
-      return await findFillEventHandler(
+      if (chainIsTvm(spokePoolClient.chainId)) {
+        // Thread the eventSearchConfig so paginatedEventQuery chunks the
+        // deploymentBlock→latestHeightSearched range on capped RPCs.
+        return await findTvmFillEvent(
+          spokePoolClient.spokePool,
+          deposit,
+          spokePoolClient.deploymentBlock,
+          spokePoolClient.latestHeightSearched,
+          { maxLookBack: spokePoolClient.eventSearchConfig.maxLookBack }
+        );
+      }
+      return await findEvmFillEvent(
         spokePoolClient.spokePool,
         deposit,
         spokePoolClient.deploymentBlock,

--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -1380,8 +1380,6 @@ export class BundleDataClient {
       );
     } else if (isEVMSpokePoolClient(spokePoolClient)) {
       if (chainIsTvm(spokePoolClient.chainId)) {
-        // Thread the eventSearchConfig so paginatedEventQuery chunks the
-        // deploymentBlock→latestHeightSearched range on capped RPCs.
         return await findTvmFillEvent(
           spokePoolClient.spokePool,
           deposit,

--- a/src/clients/SpokePoolClient/EVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/EVMSpokePoolClient.ts
@@ -58,8 +58,15 @@ export class EVMSpokePoolClient extends SpokePoolClient {
   }
 
   public override relayFillStatus(relayData: RelayData, atHeight?: number): Promise<FillStatus> {
-    const fillStatusHandler = this.tvm ? relayFillStatusTvm : relayFillStatus;
-    return fillStatusHandler(this.spokePool, relayData, atHeight, this.chainId);
+    if (this.tvm) {
+      // TVM reconstructs the historical status from events; thread the search
+      // config so paginatedEventQuery chunks on capped RPCs (e.g. Chainstack Tron).
+      return relayFillStatusTvm(this.spokePool, relayData, atHeight, this.chainId, {
+        from: this.deploymentBlock,
+        maxLookBack: this.eventSearchConfig.maxLookBack,
+      });
+    }
+    return relayFillStatus(this.spokePool, relayData, atHeight, this.chainId);
   }
 
   public override fillStatusArray(relayData: RelayData[], atHeight?: number): Promise<(FillStatus | undefined)[]> {
@@ -71,8 +78,12 @@ export class EVMSpokePoolClient extends SpokePoolClient {
     // an earlier block reverts because the contract did not yet exist.
     const effectiveStartBlock = Math.max(startBlock, this.deploymentBlock);
 
-    const maxFillDeadlineInRangeHandler = this.tvm ? getMaxFillDeadlineTvm : getMaxFillDeadline;
-    return maxFillDeadlineInRangeHandler(this.spokePool, effectiveStartBlock, endBlock);
+    if (this.tvm) {
+      return getMaxFillDeadlineTvm(this.spokePool, effectiveStartBlock, endBlock, {
+        maxLookBack: this.eventSearchConfig.maxLookBack,
+      });
+    }
+    return getMaxFillDeadline(this.spokePool, effectiveStartBlock, endBlock);
   }
 
   private _availableEventsOnSpoke(eventNames: string[] = knownEventNames): { [eventName: string]: EventFilter } {
@@ -216,8 +227,12 @@ export class EVMSpokePoolClient extends SpokePoolClient {
    * TVM overrides this with an event-based lookup.
    */
   protected _findDepositBlock(depositId: BigNumber, lowBlock: number, highBlock?: number): Promise<number | undefined> {
-    const findDepositBlockHandler = this.tvm ? findDepositBlockTvm : findDepositBlock;
-    return findDepositBlockHandler(this.spokePool, depositId, lowBlock, highBlock);
+    if (this.tvm) {
+      return findDepositBlockTvm(this.spokePool, depositId, lowBlock, highBlock, {
+        maxLookBack: this.eventSearchConfig.maxLookBack,
+      });
+    }
+    return findDepositBlock(this.spokePool, depositId, lowBlock, highBlock);
   }
 
   protected async queryDepositEvents(

--- a/src/clients/SpokePoolClient/EVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/EVMSpokePoolClient.ts
@@ -59,8 +59,6 @@ export class EVMSpokePoolClient extends SpokePoolClient {
 
   public override relayFillStatus(relayData: RelayData, atHeight?: number): Promise<FillStatus> {
     if (this.tvm) {
-      // TVM reconstructs the historical status from events; thread the search
-      // config so paginatedEventQuery chunks on capped RPCs (e.g. Chainstack Tron).
       return relayFillStatusTvm(this.spokePool, relayData, atHeight, this.chainId, {
         from: this.deploymentBlock,
         maxLookBack: this.eventSearchConfig.maxLookBack,


### PR DESCRIPTION
## Summary

`relayFillStatus`, `findFillBlock`, `findFillEvent`, `findDepositBlock`, and `getMaxFillDeadlineInRange` in `arch/tvm/SpokeUtils` were calling `paginatedEventQuery` without a `maxLookBack`. With `maxLookBack === undefined`, `getPaginatedBlockRanges` returns the whole `[from, to]` range as a single `eth_getLogs` — so the calls degrade to a single open-ended request that Chainstack Tron rejects with `exceed max block range: 5000`.

This kept biting the dataworker: `BundleDataClient._getFillStatusForDeposit` (and `findMatchingFillEvent`) call `SpokePoolClient.relayFillStatus` / `findFillEvent` with a numeric `atHeight`, which dispatches to the TVM helper, which does `paginatedEventQuery(spokePool, filter, { from: 0, to: blockTag })` against the Tron SpokePool. The relayer's `CHAIN_MAX_BLOCK_LOOKBACK[TRON] = 5_000` ([across-protocol/relayer#3480](https://github.com/across-protocol/relayer/pull/3480)) was only consulted by the `SpokePoolClient` event-ingestion path; this code path bypassed it entirely.

### What changes

The fix mirrors the threading pattern already used by `EVMSpokePoolClient.queryDepositEvents`: pull `maxLookBack` (and `from = deploymentBlock`) out of the `SpokePoolClient.eventSearchConfig` and pass it into the TVM helper.

- `arch/tvm/SpokeUtils.ts`: add an optional `{ from?, maxLookBack? }` config to all five TVM helpers and thread it into every `paginatedEventQuery`. `relayFillStatus` now uses the caller's `from` instead of hard-coded block 0 so the bounded scan starts at the SpokePool deployment block.
- `arch/evm/UpgradeUtils.ts`: add an optional `maxLookBack` to `get1967Upgrades`; its only caller is the TVM `getMaxFillDeadlineInRange`, where Tron bundles can span more than 5,000 blocks.
- `clients/SpokePoolClient/EVMSpokePoolClient.ts`: when dispatching to TVM helpers, pass `{ from: this.deploymentBlock, maxLookBack: this.eventSearchConfig.maxLookBack }`. EVM dispatches are unchanged — EVM uses historical `eth_call` over `fillStatuses(blockTag)` and doesn't need pagination.
- `clients/BundleDataClient/BundleDataClient.ts`: same threading at the `findMatchingFillEvent` TVM dispatch.

### Consistency with EVM

EVM `relayFillStatus` does a single historical `eth_call` (`fillStatuses(hash, { blockTag })`) — no event query, no pagination. EVM `findFillEvent` calls `findFillBlock` (binary search via historical `eth_call`) to narrow to one block, then runs a 1-block event query with `maxLookBack: 0` (the "single shot" hint). TVM can't do historical `eth_call`, so it must scan events — but the scan now respects the same `eventSearchConfig` shape the SpokePoolClient already produces and threads everywhere else.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.build.json` clean.
- [x] `yarn lint-check` clean.
- [x] `npx hardhat test test/SpokeUtils.ts test/SpokePoolClient.fills.ts test/SpokePoolClient.ValidateFill.ts test/SpokePoolClient.findDeposits.ts test/BundleDataClient.Arweave.test.ts test/BundleDataClient.cache.ts test/BundleDataClient.arweave.ts` — 64 passing.
- [ ] Verify on Tron mainnet: dataworker run no longer hits `exceed max block range: 5000` on the FilledRelay scan.
- [ ] No TVM-specific unit test added — there's no Tron hardhat fork, so the change is mechanical threading of a config already validated by the EVM/SpokePoolClient suite.

Reported in [#crisis Slack thread](https://uma-corp.slack.com/archives/C03GHT4RV42/p1781213602649079).

🤖 Generated with [Claude Code](https://claude.com/claude-code)