### PR TITLE
fix(esm): make the published ESM build loadable under Node's native loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build": "yarn run clean && yarn typechain && yarn dev",
     "dev": "concurrently --kill-others-on-fail --names 'cjs,esm,types' --prefix-colors 'blue,magenta,green' 'yarn run build:cjs' 'yarn run build:esm' 'yarn run build:types'",
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --outDir ./dist/cjs --removeComments --verbatimModuleSyntax false && echo > ./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir ./dist/esm && echo > ./dist/esm/package.json '{\"type\":\"module\",\"sideEffects\":false}'",
+    "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir ./dist/esm && tsc-alias --project tsconfig.build.json --outDir ./dist/esm --resolve-full-paths && echo > ./dist/esm/package.json '{\"type\":\"module\",\"sideEffects\":false}'",
     "build:types": "tsc --project tsconfig.build.json --module esnext --declarationDir ./dist/types --emitDeclarationOnly --declaration --declarationMap",
     "test": "hardhat test",
     "test:watch": "hardhat watch test",
@@ -76,6 +76,7 @@
     "prettier": "^3.0.3",
     "sinon": "^21.0.0",
     "ts-node": "^10.9.1",
+    "tsc-alias": "^1.8.17",
     "typechain": "^8.3.1",
     "typescript": "^6"
   },

--- a/src/addressAggregator/index.ts
+++ b/src/addressAggregator/index.ts
@@ -73,7 +73,7 @@ async function run(): Promise<number> {
   return 0;
 }
 
-if (require.main === module) {
+if (typeof require !== "undefined" && require.main === module) {
   run()
     .then((result: number) => {
       process.exitCode = result;

--- a/src/apiClient/mockedClient.ts
+++ b/src/apiClient/mockedClient.ts
@@ -1,5 +1,5 @@
 import { ethers } from "ethers";
-import { deepCopy } from "ethers/lib/utils";
+import { deepCopy } from "ethers/lib/utils.js";
 import { BigNumber, bnOne } from "../utils";
 import AbstractApiClient from "./abstractClient";
 import {

--- a/src/arch/evm/BlockUtils.ts
+++ b/src/arch/evm/BlockUtils.ts
@@ -1,6 +1,7 @@
 import assert from "assert";
 import { Provider, Block as EthersBlock } from "@ethersproject/abstract-provider";
-import { clamp, sortedIndexBy } from "lodash";
+import lodash from "lodash";
+const { clamp, sortedIndexBy } = lodash;
 import { chainIsOPStack, getNetworkName } from "../../utils/NetworkUtils";
 import { isDefined } from "../../utils/TypeGuards";
 import {

--- a/src/arch/evm/utils/wait.ts
+++ b/src/arch/evm/utils/wait.ts
@@ -73,7 +73,7 @@ async function run() {
 }
 
 // Only run the CLI entry point in Node.js environments
-if (typeof window === "undefined" && require.main === module) {
+if (typeof window === "undefined" && typeof require !== "undefined" && require.main === module) {
   run()
     .then(() => {
       process.exitCode = 0;

--- a/src/arch/svm/BlockUtils.ts
+++ b/src/arch/svm/BlockUtils.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
-import { clamp, sortedIndexBy } from "lodash";
+import lodash from "lodash";
+const { clamp, sortedIndexBy } = lodash;
 import { BlockFinder, type Block, type BlockTimeAverage, type BlockFinderHints } from "../../utils/BlockFinder";
 import { isDefined } from "../../utils/TypeGuards";
 import { getCurrentTime } from "../../utils/TimeUtils";

--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -1,6 +1,6 @@
 import { MessageTransmitterClient, SvmSpokeClient, TokenMessengerMinterClient } from "@across-protocol/contracts";
-import { decodeFillStatusAccount, fetchState } from "@across-protocol/contracts/dist/src/svm/clients/SvmSpoke";
-import { decodeMessageHeader } from "@across-protocol/contracts/dist/src/svm/web3-v1";
+import { decodeFillStatusAccount, fetchState } from "@across-protocol/contracts/dist/src/svm/clients/SvmSpoke/index.js";
+import { decodeMessageHeader } from "@across-protocol/contracts/dist/src/svm/web3-v1/index.js";
 import { SYSTEM_PROGRAM_ADDRESS } from "@solana-program/system";
 import {
   ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
@@ -40,7 +40,7 @@ import {
 } from "@solana/kit";
 import assert from "assert";
 import winston from "winston";
-import { arrayify } from "ethers/lib/utils";
+import { arrayify } from "ethers/lib/utils.js";
 import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "../../constants";
 import {
   DepositWithBlock,

--- a/src/arch/svm/eventsClient.ts
+++ b/src/arch/svm/eventsClient.ts
@@ -1,6 +1,6 @@
 import { Idl } from "@coral-xyz/anchor";
 import { getDeployedAddress, SvmSpokeIdl } from "@across-protocol/contracts";
-import { getSolanaChainId } from "@across-protocol/contracts/dist/src/svm/web3-v1";
+import { getSolanaChainId } from "@across-protocol/contracts/dist/src/svm/web3-v1/index.js";
 import {
   address,
   Address,

--- a/src/arch/svm/utils.ts
+++ b/src/arch/svm/utils.ts
@@ -1,6 +1,10 @@
 import { MessageTransmitterClient, SvmSpokeClient } from "@across-protocol/contracts";
 import { SpokePool__factory } from "../../typechain";
-import { BN, BorshEventCoder, Idl } from "@coral-xyz/anchor";
+import * as anchorImport from "@coral-xyz/anchor";
+// @coral-xyz/anchor is a CJS module: under Node's native ESM loader its members
+// are reachable via the namespace's `default` (module.exports); under tsc's CJS
+// interop they're on the namespace object itself. Resolve both shapes.
+const { BN, BorshEventCoder } = (anchorImport as { default?: typeof anchorImport }).default ?? anchorImport;
 import {
   Address,
   Instruction,
@@ -124,7 +128,7 @@ export function parseEventData(eventData: any): any {
 /**
  * Decodes a raw event according to a supplied IDL.
  */
-export function decodeEvent(idl: Idl, rawEvent: string): { data: unknown; name: string } {
+export function decodeEvent(idl: anchorImport.Idl, rawEvent: string): { data: unknown; name: string } {
   const event = new BorshEventCoder(idl).decode(rawEvent);
   if (!event) throw new Error(`Malformed rawEvent for IDL ${idl.address}: ${rawEvent}`);
   return {

--- a/src/caching/Arweave/ArweaveClient.ts
+++ b/src/caching/Arweave/ArweaveClient.ts
@@ -1,6 +1,6 @@
 import Arweave from "arweave";
-import Transaction from "arweave/node/lib/transaction";
-import { JWKInterface } from "arweave/node/lib/wallet";
+import Transaction from "arweave/node/lib/transaction.js";
+import { JWKInterface } from "arweave/node/lib/wallet.js";
 
 import { Struct, create } from "superstruct";
 import winston from "winston";

--- a/src/clients/BundleDataClient/utils/PoolRebalanceUtils.ts
+++ b/src/clients/BundleDataClient/utils/PoolRebalanceUtils.ts
@@ -1,4 +1,4 @@
-import { MerkleTree } from "@across-protocol/contracts/dist/utils/MerkleTree";
+import { MerkleTree } from "@across-protocol/contracts/dist/utils/MerkleTree.js";
 import { RunningBalances, PoolRebalanceLeaf, Clients, SpokePoolTargetBalance } from "../../../interfaces";
 import { isSVMSpokePoolClient, SpokePoolClient } from "../../SpokePoolClient";
 import { BigNumber, bnZero, chainIsEvm, chainIsSvm, compareAddresses, EvmAddress, isDefined } from "../../../utils";

--- a/src/clients/mocks/MockEvents.ts
+++ b/src/clients/mocks/MockEvents.ts
@@ -1,6 +1,7 @@
 import assert from "assert";
 import { utils as ethersUtils } from "ethers";
-import { random } from "lodash";
+import lodash from "lodash";
+const { random } = lodash;
 import { Log } from "../../interfaces";
 import { isDefined } from "../../utils";
 

--- a/src/clients/mocks/MockSpokePoolClient.ts
+++ b/src/clients/mocks/MockSpokePoolClient.ts
@@ -1,6 +1,7 @@
 import assert from "assert";
 import { Contract } from "ethers";
-import { random } from "lodash";
+import lodash from "lodash";
+const { random } = lodash;
 import winston from "winston";
 import { EMPTY_MESSAGE, ZERO_ADDRESS, ZERO_BYTES } from "../../constants";
 import {

--- a/src/clients/mocks/MockSvmCpiEventsClient.ts
+++ b/src/clients/mocks/MockSvmCpiEventsClient.ts
@@ -1,8 +1,9 @@
 import assert from "assert";
 import { utils as ethersUtils } from "ethers";
 import { createHash } from "crypto";
-import { hexlify, arrayify, hexZeroPad } from "ethers/lib/utils";
-import { random } from "lodash";
+import { hexlify, arrayify, hexZeroPad } from "ethers/lib/utils.js";
+import lodash from "lodash";
+const { random } = lodash;
 import { Address, UnixTimestamp, signature } from "@solana/kit";
 import { Idl } from "@coral-xyz/anchor";
 import { SvmSpokeClient } from "@across-protocol/contracts";

--- a/src/merkleDistributor/MerkleDistributor.ts
+++ b/src/merkleDistributor/MerkleDistributor.ts
@@ -1,4 +1,4 @@
-import { MerkleTree } from "@across-protocol/contracts/dist/utils/MerkleTree";
+import { MerkleTree } from "@across-protocol/contracts/dist/utils/MerkleTree.js";
 import { ethers } from "ethers";
 import { DistributionRecipientsWithProofs, DistributionRecipient } from "./model";
 

--- a/src/providers/cachedProvider.ts
+++ b/src/providers/cachedProvider.ts
@@ -1,4 +1,5 @@
-import { random } from "lodash";
+import lodash from "lodash";
+const { random } = lodash;
 import { CachingMechanismInterface } from "../interfaces";
 import { BLOCK_NUMBER_TTL, PROVIDER_CACHE_TTL, PROVIDER_CACHE_TTL_MODIFIER as ttl_modifier } from "./constants";
 import { RateLimitedProvider } from "./rateLimitedProvider";

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -1,7 +1,8 @@
 // The async/queue library has a task-based interface for building a concurrent queue.
 import assert from "assert";
 import { providers } from "ethers";
-import { isEqual, sortBy } from "lodash";
+import lodash from "lodash";
+const { isEqual, sortBy } = lodash;
 import { getOriginFromURL, isDefined } from "../utils";
 import { JsonRpcError, RpcError, RPCProvider, RPCTransport } from "./types";
 import * as alchemy from "./alchemy";

--- a/src/relayFeeCalculator/chain-queries/baseQuery.ts
+++ b/src/relayFeeCalculator/chain-queries/baseQuery.ts
@@ -1,5 +1,5 @@
-import { L2Provider } from "@eth-optimism/sdk/dist/interfaces/l2-provider";
-import { isL2Provider as isOptimismL2Provider } from "@eth-optimism/sdk/dist/l2-provider";
+import { L2Provider } from "@eth-optimism/sdk/dist/interfaces/l2-provider.js";
+import { isL2Provider as isOptimismL2Provider } from "@eth-optimism/sdk/dist/l2-provider.js";
 import { PopulatedTransaction, providers, VoidSigner } from "ethers";
 import { Coingecko } from "../../coingecko";
 import { CHAIN_IDs } from "../../constants";

--- a/src/utils/DeploymentUtils.ts
+++ b/src/utils/DeploymentUtils.ts
@@ -2,4 +2,4 @@ export {
   getContractInfoFromAddress,
   getDeployedAddress,
   getDeployedBlockNumber,
-} from "@across-protocol/contracts/dist/src/DeploymentUtils";
+} from "@across-protocol/contracts/dist/src/DeploymentUtils.js";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2982,6 +2982,11 @@ array-includes@^3.1.6:
     get-intrinsic "^1.2.1"
     is-string "^1.0.7"
 
+array-union@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
+  integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
 array.prototype.findlast@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/array.prototype.findlast/-/array.prototype.findlast-1.2.3.tgz#4e4b375de5adf4897fed155e2d2771564865cc3b"
@@ -3854,6 +3859,11 @@ commander@^8.1.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
+commander@^9.0.0:
+  version "9.5.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.5.0.tgz#bc08d1eb5cedf7ccb797a96199d41c7bc3e60d30"
+  integrity sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==
+
 compare-versions@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.1.0.tgz#3f2131e3ae93577df111dba133e6db876ffe127a"
@@ -4161,6 +4171,13 @@ diff@^8.0.4:
   version "8.0.4"
   resolved "https://registry.yarnpkg.com/diff/-/diff-8.0.4.tgz#4f5baf3188b9b2431117b962eb20ba330fadf696"
   integrity sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==
+
+dir-glob@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
+  integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
+  dependencies:
+    path-type "^4.0.0"
 
 doctrine@^2.1.0:
   version "2.1.0"
@@ -4911,6 +4928,17 @@ fast-diff@^1.1.2:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
+fast-glob@^3.2.9:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
+  integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.8"
+
 fast-glob@^3.3.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.1.tgz#784b4e897340f3dbbef17413b3f11acf03c874c4"
@@ -5220,6 +5248,13 @@ get-symbol-description@^1.0.0:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
 
+get-tsconfig@^4.10.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.14.0.tgz#985d85c52a9903864280ccc2448d413fbf1efed8"
+  integrity sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==
+  dependencies:
+    resolve-pkg-maps "^1.0.0"
+
 getopts@2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/getopts/-/getopts-2.2.5.tgz#67a0fe471cacb9c687d817cab6450b96dde8313b"
@@ -5293,6 +5328,18 @@ globalthis@^1.0.3:
   integrity sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==
   dependencies:
     define-properties "^1.1.3"
+
+globby@^11.0.4:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
+  integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.2.9"
+    ignore "^5.2.0"
+    merge2 "^1.4.1"
+    slash "^3.0.0"
 
 google-protobuf@3.21.4:
   version "3.21.4"
@@ -6440,7 +6487,7 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge2@^1.3.0:
+merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
@@ -6693,6 +6740,11 @@ mute-stream@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
+mylas@^2.1.9:
+  version "2.1.14"
+  resolved "https://registry.yarnpkg.com/mylas/-/mylas-2.1.14.tgz#bfa0a2bcbc4bb69f0af324dc7f38689ad56f12cc"
+  integrity sha512-BzQguy9W9NJgoVn2mRWzbFrFWWztGCcng2QI9+41frfk+Athwgx3qhqhvStz7ExeUUu7Kzw427sNzHpEZNINog==
 
 nanoid@3.3.3:
   version "3.3.3"
@@ -7112,6 +7164,11 @@ path-to-regexp@^6.1.0:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.1.tgz#d54934d6798eb9e5ef14e7af7962c945906918e5"
   integrity sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==
 
+path-type@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
+  integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
 pathval@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
@@ -7170,6 +7227,13 @@ pidtree@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.6.0.tgz#90ad7b6d42d5841e69e0a2419ef38f8883aa057c"
   integrity sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==
+
+plimit-lit@^1.2.6:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/plimit-lit/-/plimit-lit-1.6.1.tgz#a34594671b31ee8e93c72d505dfb6852eb72374a"
+  integrity sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==
+  dependencies:
+    queue-lit "^1.5.1"
 
 possible-typed-array-names@^1.0.0:
   version "1.1.0"
@@ -7290,6 +7354,11 @@ qs@^6.4.0, qs@^6.5.2:
   dependencies:
     side-channel "^1.1.0"
 
+queue-lit@^1.5.1:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/queue-lit/-/queue-lit-1.5.2.tgz#83c24d4f4764802377b05a6e5c73017caf3f8747"
+  integrity sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==
+
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
@@ -7408,6 +7477,11 @@ resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+
+resolve-pkg-maps@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz#616b3dc2c57056b5588c31cdf4b3d64db133720f"
+  integrity sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==
 
 resolve@1.17.0:
   version "1.17.0"
@@ -7790,6 +7864,11 @@ sinon@^21.0.0:
     "@sinonjs/samsam" "^10.0.0"
     diff "^8.0.4"
     supports-color "^10.2.2"
+
+slash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
+  integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
 slice-ansi@^5.0.0:
   version "5.0.0"
@@ -8374,6 +8453,19 @@ ts-node@^10.9.1:
     make-error "^1.1.1"
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
+
+tsc-alias@^1.8.17:
+  version "1.8.17"
+  resolved "https://registry.yarnpkg.com/tsc-alias/-/tsc-alias-1.8.17.tgz#67b55b33ff4af037ce0da43bcf49abee667fc421"
+  integrity sha512-EIduCZHqbNwPm8BZYfq1aD7BQ697A4h6uSGMOFQfYGoQwfrYFTKwYfy9Bv42YxHkduVBcn9Zx0DkX111DKskyg==
+  dependencies:
+    chokidar "^3.5.3"
+    commander "^9.0.0"
+    get-tsconfig "^4.10.0"
+    globby "^11.0.4"
+    mylas "^2.1.9"
+    normalize-path "^3.0.0"
+    plimit-lit "^1.2.6"
 
 tsc-watch@^4.6.0:
   version "4.6.2"


### PR DESCRIPTION
## Problem

The published **ESM build does not load under Node's native ESM loader**. Any consumer that loads the package under real Node ESM — Vite **dev** SSR (TanStack Start / Next), Next RSC, `ts-node`/ESM, or plain `node --input-type=module` — crashes immediately. Bundler consumers (webpack / rollup / `vite build`) tolerate the malformed output, which is why this went unnoticed.

This is the root cause of the `across-protocol/dapp` regression where `pnpm start` (vite dev) 500s on every route:

```
ERR_MODULE_NOT_FOUND: Cannot find module '.../@across-protocol/sdk/dist/esm/src/utils/NetworkUtils'
  imported from '.../@across-protocol/sdk/dist/esm/src/arch/evm/BlockUtils.js'
```

## Root cause

The ESM build is `tsc --module es2015` + a stamped `{"type":"module"}`. `tsc` neither adds extensions to relative imports nor normalizes CJS interop, so the emitted ESM is not spec-valid for Node.

## Fix — four classes, **no public API or output-layout change**

The `dist/{esm,cjs,types}/...` file layout is unchanged, so the `./dist/esm/*` / `./dist/cjs/*` deep-path exports consumers rely on still resolve. (Audited the V4 prod consumers: relayer & indexer use only the package root + named subpath exports; quote-api has a few deep `dist/` imports — all preserved.)

1. **Extensionless relative imports** → add a `tsc-alias --resolve-full-paths` post-step to `build:esm`. Emitted relative imports get `.js` / `/index.js` (606 specifiers fixed at build time, **zero source churn**).
2. **Extensionless deep imports into exports-less CJS deps** → explicit `.js`/`/index.js` for `@across-protocol/contracts/dist/*`, `@eth-optimism/sdk/dist/*`, `ethers/lib/utils`, `arweave/node/lib/*` (tsc-alias only rewrites relative imports, not bare-package ones).
3. **CJS named-import interop** → `lodash` and `@coral-xyz/anchor` don't expose Node-ESM-detectable named exports. Switched to default/namespace import with an interop fallback that is **dual CJS/ESM safe** (verified both builds).
4. **CJS-only `require.main === module` CLI guards** throw in ESM scope → gated behind `typeof require !== "undefined"` (inert in ESM/browser, unchanged in Node CJS).

## Verification

- `yarn dev` (cjs / esm / types) builds clean; `eslint` + `prettier` clean on all changed files.
- **ESM and CJS `index` both import clean** under `node` (17 exports each).
- The **`across-protocol/dapp` SDK import set** (everything `vendor/across/shared` pulls — `arch/evm/BlockUtils`, `utils/{Address,Network,Token,Event,Spoke,...}Utils`, `constants`, `interfaces/SpokePool`, …) loads under Node native ESM: **13/13 modules, 0 failures** (was 4 failures). This is exactly the dev-SSR externalization path that was failing.
- dapp `pnpm start` before/after (overlaying this build): module-load errors **4 → 0**.

## Follow-ups (separate, optional)

- **CI**: a dev-SSR smoke test (or a `node --input-type=module -e 'import(".../dist/esm/src/index.js")'` check) would catch ESM-load regressions that the bundler-based tests miss.
- **Longer term**: moving the ESM build to a bundler (tsup/rollup `preserveModules`) would handle interop wholesale; this PR is the minimal, layout-preserving fix that unblocks consumers now.
- Consumers deep-importing `@across-protocol/sdk/dist/esm/src/...` (e.g. the dapp's `vendor/across/shared`) could move to the package root — hygiene, not required by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)