### PR TITLE
fix(retryProvider): Populate mismatch diagnostics on the no-fallback quorum error

### DIFF
--- a/src/providers/retryProvider.ts
+++ b/src/providers/retryProvider.ts
@@ -156,16 +156,42 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
       });
     };
 
-    const throwQuorumError = (quorum?: {
-      quorumResult: unknown;
-      fallbackValues: [ethers.providers.StaticJsonRpcProvider, unknown][];
-    }) => {
+    // Group the results by the count of that result and return the most frequent result and its count. This is the
+    // closest thing to a quorum result that exists when quorum was not reached, so mismatches are measured against it.
+    const findQuorumCandidate = (vals: [ethers.providers.StaticJsonRpcProvider, unknown][]): [unknown, number] => {
+      const counts = vals.reduce(
+        (acc, curr) => {
+          const [, result] = curr;
+
+          // Find the first result that matches the return value.
+          const existingMatch = acc.find(([existingResult]) => compareRpcResults(method, existingResult, result));
+
+          // Increment the count if a match is found, else add a new element to the match array with a count of 1.
+          if (existingMatch) {
+            existingMatch[1]++;
+          } else {
+            acc.push([result, 1]);
+          }
+
+          // Return the same acc object because it was modified in place.
+          return acc;
+        },
+        [[undefined, 0]] as [unknown, number][] // Initialize with [undefined, 0] as the first element so something is always returned.
+      );
+
+      // Sort so the result with the highest count is first.
+      counts.sort(([, a], [, b]) => b - a);
+
+      return counts[0];
+    };
+
+    const throwQuorumError = (
+      quorumResult: unknown,
+      fallbackValues: [ethers.providers.StaticJsonRpcProvider, unknown][]
+    ) => {
       const errorTexts = errors.map(([provider, errorText]) => formatProviderError(provider, errorText));
       const successfulProviderUrls = values.map(([provider]) => getOriginFromURL(provider.connection.url));
-      // On the early-exit path (no fallback providers left) no quorum result exists to compare mismatches against.
-      const mismatchedProviders = quorum
-        ? getMismatchedProviders(quorum.quorumResult, [...values, ...quorum.fallbackValues])
-        : [];
+      const mismatchedProviders = getMismatchedProviders(quorumResult, [...values, ...fallbackValues]);
       logQuorumMismatchOrFailureDetails(method, params, successfulProviderUrls, mismatchedProviders, errors);
       throw new Error(
         "Not enough providers agreed to meet quorum.\n" +
@@ -176,9 +202,11 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
       );
     };
 
-    // Exit early if there are no fallback providers left.
+    // Exit early if there are no fallback providers left. The most frequent result stands in for the quorum result so
+    // the diagnostic log can identify which providers disagreed.
     if (fallbackProviders.length === 0) {
-      throwQuorumError();
+      const [quorumCandidate] = findQuorumCandidate(values);
+      throwQuorumError(quorumCandidate, []);
     }
 
     // Try each fallback provider in parallel.
@@ -196,36 +224,12 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
     // This filters only the fallbacks that succeeded.
     const fallbackValues = fallbackResults.filter(isPromiseFulfilled).map((promise) => promise.value);
 
-    // Group the results by the count of that result.
-    const counts = [...values, ...fallbackValues].reduce(
-      (acc, curr) => {
-        const [, result] = curr;
-
-        // Find the first result that matches the return value.
-        const existingMatch = acc.find(([existingResult]) => compareRpcResults(method, existingResult, result));
-
-        // Increment the count if a match is found, else add a new element to the match array with a count of 1.
-        if (existingMatch) {
-          existingMatch[1]++;
-        } else {
-          acc.push([result, 1]);
-        }
-
-        // Return the same acc object because it was modified in place.
-        return acc;
-      },
-      [[undefined, 0]] as [unknown, number][] // Initialize with [undefined, 0] as the first element so something is always returned.
-    );
-
-    // Sort so the result with the highest count is first.
-    counts.sort(([, a], [, b]) => b - a);
-
-    // Extract the result by grabbing the first element.
-    const [quorumResult, count] = counts[0];
+    // Extract the most frequent result and its count.
+    const [quorumResult, count] = findQuorumCandidate([...values, ...fallbackValues]);
 
     // If this count is less than we need for quorum, throw the quorum error.
     if (count < quorumThreshold) {
-      throwQuorumError({ quorumResult, fallbackValues });
+      throwQuorumError(quorumResult, fallbackValues);
     }
 
     // If we've achieved quorum, then we should still log the providers that mismatched with the quorum result.

--- a/test/providers/retryProvider.test.ts
+++ b/test/providers/retryProvider.test.ts
@@ -1,6 +1,7 @@
 import { ethers } from "ethers";
+import { Logger } from "winston";
 import { RetryProvider } from "../../src/providers";
-import { expect } from "../utils";
+import { createSpyLogger, expect } from "../utils";
 
 const chainId = 1;
 const providerCacheNamespace = "test-cache-ns";
@@ -14,7 +15,7 @@ const makeLog = (logIndex: string) => ({
   data: "0x",
 });
 
-function makeProvider(quorumThreshold: number, behaviors: (unknown | Error)[]): RetryProvider {
+function makeProvider(quorumThreshold: number, behaviors: (unknown | Error)[], logger?: Logger): RetryProvider {
   const params = behaviors.map(
     (_, i): ConstructorParameters<typeof ethers.providers.StaticJsonRpcProvider> => [
       `https://test${i}.example.com`,
@@ -29,7 +30,12 @@ function makeProvider(quorumThreshold: number, behaviors: (unknown | Error)[]): 
     0, // delay
     1, // maxConcurrency
     providerCacheNamespace,
-    0 // pctRpcCallsLogged
+    0, // pctRpcCallsLogged
+    undefined, // redisClient
+    undefined, // standardTtlBlockDistance
+    undefined, // noTtlBlockDistance
+    undefined, // providerCacheTtl
+    logger
   );
   provider.providers.forEach((subProvider, i) => {
     const behavior = behaviors[i];
@@ -52,6 +58,21 @@ describe("RetryProvider quorum", () => {
 
     expect(caught).to.not.be.instanceOf(ReferenceError);
     expect((caught as Error).message).to.include(quorumError);
+  });
+
+  it("identifies the mismatched providers in the diagnostic log when quorum fails with no fallbacks", async () => {
+    const { spy, spyLogger } = createSpyLogger();
+    const provider = makeProvider(2, [[makeLog("0x1")], []], spyLogger);
+
+    await expect(provider.send("eth_getLogs", [{ fromBlock: "0x1", toBlock: "0x2" }])).to.be.rejectedWith(quorumError);
+
+    const warnLog = spy
+      .getCalls()
+      .map((call) => call.lastArg)
+      .find((log) => log.at === "ProviderUtils" && log.message.includes("mismatched"));
+    expect(warnLog).to.exist;
+    // The first provider's result is the most frequent, so the second provider is flagged as the mismatch.
+    expect(warnLog.mismatchedProviders).to.deep.equal(["https://test1.example.com"]);
   });
 
   it("throws the quorum error when a failing provider consumes the fallback and the survivors disagree", async () => {


### PR DESCRIPTION
Follow-up to #1483, addressing the Codex P2 finding (https://github.com/across-protocol/sdk/pull/1483#discussion_r3588905813). The fix was committed to the PR branch but #1483 was squash-merged moments before the push landed, so it never reached master.

When quorum fails on the early-exit path (no fallback providers left), `throwQuorumError()` was called without a quorum candidate, so the diagnostic warn log reported `mismatchedProviders: []` — even though the only way to reach that path is that the successful providers disagreed.

This extracts the result-frequency counting into a `findQuorumCandidate` helper and uses it on both quorum-failure paths: the early-exit path now computes the most frequent result from the successful providers' responses and measures mismatches against it, so the log identifies which providers diverged.

Includes a test asserting `mismatchedProviders` is populated on the no-fallback path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)