### PR TITLE
chore: Bump version from 4.4.3 to 4.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.4.3",
+  "version": "4.4.4",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {


### PR DESCRIPTION
Bumps `@across-protocol/sdk` patch version `4.4.3` → `4.4.4`.

Requested by Paul (<@U03MNG527GQ>) via Slack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)