### PR TITLE
fix(retryProvider): Don't mask quorum failures with a ReferenceError

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.4.11",
+  "version": "4.4.12",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/src/providers/retryProvider.ts
+++ b/src/providers/retryProvider.ts
@@ -128,7 +128,10 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
       return values[0][1];
     }
 
-    const getMismatchedProviders = (values: [ethers.providers.StaticJsonRpcProvider, unknown][]) => {
+    const getMismatchedProviders = (
+      quorumResult: unknown,
+      values: [ethers.providers.StaticJsonRpcProvider, unknown][]
+    ) => {
       return values
         .filter(([, result]) => !compareRpcResults(method, result, quorumResult))
         .map(([provider]) => getOriginFromURL(provider.connection.url));
@@ -153,10 +156,16 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
       });
     };
 
-    const throwQuorumError = (fallbackValues?: [ethers.providers.StaticJsonRpcProvider, unknown][]) => {
+    const throwQuorumError = (quorum?: {
+      quorumResult: unknown;
+      fallbackValues: [ethers.providers.StaticJsonRpcProvider, unknown][];
+    }) => {
       const errorTexts = errors.map(([provider, errorText]) => formatProviderError(provider, errorText));
       const successfulProviderUrls = values.map(([provider]) => getOriginFromURL(provider.connection.url));
-      const mismatchedProviders = getMismatchedProviders([...values, ...(fallbackValues || [])]);
+      // On the early-exit path (no fallback providers left) no quorum result exists to compare mismatches against.
+      const mismatchedProviders = quorum
+        ? getMismatchedProviders(quorum.quorumResult, [...values, ...quorum.fallbackValues])
+        : [];
       logQuorumMismatchOrFailureDetails(method, params, successfulProviderUrls, mismatchedProviders, errors);
       throw new Error(
         "Not enough providers agreed to meet quorum.\n" +
@@ -216,11 +225,11 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
 
     // If this count is less than we need for quorum, throw the quorum error.
     if (count < quorumThreshold) {
-      throwQuorumError(fallbackValues);
+      throwQuorumError({ quorumResult, fallbackValues });
     }
 
     // If we've achieved quorum, then we should still log the providers that mismatched with the quorum result.
-    const mismatchedProviders = getMismatchedProviders([...values, ...fallbackValues]);
+    const mismatchedProviders = getMismatchedProviders(quorumResult, [...values, ...fallbackValues]);
     const quorumProviders = [...values, ...fallbackValues]
       .filter(([, result]) => compareRpcResults(method, result, quorumResult))
       .map(([provider]) => getOriginFromURL(provider.connection.url));

--- a/test/providers/retryProvider.test.ts
+++ b/test/providers/retryProvider.test.ts
@@ -1,0 +1,80 @@
+import { ethers } from "ethers";
+import { RetryProvider } from "../../src/providers";
+import { expect } from "../utils";
+
+const chainId = 1;
+const providerCacheNamespace = "test-cache-ns";
+const quorumError = "Not enough providers agreed to meet quorum";
+
+const makeLog = (logIndex: string) => ({
+  address: "0x9295ee1d8c5b022be115a2ad3c30c72e34e7f096",
+  blockNumber: "0x1",
+  logIndex,
+  topics: [],
+  data: "0x",
+});
+
+function makeProvider(quorumThreshold: number, behaviors: (unknown | Error)[]): RetryProvider {
+  const params = behaviors.map(
+    (_, i): ConstructorParameters<typeof ethers.providers.StaticJsonRpcProvider> => [
+      `https://test${i}.example.com`,
+      chainId,
+    ]
+  );
+  const provider = new RetryProvider(
+    params,
+    chainId,
+    quorumThreshold,
+    0, // retries
+    0, // delay
+    1, // maxConcurrency
+    providerCacheNamespace,
+    0 // pctRpcCallsLogged
+  );
+  provider.providers.forEach((subProvider, i) => {
+    const behavior = behaviors[i];
+    subProvider.send = () => (behavior instanceof Error ? Promise.reject(behavior) : Promise.resolve(behavior));
+  });
+  return provider;
+}
+
+describe("RetryProvider quorum", () => {
+  it("throws the quorum error, not a ReferenceError, when providers disagree and no fallbacks remain", async () => {
+    const provider = makeProvider(2, [[makeLog("0x1")], []]);
+
+    let caught: unknown;
+    try {
+      await provider.send("eth_getLogs", [{ fromBlock: "0x1", toBlock: "0x2" }]);
+      expect.fail("Expected send to reject");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).to.not.be.instanceOf(ReferenceError);
+    expect((caught as Error).message).to.include(quorumError);
+  });
+
+  it("throws the quorum error when a failing provider consumes the fallback and the survivors disagree", async () => {
+    const provider = makeProvider(2, [new Error("rpc down"), [makeLog("0x1")], [makeLog("0x2")]]);
+
+    let caught: unknown;
+    try {
+      await provider.send("eth_getLogs", [{ fromBlock: "0x1", toBlock: "0x2" }]);
+      expect.fail("Expected send to reject");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).to.not.be.instanceOf(ReferenceError);
+    expect((caught as Error).message).to.include(quorumError);
+    expect((caught as Error).message).to.include("rpc down");
+  });
+
+  it("returns the quorum result when enough providers agree after a fallback query", async () => {
+    const agreed = [makeLog("0x1")];
+    const provider = makeProvider(2, [agreed, [makeLog("0x2")], agreed]);
+
+    const result = await provider.send("eth_getLogs", [{ fromBlock: "0x1", toBlock: "0x2" }]);
+    expect(result).to.deep.equal(agreed);
+  });
+});


### PR DESCRIPTION
## Motivation

When `RetryProvider.send` fails to reach quorum and no fallback providers remain, the early-exit `throwQuorumError()` call crashes with:

```
ReferenceError: Cannot access 'quorumResult' before initialization
    at getMismatchedProviders (retryProvider.js:77)
    at throwQuorumError (retryProvider.js:95)
    at RetryProvider.send (retryProvider.js:104)
```

`getMismatchedProviders` closes over `quorumResult`, a `const` that is only declared ~45 lines later (after fallback results are counted). The early-exit path invokes it inside the temporal dead zone, so instead of the intended "Not enough providers agreed to meet quorum" error the process dies with a `ReferenceError` — and since the crash happens before `logQuorumMismatchOrFailureDetails`, the diagnostic warn (which providers mismatched, on which method) is lost too.

The pattern was introduced in #728. In production it has been crashing the Across dataworker/proposer and other bots whenever a provider failure exhausts the fallback list and the surviving providers disagree (most recently `zion-across-proposer`, 5 consecutive runs on 2026-07-15).

## Changes

- `getMismatchedProviders` now takes the quorum result as an explicit parameter instead of closing over the not-yet-declared `quorumResult`.
- `throwQuorumError` takes an optional `{ quorumResult, fallbackValues }`: the post-count call site passes it; the early-exit call site has no quorum result, so mismatch computation is skipped there (there is nothing to compare against — the thrown error already lists the disagreeing providers).
- Added `test/providers/retryProvider.test.ts` covering: the no-fallback disagreement path (throws the quorum error, not a `ReferenceError`), the fallback-consumed-by-failure path, and the quorum-reached-via-fallback happy path.
- Bumped patch version 4.4.11 → 4.4.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
