### PR TITLE
feat(BundleDataClient): refund deposits to abandoned destinations (UMIP-179)

### DIFF
--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -61,7 +61,7 @@ import {
 } from "./utils";
 import { isEVMSpokePoolClient, isSVMSpokePoolClient } from "../SpokePoolClient";
 import { SpokePoolManager } from "../SpokePoolClient/SpokePoolClientManager";
-import { DEFAULT_CACHING_TTL } from "../../constants";
+import { ABANDONED_DESTINATION_REFUND_CONFIG_STORE_VERSION, DEFAULT_CACHING_TTL } from "../../constants";
 type DataCache = Record<string, Promise<LoadDataReturnValue>>;
 
 // V3 dictionary helper functions
@@ -1193,6 +1193,75 @@ export class BundleDataClient {
         }
       }
     });
+
+    // Refund deposits whose destination is not an active protocol chain ("abandoned destinations").
+    // A deposit to a destination that was never onboarded, or that was in DISABLED_CHAINS across its
+    // fillable window, is otherwise filtered out of bundle consideration entirely (see `allChainIds`) and
+    // stranded on the origin SpokePool. Per UMIP-179 "Finding Abandoned-Destination Deposits", refund it to
+    // the depositor on the ORIGIN chain once its fillDeadline elapses within the origin bundle range. Gated
+    // on the ConfigStore VERSION so proposers switch deterministically.
+    if (
+      this.clients.configStoreClient.getConfigStoreVersionForBlock(bundleEndBlockForMainnet) >=
+      ABANDONED_DESTINATION_REFUND_CONFIG_STORE_VERSION
+    ) {
+      const activeChainIds = new Set(allChainIds);
+      // Cache HubPool-block resolutions by timestamp; abandoned deposits are rare so per-deposit is fine.
+      const hubPoolBlockForTimestamp: { [timestamp: number]: number } = {};
+      const resolveHubPoolBlock = async (timestamp: number): Promise<number> =>
+        (hubPoolBlockForTimestamp[timestamp] ??= await this.clients.hubPoolClient.getBlockNumber(timestamp));
+
+      for (const originChainId of allChainIds) {
+        const originClient = spokePoolClients[originChainId];
+        const originBundleTimestamps = bundleBlockTimestamps[originChainId];
+        if (!isDefined(originClient) || !isDefined(originBundleTimestamps)) {
+          continue;
+        }
+        const [originStartTime, originEndTime] = originBundleTimestamps;
+
+        for (const deposit of originClient.getDeposits()) {
+          const { destinationChainId, fillDeadline } = deposit;
+          // Active destinations are handled by the loops above; only non-active destinations reach here.
+          if (activeChainIds.has(destinationChainId)) {
+            continue;
+          }
+          // Forward-only origin-clock gate: only refund deposits whose fillDeadline elapses within this
+          // bundle's origin block range. Deposits whose fillDeadline elapsed in an earlier bundle are
+          // assumed already resolved (mirrors the destination-clock expiry gate above).
+          if (fillDeadline < originStartTime || fillDeadline > originEndTime) {
+            continue;
+          }
+
+          // Classify using on-chain event timestamps (never quoteTimestamp), so the rule is independent of
+          // depositQuoteTimeBuffer. `CHAIN_ID_INDICES` is append-only, so absence at the fillDeadline HubPool
+          // block implies absence for the whole [deposit, fillDeadline] window => no SpokePool ever existed.
+          const fillDeadlineHubBlock = await resolveHubPoolBlock(fillDeadline);
+          const orphaned = !this.clients.configStoreClient
+            .getChainIdIndicesForBlock(fillDeadlineHubBlock)
+            .includes(destinationChainId);
+
+          let abandoned = orphaned;
+          if (!abandoned) {
+            // Disabled destination: require it to have been in DISABLED_CHAINS as of BOTH the deposit's
+            // origin block.timestamp and its fillDeadline (disabled across the whole window). Combined with
+            // the re-enablement bundle-range rule (disabled-gap fills are never bundled), this guarantees no
+            // repayable fill can be double-paid against the depositor refund.
+            const depositTime = await originClient.getTimestampForBlock(deposit.blockNumber);
+            const depositHubBlock = await resolveHubPoolBlock(depositTime);
+            const disabledAtDeposit = this.clients.configStoreClient
+              .getDisabledChainsForBlock(depositHubBlock)
+              .includes(destinationChainId);
+            const disabledAtFillDeadline = this.clients.configStoreClient
+              .getDisabledChainsForBlock(fillDeadlineHubBlock)
+              .includes(destinationChainId);
+            abandoned = disabledAtDeposit && disabledAtFillDeadline;
+          }
+
+          if (abandoned) {
+            updateExpiredDepositsV3(expiredDepositsToRefundV3, deposit);
+          }
+        }
+      }
+    }
 
     // Batch compute V3 lp fees.
     start = performance.now();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -33,6 +33,15 @@ export const HUBPOOL_CHAIN_ID = 1;
 // List of versions where certain UMIP features were deprecated or activated
 export const TRANSFER_THRESHOLD_MAX_CONFIG_STORE_VERSION = 1;
 
+// ConfigStore VERSION at which UMIP-179 "abandoned-destination" depositor refunds activate. From this
+// version onward, a deposit whose destinationChainId is not an active protocol chain (never onboarded, or
+// in DISABLED_CHAINS across its fillable window) is refunded to the depositor on the origin SpokePool once
+// its fillDeadline elapses, instead of being silently dropped from bundle consideration. See UMIP-179
+// "Finding Abandoned-Destination Deposits".
+// TODO(UMIP-179): set to the ratified activation VERSION before mainnet enablement. The high placeholder
+// keeps the feature inert (never triggers) until governance sets the real value.
+export const ABANDONED_DESTINATION_REFUND_CONFIG_STORE_VERSION = 100;
+
 // A hardcoded identifier used, by default, to tag all Arweave records.
 export const ARWEAVE_TAG_APP_NAME = "across-protocol";
 


### PR DESCRIPTION
> **Draft** — companion implementation to UMAprotocol/UMIPs#631. Compiles clean (cjs/esm/types); **needs dedicated test coverage + review before merge** (this is consensus/settlement code). Inert until the ConfigStore VERSION gate is set, so it does not change current bundle output.

## Problem

A `Deposit` whose `destinationChainId` is not an active protocol chain — **never onboarded** (typo / unsupported id) or **currently in `DISABLED_CHAINS`** (e.g. Scroll) — is accepted on-chain (`SpokePool._depositV3` does not validate `destinationChainId`) but then **silently dropped** by the dataworker: `loadData` only iterates `allChainIds` (active chains), so these deposits never enter the origin/destination loops, and expired-deposit refunds are defined against a destination clock that doesn't exist for them. The input funds sit on the origin SpokePool indefinitely. Hit in production (Base→Scroll via a third-party integrator; funds stranded, manual admin recovery required).

## Change

After the existing deposit/fill/expiry processing in `loadData`, add an origin-clock refund pass for abandoned-destination deposits (gated on `ABANDONED_DESTINATION_REFUND_CONFIG_STORE_VERSION`):

- For each origin chain, scan deposits whose `destinationChainId ∉ allChainIds`.
- Apply the same **forward-only** gate as expired deposits, but on the **origin** bundle window: refund only if `fillDeadline` falls within `[originStart, originEnd]`. Older deadlines are assumed resolved in a prior bundle → no retroactive sweep.
- Classify using **on-chain event timestamps, never `quoteTimestamp`** (so it's independent of `depositQuoteTimeBuffer`, which may be raised to ~1 week):
  - **orphan** — destination `∉ CHAIN_ID_INDICES` at the `fillDeadline` HubPool block. `CHAIN_ID_INDICES` is append-only ⇒ absent at the deadline ⇒ absent across the whole window ⇒ no SpokePool ever existed ⇒ no fill.
  - **disabled** — destination `∈ DISABLED_CHAINS` at **both** the deposit `block.timestamp` and the `fillDeadline` HubPool blocks. Combined with the re-enablement bundle-range rule (UMIP PR), disabled-interval fills are never bundled, so the depositor refund can't be double-paid.
- Refund via the existing `updateExpiredDepositsV3` → flows into the origin relayer-refund root. No new leaf type, no contract change.

## Safety

No destination `FillStatus` check (the chain is unresolvable) — safety is structural: an orphan destination never had a SpokePool, and a disabled-throughout destination's fills are never in any bundle range. Membership resolves from deposit/`fillDeadline` block timestamps via `HubPoolClient.getBlockNumber()`; near a `DISABLED_CHAINS` boundary the origin→mainnet resolution should be taken conservatively (design note in the UMIP).

## Test plan (TODO before un-drafting)

- Extend the `BundleDataClient` loadData suite (`MockConfigStoreClient` version ≥ gate) to assert:
  - Deposit to a never-onboarded destination → refunded to depositor on origin when `fillDeadline` in window; not before.
  - Deposit to a `DISABLED_CHAINS` destination disabled at both deposit & deadline → refunded; disabled only after deposit (active at deposit) → **not** refunded (double-pay guard).
  - Deposit whose `fillDeadline` predates the origin window → not refunded (forward-only).
  - Version below gate → no behavior change.
- Confirm `ABANDONED_DESTINATION_REFUND_CONFIG_STORE_VERSION` is set to the ratified activation VERSION.

🤖 Generated with [Claude Code](https://claude.com/claude-code)