### PR TITLE
feat(providers): surface revert reason from failed RPC sends

### DIFF
--- a/src/providers/retryProvider.ts
+++ b/src/providers/retryProvider.ts
@@ -4,7 +4,13 @@ import { CHAIN_IDs } from "../constants";
 import { delay, isDefined, isPromiseFulfilled, isPromiseRejected } from "../utils";
 import { getOriginFromURL } from "../utils/NetworkUtils";
 import { CacheProvider } from "./cachedProvider";
-import { compareRpcResults, createSendErrorWithMessage, formatProviderError, parseJsonRpcError } from "./utils";
+import {
+  compareRpcResults,
+  createSendErrorWithMessage,
+  formatProviderError,
+  getRevertReason,
+  parseJsonRpcError,
+} from "./utils";
 import { PROVIDER_CACHE_TTL } from "./constants";
 import { Logger } from "winston";
 
@@ -113,10 +119,21 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
       const successfulProviderUrls = results
         .filter(isPromiseFulfilled)
         .map((result) => getOriginFromURL(result.value[0].connection.url));
+
+      // If the underlying failure was a deterministic contract revert, surface the decoded reason
+      // (including the ABI-encoded custom error selector) up-front rather than leaving it buried in the
+      // raw response body. This makes reverts like RelayFilled (0x8f260c60) legible to callers and logs.
+      // The original rejection is also preserved on the thrown error's `cause`, so callers can recover
+      // the structured JSON-RPC error via parseJsonRpcError(err.cause).
+      const rejection = results.find(isPromiseRejected)?.reason;
+      const revertReason = getRevertReason(rejection);
+      const revertText = isDefined(revertReason) ? `Revert reason: ${revertReason}\n` : "";
+
       throw createSendErrorWithMessage(
         `Not enough providers succeeded. Errors:\n${errorTexts.join("\n")}\n` +
+          revertText +
           `Successful Providers:\n${successfulProviderUrls.join("\n")}`,
-        results.find(isPromiseRejected)?.reason
+        rejection
       );
     }
 

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -170,6 +170,29 @@ export function parseJsonRpcError(response: unknown): { code: number; message: s
 }
 
 /**
+ * Extract a concise, human-readable revert reason from a provider error, if one is present.
+ *
+ * `eth_estimateGas` / `eth_call` / `eth_sendRawTransaction` reverts surface an ABI-encoded error in
+ * the JSON-RPC `data` field (e.g. `0x8f260c60` decodes to the SpokePool custom error `RelayFilled()`).
+ * The generic RetryProvider failure wrapper would otherwise leave this buried inside the raw response
+ * body, so this pulls it back out reliably for logging.
+ * @param error An unknown error object received in response to a JSON-RPC request.
+ * @returns A string such as "execution reverted (0x8f260c60)", or undefined if the error is not a
+ *          parseable JSON-RPC error.
+ */
+export function getRevertReason(error: unknown): string | undefined {
+  const jsonRpcError = parseJsonRpcError(error);
+  if (!isDefined(jsonRpcError)) {
+    return undefined;
+  }
+
+  // `data`, when present, is the ABI-encoded revert payload (custom error selector + any args).
+  const { message, data } = jsonRpcError;
+  const selector = typeof data === "string" && data.length > 0 ? data : undefined;
+  return isDefined(selector) ? `${message} (${selector})` : message;
+}
+
+/**
  * Compares two RPC results, filtering out fields that are known to differ between providers.
  * Note: this function references `IGNORED_ERROR_CODES` which is a record of error codes that correspond to fields
  *       that should be ignored when comparing RPC results.

--- a/test/providers/utils.test.ts
+++ b/test/providers/utils.test.ts
@@ -1,5 +1,60 @@
-import { createSendErrorWithMessage } from "../../src/providers/utils";
+import { createSendErrorWithMessage, getRevertReason, parseJsonRpcError } from "../../src/providers/utils";
 import { expect } from "../utils";
+
+// Reconstructs the ethers v5 SERVER_ERROR ("processing response error") object seen in production when an
+// `eth_estimateGas` call reverts on-chain. The JSON-RPC error - including the ABI-encoded custom error
+// selector - is carried on the `body` string, exactly as ethers surfaces it. `0x8f260c60` is the selector
+// for the SpokePool custom error `RelayFilled()`.
+function makeProcessingResponseError(data: string | null = "0x8f260c60"): Error {
+  const body = JSON.stringify({
+    jsonrpc: "2.0",
+    id: 361,
+    error: { code: 3, message: "execution reverted", data },
+  });
+  return Object.assign(new Error(`processing response error (body="${body}", ...)`), {
+    reason: "processing response error",
+    code: "SERVER_ERROR",
+    body,
+    error: { code: 3, data },
+    requestMethod: "POST",
+    url: "https://opt-mainnet.g.alchemy.com",
+  });
+}
+
+describe("parseJsonRpcError", () => {
+  it("extracts the JSON-RPC error (code/message/data) from an ethers SERVER_ERROR", () => {
+    const parsed = parseJsonRpcError(makeProcessingResponseError());
+    expect(parsed).to.deep.equal({ code: 3, message: "execution reverted", data: "0x8f260c60" });
+  });
+
+  it("extracts a revert with null data", () => {
+    const parsed = parseJsonRpcError(makeProcessingResponseError(null));
+    expect(parsed).to.deep.equal({ code: 3, message: "execution reverted", data: null });
+  });
+
+  it("returns undefined for a plain Error with no JSON-RPC body", () => {
+    expect(parseJsonRpcError(new Error("connection refused"))).to.equal(undefined);
+  });
+
+  it("returns undefined for a non-object", () => {
+    expect(parseJsonRpcError("execution reverted")).to.equal(undefined);
+    expect(parseJsonRpcError(undefined)).to.equal(undefined);
+  });
+});
+
+describe("getRevertReason", () => {
+  it("surfaces the revert message and ABI-encoded selector (RelayFilled = 0x8f260c60)", () => {
+    expect(getRevertReason(makeProcessingResponseError())).to.equal("execution reverted (0x8f260c60)");
+  });
+
+  it("omits the selector when the node returns no data", () => {
+    expect(getRevertReason(makeProcessingResponseError(null))).to.equal("execution reverted");
+  });
+
+  it("returns undefined when the error is not a JSON-RPC revert", () => {
+    expect(getRevertReason(new Error("connection refused"))).to.equal(undefined);
+  });
+});
 
 describe("createSendErrorWithMessage", () => {
   const wrapperMessage = "Not enough providers succeeded.";
@@ -34,5 +89,17 @@ describe("createSendErrorWithMessage", () => {
     const wrapped = createSendErrorWithMessage(wrapperMessage, inner);
     expect(wrapped.message).to.equal(wrapperMessage);
     expect((wrapped.cause as Error).message).to.equal(inner.message);
+  });
+
+  // End-to-end: this is how RetryProvider.send wraps a failed required provider. The structured revert
+  // remains recoverable from the wrapper via `cause`, so a caller never has to scrape the message string.
+  it("keeps the revert reason recoverable from `cause` via parseJsonRpcError", () => {
+    const wrapped = createSendErrorWithMessage(wrapperMessage, makeProcessingResponseError());
+    expect(parseJsonRpcError(wrapped.cause)).to.deep.equal({
+      code: 3,
+      message: "execution reverted",
+      data: "0x8f260c60",
+    });
+    expect(getRevertReason(wrapped.cause)).to.equal("execution reverted (0x8f260c60)");
   });
 });


### PR DESCRIPTION
## Context

From a Slack thread: the relayer logged a confusing error on an `eth_estimateGas` for `fillRelay`:

```
cannot estimate gas; transaction may fail or may require manual gas limit
(error={"reason":"Not enough providers succeeded. Errors:
Provider https://opt-mainnet.g.alchemy.com failed with error: ... execution reverted ... "data":"0x8f260c60" ...
```

Two issues were raised:
1. Why does it say **"Not enough providers succeeded"** when this should be an immediate failure?
2. Can we **reliably catch the revert reason** to improve logging?

On (1): that string is `RetryProvider.send`'s unconditional failure wrapper — it fires whenever the required-quorum providers don't all succeed, regardless of cause. For `eth_estimateGas`/`eth_call`-at-latest the quorum is **1**, so it really means "the one provider we needed reverted." It *did* fail fast (`failImmediate` short-circuits on revert keywords), the wording just doesn't reflect that — and the decoded revert (`0x8f260c60` = SpokePool `RelayFilled()`, a benign already-filled race) is left buried in the raw response body.

On (2): **yes** — the structured error is already parseable via the existing `parseJsonRpcError()`. This PR demonstrates that and wires it into the failure path.

## Change

- Add `getRevertReason()` in `src/providers/utils.ts` — a thin wrapper over `parseJsonRpcError()` that returns e.g. `"execution reverted (0x8f260c60)"`.
- In `RetryProvider.send()`, when the required providers fail:
  - prepend a decoded `Revert reason: <message> (<selector>)` line to the wrapper message, and
  - keep passing the original rejection as the thrown error's `cause`, so callers can recover the structured `{ code, message, data }` via `parseJsonRpcError(err.cause)` instead of scraping the message string.

No behavioural change to control flow (retries/quorum/fail-fast all unchanged) — this only enriches the error surface.

## Tests

Added unit tests in `test/providers/utils.test.ts` that reconstruct the **exact** ethers v5 SERVER_ERROR ("processing response error") shape from the report and assert reliable extraction:

- `parseJsonRpcError` returns `{ code: 3, message: "execution reverted", data: "0x8f260c60" }` (and `undefined` for non-JSON-RPC errors / null data handled).
- `getRevertReason` returns `"execution reverted (0x8f260c60)"`.
- End-to-end: the revert reason is recoverable from a `createSendErrorWithMessage(...)` wrapper via `parseJsonRpcError(err.cause)`.

```
  parseJsonRpcError
    ✔ extracts the JSON-RPC error (code/message/data) from an ethers SERVER_ERROR
    ✔ extracts a revert with null data
    ✔ returns undefined for a plain Error with no JSON-RPC body
    ✔ returns undefined for a non-object
  getRevertReason
    ✔ surfaces the revert message and ABI-encoded selector (RelayFilled = 0x8f260c60)
    ✔ omits the selector when the node returns no data
    ✔ returns undefined when the error is not a JSON-RPC revert
  createSendErrorWithMessage
    ✔ ... (existing, still green)
    ✔ keeps the revert reason recoverable from `cause` via parseJsonRpcError

  13 passing
```

## Follow-ups (not in this PR)

- Decode the selector to a name (`0x8f260c60` → `RelayFilled`) against the SpokePool interface for even friendlier logs — the relayer already maps known selectors.
- The relayer's `MultiCallerClient.knownRevertReasons` already lists `RelayFilled`; preserving the structured `cause` here lets that filtering work even when the error is wrapped by estimateGas/`UNPREDICTABLE_GAS_LIMIT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)