### PR TITLE
improve(HubPoolClient): retain pre-lookback RootBundleExecuted events for reuse

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.4.7",
+  "version": "4.4.8",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -85,6 +85,8 @@ export class HubPoolClient extends BaseAbstractClient {
   protected canceledRootBundles: CancelledRootBundle[] = [];
   protected disputedRootBundles: DisputedRootBundle[] = [];
   protected executedRootBundles: ExecutedRootBundle[] = [];
+  // Retained result of the pre-lookback RootBundleExecuted query; see getHistoricalExecutedRootBundles().
+  protected historicalExecutedRootBundles: Promise<ExecutedRootBundle[]> | undefined;
   protected crossChainContracts: { [l2ChainId: number]: CrossChainContractsSet[] } = {};
   protected l1TokensToDestinationTokensWithBlock: {
     // @dev `l1Token` here is a 20-byte hex sting
@@ -830,30 +832,50 @@ export class HubPoolClient extends BaseAbstractClient {
     let executedRootBundle = this.getLatestExecutedRootBundleContainingL1Token(block, chain, l1Token);
 
     // `executedRootBundles` only spans the configured event lookback. If there's no balance update for this
-    // (chain, l1Token) within it, query the preceding history on the fly before assuming a zero running
+    // (chain, l1Token) within it, query the preceding history before assuming a zero running
     // balance -- otherwise a balance carried by a token idle longer than the lookback is silently dropped,
     // under-pulling spoke liquidity.
     if (!isDefined(executedRootBundle)) {
-      const to = this.eventSearchConfig.from - 1; // the range preceding the already-loaded lookback window
-      if (to >= this.deploymentBlock) {
-        const events = await paginatedEventQuery(this.hubPool, this.hubPool.filters.RootBundleExecuted(), {
-          from: this.deploymentBlock,
-          to,
-          maxLookBack: this.eventSearchConfig.maxLookBack,
-        });
-        const historical = events
-          .filter((event) => !this.configOverride.ignoredHubExecutedBundles.includes(event.blockNumber))
-          .map((event) => this.decodeExecutedRootBundle(event));
-        executedRootBundle = sortEventsDescending(historical).find(
-          (executedLeaf) =>
-            executedLeaf.blockNumber <= block &&
-            executedLeaf.chainId === chain &&
-            executedLeaf.l1Tokens.some((token) => token.eq(l1Token))
-        );
-      }
+      const historical = await this.getHistoricalExecutedRootBundles();
+      executedRootBundle = historical.find(
+        (executedLeaf) =>
+          executedLeaf.blockNumber <= block &&
+          executedLeaf.chainId === chain &&
+          executedLeaf.l1Tokens.some((token) => token.eq(l1Token))
+      );
     }
 
     return this.getRunningBalanceForToken(l1Token, executedRootBundle);
+  }
+
+  /**
+   * Query RootBundleExecuted events preceding the configured event lookback, back to the HubPool deployment
+   * block. That range never changes for the lifetime of the client and its history is immutable, so the decoded
+   * events are retained on the instance: the expensive paginated query runs at most once per client, and
+   * concurrent callers share the in-flight query. Returned sorted descending by block.
+   */
+  protected getHistoricalExecutedRootBundles(): Promise<ExecutedRootBundle[]> {
+    this.historicalExecutedRootBundles ??= (async () => {
+      const to = this.eventSearchConfig.from - 1; // the range preceding the already-loaded lookback window
+      if (to < this.deploymentBlock) {
+        return [];
+      }
+      const events = await paginatedEventQuery(this.hubPool, this.hubPool.filters.RootBundleExecuted(), {
+        from: this.deploymentBlock,
+        to,
+        maxLookBack: this.eventSearchConfig.maxLookBack,
+      });
+      return sortEventsDescending(
+        events
+          .filter((event) => !this.configOverride.ignoredHubExecutedBundles.includes(event.blockNumber))
+          .map((event) => this.decodeExecutedRootBundle(event))
+      );
+    })().catch((error) => {
+      // Don't retain a rejected promise; let the next caller retry the query.
+      this.historicalExecutedRootBundles = undefined;
+      throw error;
+    });
+    return this.historicalExecutedRootBundles;
   }
 
   public getRunningBalanceForToken(

--- a/test/HubPoolClient.RootBundleEvents.ts
+++ b/test/HubPoolClient.RootBundleEvents.ts
@@ -310,13 +310,42 @@ describe("HubPoolClient: RootBundle Events", function () {
       )
     ).to.be.undefined;
 
-    // The full-history fallback recovers the true running balance instead of defaulting to 0.
+    // Count underlying event queries to verify the pre-lookback history is fetched at most once per client.
+    // maxLookBack of 0 means each historical scan issues exactly one queryFilter call.
+    let historicalQueries = 0;
+    const queryFilter = shortLookbackClient.hubPool.queryFilter.bind(shortLookbackClient.hubPool);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (shortLookbackClient.hubPool as any).queryFilter = (...args: any[]) => {
+      historicalQueries++;
+      return queryFilter(...args);
+    };
+
+    // The full-history fallback recovers the true running balance instead of defaulting to 0. Concurrent
+    // lookups for different (chain, l1Token) pairs share a single underlying query.
+    const [first, second] = await Promise.all([
+      shortLookbackClient.getRunningBalanceBeforeBlockForChain(
+        bundleBlock,
+        constants.originChainId,
+        EvmAddress.from(l1Token_1.address)
+      ),
+      shortLookbackClient.getRunningBalanceBeforeBlockForChain(
+        bundleBlock,
+        constants.destinationChainId,
+        EvmAddress.from(l1Token_2.address)
+      ),
+    ]);
+    expect(first.runningBalance.eq(toBNWei(100))).to.be.true;
+    expect(second.runningBalance.eq(toBNWei(300))).to.be.true;
+    expect(historicalQueries).to.equal(1);
+
+    // Subsequent lookups reuse the retained events without re-querying.
     const { runningBalance } = await shortLookbackClient.getRunningBalanceBeforeBlockForChain(
       bundleBlock,
       constants.originChainId,
-      EvmAddress.from(l1Token_1.address)
+      EvmAddress.from(l1Token_2.address)
     );
-    expect(runningBalance.eq(toBNWei(100))).to.be.true;
+    expect(runningBalance.eq(toBNWei(200))).to.be.true;
+    expect(historicalQueries).to.equal(1);
   });
 
   it("returns proposed and disputed bundles", async function () {


### PR DESCRIPTION
## Motivation

Two valid root bundle proposals were auto-disputed by the disputer watchdog on 2026-07-06 (context: [Slack thread](https://risklabs.slack.com/archives/C03GKNS03C7/p1783365026960569)). Log analysis pinned the delay inside `_buildPoolRebalanceRoot` → `addLastRunningBalance` → `HubPoolClient.getRunningBalanceBeforeBlockForChain()`:

- When a (chain, l1Token) pair has no running-balance update inside the configured lookback (`DATAWORKER_FAST_LOOKBACK_COUNT=64` bundles), the method deep-scans `RootBundleExecuted` from the HubPool **deployment block** (~14.82M) to the lookback start (~25.27M) — ~10.5M blocks ≈ ~1,050 paged `getLogs` on mainnet.
- The result was a local variable, discarded after each call, and the dataworker awaits this method once per (chain, l1Token) pair — so bundles with slow relay leaves on idle pairs re-paid the scan repeatedly: **17.5s** root-build for a bundle with no slow fills vs **16m43s–23m16s** for bundles with them.
- That pushed validator attestations past the watchdog's `challengeLimit` deadline (30-min liveness − 600s), so every such proposal gets disputed at <2 attestations.

## Changes

- `HubPoolClient.getHistoricalExecutedRootBundles()`: the pre-lookback scan range `[deploymentBlock, eventSearchConfig.from - 1]` is fixed for the client's lifetime and its contents are immutable, so the decoded (descending-sorted) events are now retained on the instance. The paginated query runs at most once per client; concurrent callers share the in-flight promise; a failed query is not retained (next caller retries).
- `getRunningBalanceBeforeBlockForChain()` consumes the retained events; behavior is otherwise unchanged.
- Extended the existing fallback test to assert: concurrent lookups for different (chain, token) pairs share a single underlying `queryFilter` call, and subsequent lookups issue none.

## Testing

`yarn hardhat test test/HubPoolClient.RootBundleEvents.ts` — 8 passing. `tsc -p tsconfig.build.json --noEmit`, eslint, and prettier clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)