### PR TITLE
fix(HubPoolClient): Resolve unknown running balances

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.3.171",
+  "version": "4.4.0",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/src/clients/BundleDataClient/utils/DataworkerUtils.ts
+++ b/src/clients/BundleDataClient/utils/DataworkerUtils.ts
@@ -194,7 +194,7 @@ export async function _buildPoolRebalanceRoot(
  * @param clients Clients required to construct a new pool rebalance root.
  * @maxL1TokenCountOverride Optional parameter to cap the number of tokens in a single pool rebalance leaf.
  */
-export function _buildHistoricalPoolRebalanceRoot(
+export async function _buildHistoricalPoolRebalanceRoot(
   latestMainnetBlock: number,
   mainnetBundleEndBlock: number,
   bundleV3Deposits: BundleDepositsV3,
@@ -207,7 +207,7 @@ export function _buildHistoricalPoolRebalanceRoot(
     configStoreClient: AcrossConfigStoreClient;
   },
   maxL1TokenCountOverride?: number
-): PoolRebalanceRoot {
+): Promise<PoolRebalanceRoot> {
   const { runningBalances, realizedLpFees, chainWithRefundsOnly } = _getMarginalRunningBalances(
     mainnetBundleEndBlock,
     bundleV3Deposits,
@@ -217,7 +217,7 @@ export function _buildHistoricalPoolRebalanceRoot(
     expiredDepositsToRefundV3,
     clients
   );
-  addLastRunningBalance(latestMainnetBlock, runningBalances, clients.hubPoolClient);
+  await addLastRunningBalance(latestMainnetBlock, runningBalances, clients.hubPoolClient);
   const leaves: PoolRebalanceLeaf[] = constructPoolRebalanceLeaves(
     mainnetBundleEndBlock,
     runningBalances,
@@ -286,7 +286,7 @@ export async function _buildOptimisticPoolRebalanceRoot(
     true
   );
   // Build the pool rebalance root for the pending root bundle.
-  const { leaves, tree } = _buildHistoricalPoolRebalanceRoot(
+  const { leaves, tree } = await _buildHistoricalPoolRebalanceRoot(
     latestMainnetBlock,
     blockRangesForChains[0][1],
     pendingRootBundleData.bundleDepositsV3,
@@ -302,9 +302,8 @@ export async function _buildOptimisticPoolRebalanceRoot(
 
   // Only add marginal pending running balances if there is already an entry in `runningBalances`. If there is no entry in `runningBalances`, then
   // The running balance for this entry was unchanged since the last root bundle.
-  Object.keys(runningBalances).forEach((_repaymentChainId) => {
-    Object.keys(runningBalances[Number(_repaymentChainId)]).forEach((_l1TokenAddress) => {
-      const repaymentChainId = Number(_repaymentChainId);
+  for (const repaymentChainId of Object.keys(runningBalances).map(Number)) {
+    for (const _l1TokenAddress of Object.keys(runningBalances[repaymentChainId])) {
       const l1TokenAddress = EvmAddress.from(_l1TokenAddress);
       const pendingPoolRebalanceLeaf = leaves.find(
         (leaf) => leaf.chainId === repaymentChainId && leaf.l1Tokens.some((l1Token) => l1Token.eq(l1TokenAddress))
@@ -322,7 +321,7 @@ export async function _buildOptimisticPoolRebalanceRoot(
       } else {
         // Otherwise, add the last running balance for this token.
         const { runningBalance: lastExecutedBundleRunningBalance } =
-          clients.hubPoolClient.getRunningBalanceBeforeBlockForChain(
+          await clients.hubPoolClient.getRunningBalanceBeforeBlockForChain(
             latestMainnetBlock,
             repaymentChainId,
             l1TokenAddress
@@ -331,8 +330,8 @@ export async function _buildOptimisticPoolRebalanceRoot(
           updateRunningBalance(runningBalances, repaymentChainId, _l1TokenAddress, lastExecutedBundleRunningBalance);
         }
       }
-    });
-  });
+    }
+  }
   const poolRebalanceLeaves: PoolRebalanceLeaf[] = constructPoolRebalanceLeaves(
     mainnetBundleEndBlock,
     runningBalances,

--- a/src/clients/BundleDataClient/utils/PoolRebalanceUtils.ts
+++ b/src/clients/BundleDataClient/utils/PoolRebalanceUtils.ts
@@ -184,23 +184,23 @@ export function updateRunningBalance(
   }
 }
 
-export function addLastRunningBalance(
+export async function addLastRunningBalance(
   latestMainnetBlock: number,
   runningBalances: RunningBalances,
   hubPoolClient: HubPoolClient
-): void {
-  Object.keys(runningBalances).forEach((repaymentChainId) => {
-    Object.keys(runningBalances[Number(repaymentChainId)]).forEach((l1TokenAddress) => {
-      const { runningBalance } = hubPoolClient.getRunningBalanceBeforeBlockForChain(
+): Promise<void> {
+  for (const repaymentChainId of Object.keys(runningBalances).map(Number)) {
+    for (const l1TokenAddress of Object.keys(runningBalances[repaymentChainId])) {
+      const { runningBalance } = await hubPoolClient.getRunningBalanceBeforeBlockForChain(
         latestMainnetBlock,
-        Number(repaymentChainId),
+        repaymentChainId,
         EvmAddress.from(l1TokenAddress)
       );
       if (!runningBalance.eq(bnZero)) {
-        updateRunningBalance(runningBalances, Number(repaymentChainId), l1TokenAddress, runningBalance);
+        updateRunningBalance(runningBalances, repaymentChainId, l1TokenAddress, runningBalance);
       }
-    });
-  });
+    }
+  }
 }
 
 export function updateRunningBalanceForDeposit(

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -40,7 +40,6 @@ import {
   shouldCache,
   sortEventsDescending,
   spreadEventWithBlockNumber,
-  toBN,
   getTokenInfo,
   getUsdcSymbol,
   chainIsSvm,
@@ -803,8 +802,43 @@ export class HubPoolClient extends BaseAbstractClient {
     });
   }
 
-  getRunningBalanceBeforeBlockForChain(block: number, chain: number, l1Token: EvmAddress): TokenRunningBalance {
-    const executedRootBundle = this.getLatestExecutedRootBundleContainingL1Token(block, chain, l1Token);
+  async getRunningBalanceBeforeBlockForChain(
+    block: number,
+    chain: number,
+    l1Token: EvmAddress
+  ): Promise<TokenRunningBalance> {
+    let executedRootBundle = this.getLatestExecutedRootBundleContainingL1Token(block, chain, l1Token);
+
+    // `executedRootBundles` only spans the configured event lookback. If there's no balance update for this
+    // (chain, l1Token) within it, query the preceding history on the fly before assuming a zero running
+    // balance -- otherwise a balance carried by a token idle longer than the lookback is silently dropped,
+    // under-pulling spoke liquidity.
+    if (!isDefined(executedRootBundle)) {
+      const to = this.eventSearchConfig.from - 1; // the range preceding the already-loaded lookback window
+      if (to >= this.deploymentBlock) {
+        // Mirror update(): query RootBundleExecuted unfiltered and match chainId in-memory (chainId is not
+        // reliably filterable across HubPool versions).
+        const events = await paginatedEventQuery(this.hubPool, this.hubPool.filters.RootBundleExecuted(), {
+          from: this.deploymentBlock,
+          to,
+          maxLookBack: this.eventSearchConfig.maxLookBack,
+        });
+        const historical = events.map((event) => {
+          const spread = spreadEventWithBlockNumber(event) as Omit<ExecutedRootBundle, "l1Tokens"> & {
+            l1Tokens: string[];
+          };
+          // runningBalances may include incentive balances in the second half; keep the first nTokens.
+          spread.runningBalances = spread.runningBalances.slice(0, spread.l1Tokens.length);
+          return { ...spread, l1Tokens: spread.l1Tokens.map((token) => EvmAddress.from(token)) } as ExecutedRootBundle;
+        });
+        executedRootBundle = sortEventsDescending(historical).find(
+          (executedLeaf) =>
+            executedLeaf.blockNumber <= block &&
+            executedLeaf.chainId === chain &&
+            executedLeaf.l1Tokens.some((token) => token.eq(l1Token))
+        );
+      }
+    }
 
     return this.getRunningBalanceForToken(l1Token, executedRootBundle);
   }
@@ -813,7 +847,7 @@ export class HubPoolClient extends BaseAbstractClient {
     l1Token: EvmAddress,
     executedRootBundle: ExecutedRootBundle | undefined
   ): TokenRunningBalance {
-    let runningBalance = toBN(0);
+    let runningBalance = bnZero;
     if (executedRootBundle) {
       const indexOfL1Token = executedRootBundle.l1Tokens.findIndex((tokenInBundle) => tokenInBundle.eq(l1Token));
       if (indexOfL1Token !== -1) {

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -132,6 +132,26 @@ export class HubPoolClient extends BaseAbstractClient {
     };
   }
 
+  // Decode a RootBundleExecuted log and normalize it into ExecutedRootBundle. runningBalances may carry
+  // incentive balances in the second half — keep only the first nTokens entries, matching the on-chain layout.
+  private decodeExecutedRootBundle(event: Log): ExecutedRootBundle {
+    const spread = spreadEventWithBlockNumber(event) as Omit<ExecutedRootBundle, "l1Tokens"> & {
+      l1Tokens: string[];
+    };
+    const nTokens = spread.l1Tokens.length;
+    if (![nTokens, nTokens * 2].includes(spread.runningBalances.length)) {
+      throw new Error(
+        `Invalid runningBalances length: ${spread.runningBalances.length}.` +
+          ` Expected ${nTokens} or ${nTokens * 2} for chain ${this.chainId} transaction ${spread.txnRef}`
+      );
+    }
+    return {
+      ...spread,
+      runningBalances: spread.runningBalances.slice(0, nTokens),
+      l1Tokens: spread.l1Tokens.map((token) => EvmAddress.from(token)),
+    };
+  }
+
   hasPendingProposal(): boolean {
     return this.pendingRootBundle !== undefined;
   }
@@ -816,21 +836,14 @@ export class HubPoolClient extends BaseAbstractClient {
     if (!isDefined(executedRootBundle)) {
       const to = this.eventSearchConfig.from - 1; // the range preceding the already-loaded lookback window
       if (to >= this.deploymentBlock) {
-        // Mirror update(): query RootBundleExecuted unfiltered and match chainId in-memory (chainId is not
-        // reliably filterable across HubPool versions).
         const events = await paginatedEventQuery(this.hubPool, this.hubPool.filters.RootBundleExecuted(), {
           from: this.deploymentBlock,
           to,
           maxLookBack: this.eventSearchConfig.maxLookBack,
         });
-        const historical = events.map((event) => {
-          const spread = spreadEventWithBlockNumber(event) as Omit<ExecutedRootBundle, "l1Tokens"> & {
-            l1Tokens: string[];
-          };
-          // runningBalances may include incentive balances in the second half; keep the first nTokens.
-          spread.runningBalances = spread.runningBalances.slice(0, spread.l1Tokens.length);
-          return { ...spread, l1Tokens: spread.l1Tokens.map((token) => EvmAddress.from(token)) } as ExecutedRootBundle;
-        });
+        const historical = events
+          .filter((event) => !this.configOverride.ignoredHubExecutedBundles.includes(event.blockNumber))
+          .map((event) => this.decodeExecutedRootBundle(event));
         executedRootBundle = sortEventsDescending(historical).find(
           (executedLeaf) =>
             executedLeaf.blockNumber <= block &&
@@ -1101,26 +1114,7 @@ export class HubPoolClient extends BaseAbstractClient {
         if (this.configOverride.ignoredHubExecutedBundles.includes(event.blockNumber)) {
           continue;
         }
-
-        // Set running balances and incentive balances for this bundle.
-        const executedRootBundle = spreadEventWithBlockNumber(event) as Omit<ExecutedRootBundle, "l1Tokens"> & {
-          l1Tokens: string[];
-        };
-        const { l1Tokens, runningBalances } = executedRootBundle;
-        const nTokens = l1Tokens.length;
-
-        // Safeguard
-        if (![nTokens, nTokens * 2].includes(runningBalances.length)) {
-          throw new Error(
-            `Invalid runningBalances length: ${runningBalances.length}.` +
-              ` Expected ${nTokens} or ${nTokens * 2} for chain ${this.chainId} transaction ${event.transactionHash}`
-          );
-        }
-        executedRootBundle.runningBalances = runningBalances.slice(0, nTokens);
-        this.executedRootBundles.push({
-          ...executedRootBundle,
-          l1Tokens: l1Tokens.map((l1Token) => EvmAddress.from(l1Token)),
-        });
+        this.executedRootBundles.push(this.decodeExecutedRootBundle(event));
       }
     }
 

--- a/test/HubPoolClient.RootBundleEvents.ts
+++ b/test/HubPoolClient.RootBundleEvents.ts
@@ -203,7 +203,7 @@ describe("HubPoolClient: RootBundle Events", function () {
     await hubPool.connect(dataworker).executeRootBundle(...Object.values(leaves1[1]), tree1.getHexProof(leaves1[1]));
     const firstRootBundleBlockNumber = await hubPool.provider.getBlockNumber();
 
-    ({ runningBalance } = hubPoolClient.getRunningBalanceBeforeBlockForChain(
+    ({ runningBalance } = await hubPoolClient.getRunningBalanceBeforeBlockForChain(
       firstRootBundleBlockNumber,
       constants.originChainId,
       EvmAddress.from(l1Token_1.address)
@@ -212,7 +212,7 @@ describe("HubPoolClient: RootBundle Events", function () {
     await hubPoolClient.update();
 
     // Happy case where client returns most recent running balance for chain ID and l1 token.
-    ({ runningBalance } = hubPoolClient.getRunningBalanceBeforeBlockForChain(
+    ({ runningBalance } = await hubPoolClient.getRunningBalanceBeforeBlockForChain(
       firstRootBundleBlockNumber,
       constants.originChainId,
       EvmAddress.from(l1Token_1.address)
@@ -220,7 +220,7 @@ describe("HubPoolClient: RootBundle Events", function () {
     expect(runningBalance.eq(toBNWei(100))).to.be.true;
 
     // Target block is before event.
-    ({ runningBalance } = hubPoolClient.getRunningBalanceBeforeBlockForChain(
+    ({ runningBalance } = await hubPoolClient.getRunningBalanceBeforeBlockForChain(
       0,
       constants.originChainId,
       EvmAddress.from(l1Token_1.address)
@@ -228,14 +228,14 @@ describe("HubPoolClient: RootBundle Events", function () {
     expect(runningBalance.eq(0)).to.be.true;
 
     // chain ID and L1 token combination not found.
-    ({ runningBalance } = hubPoolClient.getRunningBalanceBeforeBlockForChain(
+    ({ runningBalance } = await hubPoolClient.getRunningBalanceBeforeBlockForChain(
       firstRootBundleBlockNumber,
       constants.destinationChainId,
       EvmAddress.from(l1Token_1.address)
     ));
     expect(runningBalance.eq(0)).to.be.true;
 
-    ({ runningBalance } = hubPoolClient.getRunningBalanceBeforeBlockForChain(
+    ({ runningBalance } = await hubPoolClient.getRunningBalanceBeforeBlockForChain(
       firstRootBundleBlockNumber,
       constants.originChainId,
       EvmAddress.from(timer.address)
@@ -243,7 +243,7 @@ describe("HubPoolClient: RootBundle Events", function () {
     expect(runningBalance.eq(0)).to.be.true;
 
     // Running balance at index of L1 token returned:
-    ({ runningBalance } = hubPoolClient.getRunningBalanceBeforeBlockForChain(
+    ({ runningBalance } = await hubPoolClient.getRunningBalanceBeforeBlockForChain(
       firstRootBundleBlockNumber,
       constants.originChainId,
       EvmAddress.from(l1Token_2.address)
@@ -261,19 +261,62 @@ describe("HubPoolClient: RootBundle Events", function () {
     await hubPoolClient.update();
 
     // Grabs most up to date running balance for block:
-    ({ runningBalance } = hubPoolClient.getRunningBalanceBeforeBlockForChain(
+    ({ runningBalance } = await hubPoolClient.getRunningBalanceBeforeBlockForChain(
       secondRootBundleBlockNumber,
       constants.originChainId,
       EvmAddress.from(l1Token_1.address)
     ));
     expect(runningBalance.eq(toBNWei(200))).to.be.true; // Grabs second running balance
 
-    ({ runningBalance } = hubPoolClient.getRunningBalanceBeforeBlockForChain(
+    ({ runningBalance } = await hubPoolClient.getRunningBalanceBeforeBlockForChain(
       firstRootBundleBlockNumber,
       constants.originChainId,
       EvmAddress.from(l1Token_1.address)
     ));
     expect(runningBalance.eq(toBNWei(100))).to.be.true; // Grabs first running balance
+  });
+
+  it("falls back to a full-history query for a running balance that precedes the event lookback", async function () {
+    const { tree, leaves } = await constructSimpleTree(toBNWei(100));
+
+    await configStoreClient.update();
+    await hubPoolClient.update();
+
+    // Propose + execute a root bundle establishing a non-zero running balance for (originChainId, l1Token_1).
+    await hubPool
+      .connect(dataworker)
+      .proposeRootBundle([11, 22], 2, tree.getHexRoot(), constants.mockTreeRoot, constants.mockTreeRoot);
+    await timer.setCurrentTime(Number(await timer.getCurrentTime()) + constants.refundProposalLiveness + 1);
+    await hubPool.connect(dataworker).executeRootBundle(...Object.values(leaves[0]), tree.getHexProof(leaves[0]));
+    await hubPool.connect(dataworker).executeRootBundle(...Object.values(leaves[1]), tree.getHexProof(leaves[1]));
+    const bundleBlock = await hubPool.provider.getBlockNumber();
+    // Ensure at least one block exists after the bundle so the short-lookback search range is valid.
+    await timer.setCurrentTime(Number(await timer.getCurrentTime()) + 1);
+
+    // A client whose event lookback STARTS AFTER the executed bundle never loads it into memory -- the
+    // production failure mode for a token idle longer than the lookback window.
+    const shortLookbackClient = new HubPoolClient(logger, hubPool, configStoreClient, 0, 1, {
+      from: bundleBlock + 1,
+      maxLookBack: 0,
+    });
+    await shortLookbackClient.update();
+
+    // In-memory lookup misses it -- previously this caused getRunningBalanceBeforeBlockForChain to assume 0.
+    expect(
+      shortLookbackClient.getLatestExecutedRootBundleContainingL1Token(
+        bundleBlock,
+        constants.originChainId,
+        EvmAddress.from(l1Token_1.address)
+      )
+    ).to.be.undefined;
+
+    // The full-history fallback recovers the true running balance instead of defaulting to 0.
+    const { runningBalance } = await shortLookbackClient.getRunningBalanceBeforeBlockForChain(
+      bundleBlock,
+      constants.originChainId,
+      EvmAddress.from(l1Token_1.address)
+    );
+    expect(runningBalance.eq(toBNWei(100))).to.be.true;
   });
 
   it("returns proposed and disputed bundles", async function () {


### PR DESCRIPTION
The HubPoolClient currently reverts to an assumed balance of 0 if it can't resolve the last recorded running balance within its event lookback / search window. This can break running balance accounting for chain/token pairs that are infrequently used.

This change modifies running balance resolution to revert to an eth_getLogs query in case no more recent event was identified within the current lookback.