### PR TITLE
fix(svm): reject forged CPI events missing the Anchor event discriminator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.4.12",
+  "version": "4.4.13",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/src/arch/svm/eventsClient.ts
+++ b/src/arch/svm/eventsClient.ts
@@ -19,9 +19,11 @@ import assert from "assert";
 
 /**
  * Anchor emits CPI events (`emit_cpi!`) as a *self*-invocation of the program that targets its
- * `__event_authority` PDA and prefixes the instruction data with this fixed 8-byte discriminator
- * (`sha256("anchor:event")[..8]`), followed by the 8-byte event discriminator and the Borsh event
- * payload. Checking this prefix is what proves an inner instruction is a genuine emitted event and
+ * `__event_authority` PDA and prefixes the instruction data with this fixed 8-byte discriminator,
+ * followed by the 8-byte event discriminator and the Borsh event payload. The wire bytes are the
+ * little-endian encoding of Anchor's `EVENT_IX_TAG: u64 = 0x1d9acb512ea545e4` (the first 8 bytes of
+ * `sha256("anchor:event")` read as a big-endian u64) — i.e. the digest prefix in *reversed* byte
+ * order. Checking this prefix is what proves an inner instruction is a genuine emitted event and
  * not just some other instruction that happens to touch the program. Without it, any program can
  * forge an event by CPI-ing into the SpokePool with the event authority passed as the sole account
  * and attacker-controlled trailing data (e.g. via the read-only `GetUnsafeDepositId` instruction),

--- a/src/arch/svm/eventsClient.ts
+++ b/src/arch/svm/eventsClient.ts
@@ -17,6 +17,18 @@ import { Deposit, DepositWithTime, Fill, FillWithTime } from "../../interfaces";
 import { unwrapEventData } from "./";
 import assert from "assert";
 
+/**
+ * Anchor emits CPI events (`emit_cpi!`) as a *self*-invocation of the program that targets its
+ * `__event_authority` PDA and prefixes the instruction data with this fixed 8-byte discriminator
+ * (`sha256("anchor:event")[..8]`), followed by the 8-byte event discriminator and the Borsh event
+ * payload. Checking this prefix is what proves an inner instruction is a genuine emitted event and
+ * not just some other instruction that happens to touch the program. Without it, any program can
+ * forge an event by CPI-ing into the SpokePool with the event authority passed as the sole account
+ * and attacker-controlled trailing data (e.g. via the read-only `GetUnsafeDepositId` instruction),
+ * which the client would otherwise decode as a real FundsDeposited/FilledRelay event.
+ */
+const ANCHOR_CPI_EVENT_DISCRIMINATOR = Buffer.from([0xe4, 0x45, 0xa5, 0x2e, 0x51, 0xcb, 0x9a, 0x1d]);
+
 // Utility type to extract the return type for the JSON encoding overload. We only care about the overload where the
 // configuration parameter (C) has the optional property 'encoding' set to 'json'.
 type ExtractJsonOverload<T> = T extends (signature: infer _S, config: infer C) => infer R
@@ -213,7 +225,17 @@ export class SvmCpiEventsClient {
           this.programEventAuthority === singleIxAccount
         ) {
           const ixData = bs58.decode(ix.data);
-          // Skip the first 8 bytes (assumed header) and encode the rest.
+          // Only decode genuine Anchor CPI events. The instruction data of an emitted event is
+          // prefixed with the Anchor event discriminator; requiring it prevents an arbitrary CPI
+          // into the program (with the event authority as its sole account and crafted trailing
+          // bytes) from being decoded as a forged event.
+          if (
+            ixData.length < ANCHOR_CPI_EVENT_DISCRIMINATOR.length ||
+            !ANCHOR_CPI_EVENT_DISCRIMINATOR.equals(Buffer.from(ixData.slice(0, ANCHOR_CPI_EVENT_DISCRIMINATOR.length)))
+          ) {
+            continue;
+          }
+          // Skip the 8-byte Anchor event discriminator and decode the remaining event payload.
           const eventData = Buffer.from(ixData.slice(8)).toString("base64");
           const { name, data } = decodeEvent(this.idl, eventData);
           events.push({ program: this.programAddress, name, data });

--- a/test/Solana.SvmCpiEventsClient.ForgedEvent.unit.test.ts
+++ b/test/Solana.SvmCpiEventsClient.ForgedEvent.unit.test.ts
@@ -1,0 +1,87 @@
+import { SvmSpokeIdl } from "@across-protocol/contracts";
+import { expect } from "chai";
+import bs58 from "bs58";
+import { SvmCpiEventsClient } from "../src/arch/svm";
+
+/**
+ * Regression test for forged SVM CPI events.
+ *
+ * Anchor emits CPI events as a self-invocation of the program that targets its `__event_authority`
+ * PDA, with the instruction data prefixed by the 8-byte Anchor event discriminator
+ * (`e445a52e51cb9a1d`). `SvmCpiEventsClient` must only decode an inner instruction as an event when
+ * that prefix is present. Otherwise any program can forge a `FundsDeposited` event by CPI-ing into
+ * the SpokePool with the event authority passed as the sole account and attacker-controlled trailing
+ * bytes — which is exactly what was observed on mainnet (e.g. tx
+ * 3rLkGVvyYL2LTuDzbo8MBYNwjhYaKo1pEoqd24HCPQJEhNgyVnKZeNFsFrStKYY6cVizBfLpa2RMiB8dxHPzGHMV), where a
+ * wrapper program CPI'd into the read-only `GetUnsafeDepositId` instruction to fake ~$4.1M deposits
+ * that never escrowed any funds.
+ */
+describe("SvmCpiEventsClient (forged event rejection)", () => {
+  // Mainnet SvmSpoke program.
+  const PROGRAM = "DLv3NggMiSaef97YCkew5xKUHDh13tVGZ7tydt3ZeAru";
+
+  // The Anchor CPI event discriminator (prefix of a genuine emitted event).
+  const ANCHOR_EVENT_DISCRIMINATOR = Buffer.from([0xe4, 0x45, 0xa5, 0x2e, 0x51, 0xcb, 0x9a, 0x1d]);
+  // Discriminator of the read-only `get_unsafe_deposit_id` instruction the attacker abused.
+  const GET_UNSAFE_DEPOSIT_ID_DISCRIMINATOR = Buffer.from([0x76, 0x0a, 0x87, 0x00, 0xa8, 0xf3, 0xdf, 0x75]);
+
+  // Real bytes captured from the mainnet exploit tx: the 8-byte FundsDeposited event discriminator
+  // followed by the Borsh-encoded (attacker-crafted) event payload — i.e. the data that follows the
+  // 8-byte instruction prefix. Reused verbatim for both cases so the *only* difference is the prefix.
+  const eventDiscriminatorAndBody = Buffer.from(
+    "9dd1645f3b640344c6fa7af3bedbad3a3d65f36aabc97431b1bbe4c2d2f6e0e47ca60203452f5d61" +
+      "000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb4859df7cd6bd0300000000" +
+      "0000000000000000000000000000000000000000000000000003b42aa2a336010000000000000000000000" +
+      "0000000000000000000000000000000000000000000000000088c48a2ec190c8b8596a1ec7596a00000000" +
+      "0066f4dd792ef4ba76f0427abfe89e2a7366dbc8f6543bdcb48018be9578ef6879000000000000000000000000" +
+      "a6fb971f3b7a9b9f76eda76bc89268fe26560189000000000000000000000000000000000000000000000000" +
+      "000000000000000000000000",
+    "hex"
+  );
+
+  let client: SvmCpiEventsClient;
+  // Access the private members exercised by this test without widening to `any`.
+  let internal: {
+    programEventAuthority: string;
+    processEventFromTx(txResult: unknown): { name: string }[];
+  };
+
+  before(async () => {
+    // createFor only uses the rpc to construct the instance; PDA derivation is local, so a stub is fine.
+    const rpc = {} as unknown as Parameters<typeof SvmCpiEventsClient.createFor>[0];
+    client = await SvmCpiEventsClient.createFor(rpc, PROGRAM, SvmSpokeIdl);
+    internal = client as unknown as typeof internal;
+  });
+
+  const makeTx = (instructionPrefix: Buffer) => ({
+    meta: {
+      err: null,
+      loadedAddresses: { writable: [], readonly: [] },
+      innerInstructions: [
+        {
+          index: 0,
+          instructions: [
+            {
+              programIdIndex: 0,
+              accounts: [1],
+              data: bs58.encode(Buffer.concat([instructionPrefix, eventDiscriminatorAndBody])),
+            },
+          ],
+        },
+      ],
+    },
+    transaction: {
+      message: { accountKeys: [client.getProgramAddress(), internal.programEventAuthority] },
+    },
+  });
+
+  it("decodes a genuine emitted event (Anchor event discriminator prefix)", () => {
+    const events = internal.processEventFromTx(makeTx(ANCHOR_EVENT_DISCRIMINATOR));
+    expect(events.map((e) => e.name)).to.deep.equal(["FundsDeposited"]);
+  });
+
+  it("ignores a forged event emitted via an arbitrary CPI into the program", () => {
+    const events = internal.processEventFromTx(makeTx(GET_UNSAFE_DEPOSIT_ID_DISCRIMINATOR));
+    expect(events).to.have.lengthOf(0);
+  });
+});


### PR DESCRIPTION
SvmCpiEventsClient.processEventFromTx treated any inner instruction to the SpokePool whose sole account was the __event_authority PDA as an emitted event: it sliced the first 8 bytes and Borsh-decoded the rest. It never checked the Anchor CPI event discriminator (e445a52e51cb9a1d) prefix that marks a genuine `emit_cpi!` self-invocation.

This let an attacker forge FundsDeposited/FilledRelay events. By deploying a wrapper program that CPIs into the read-only `GetUnsafeDepositId` instruction with the event authority passed as the sole account and a crafted event payload appended after the instruction args, the wrapper produced an inner instruction that satisfied the (program + event authority) check while escrowing no funds. The client decoded the crafted bytes as a real deposit, so the indexer recorded phantom deposits and the relayer filled them — paying out against origin escrow that never existed.

Require the 8-byte Anchor event discriminator prefix before decoding. Add a regression test using bytes captured from the mainnet exploit transaction.