### PR TITLE
chore: reduce DEFAULT_CACHING_TTL from 2 weeks to 1 week

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -53,7 +53,7 @@ export const ARWEAVE_TAG_APP_VERSION = 4;
  */
 export const PROTOCOL_DEFAULT_CHAIN_ID_INDICES = [1, 10, 137, 288, 42161];
 
-export const DEFAULT_CACHING_TTL = 60 * 60 * 24 * 7 * 2; // 2 Weeks
+export const DEFAULT_CACHING_TTL = 60 * 60 * 24 * 7; // 1 Week
 export const DEFAULT_CACHING_SAFE_LAG = 60 * 60; // 1 hour
 
 export const DEFAULT_SIMULATED_RELAYER_ADDRESS = "0x07aE8551Be970cB1cCa11Dd7a11F47Ae82e70E67";


### PR DESCRIPTION
## What

Reduce `DEFAULT_CACHING_TTL` from 2 weeks to 1 week (`src/constants.ts`).

```diff
-export const DEFAULT_CACHING_TTL = 60 * 60 * 24 * 7 * 2; // 2 Weeks
+export const DEFAULT_CACHING_TTL = 60 * 60 * 24 * 7; // 1 Week
```

## Why

`DEFAULT_CACHING_TTL` is the default expiry for `RedisCache.set` and the cache writes in `HubPoolClient`, `BundleDataClient`, `DepositUtils`, etc. With a 2-week retention, the working set keeps accumulating for two weeks before anything expires. The bots' Memorystore instance (`redis-bots-across`, BASIC 32 GB, `maxmemory-policy=allkeys-lru`, persistence disabled) has been running at its ~25.9 GB ceiling and **evicting keys continuously for 24h+**.

That eviction caused a production incident: the disputer-watchdog stores per-proposal validator-attestation counts as no-TTL Redis counters, an LRU eviction dropped a counter mid-liveness, the watchdog read the missing key as `0` attestations and submitted a **false HubPool root-bundle dispute** of a valid bundle (3 occurrences in ~2 weeks). Halving the default TTL roughly halves the retained working set for default-TTL entries, relieving the memory pressure.

## Impact / trade-offs

- Cache entries older than 1 week now expire, so reads of data >1 week old fall through to recompute/RPC. These are caches only (miss → re-derive from chain), so this trades a modest RPC increase for far less memory pressure — no correctness change.
- Takes effect in prod once this SDK is released and consumers (`relayer`) bump the version.

## Follow-ups (separate, not in this PR)

- Harden `runDisputerWatchdog` so a **missing** attestation key is treated as "unknown", not `0` — it must not dispute on absent data (this is what converts a cache hiccup into an on-chain dispute + bond).
- Profile the Redis keyspace (`INFO memory` / `--bigkeys`) and right-size the instance; this TTL cut is mitigation, not the full fix.

Context: internal incident thread (zion-across-disputer-watchdog false dispute, 2026-06-24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)