### PR TITLE
feat(BundleDataClient): never pay blocked addresses out of a root bundle

### DIFF
--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -49,6 +49,7 @@ import {
 } from "../../utils";
 import winston from "winston";
 import {
+  BLOCKED_ADDRESSES,
   BundleDataSS,
   BundleData as PersistedArweaveBundleData,
   getRefundInformationFromFill,
@@ -68,6 +69,11 @@ type DataCache = Record<string, Promise<LoadDataReturnValue>>;
 function updateExpiredDepositsV3(dict: ExpiredDepositsToRefundV3, deposit: V3DepositWithBlock): void {
   // A deposit refund for a deposit is invalid if the depositor has a bytes32 address input for an EVM chain. It is valid otherwise.
   if (!deposit.depositor.isValidOn(deposit.originChainId)) {
+    return;
+  }
+
+  // Protocol rule: never refund deposits from blocked depositors.
+  if (BLOCKED_ADDRESSES.some((blockedAddress) => blockedAddress.eq(deposit.depositor))) {
     return;
   }
 
@@ -146,6 +152,12 @@ function updateBundleExcessSlowFills(
 
 function updateBundleSlowFills(dict: BundleSlowFills, deposit: V3DepositWithBlock & { lpFeePct: BigNumber }): void {
   if (!deposit.recipient.isValidOn(deposit.destinationChainId)) {
+    return;
+  }
+
+  // Protocol rule: never slow fill deposits with blocked recipients; the deposit instead expires and is
+  // refunded to the depositor.
+  if (BLOCKED_ADDRESSES.some((blockedAddress) => blockedAddress.eq(deposit.recipient))) {
     return;
   }
 

--- a/src/clients/BundleDataClient/utils/FillUtils.ts
+++ b/src/clients/BundleDataClient/utils/FillUtils.ts
@@ -2,9 +2,26 @@ import _ from "lodash";
 import assert from "assert";
 import { providers } from "ethers";
 import { DepositWithBlock, Fill, FillWithBlock } from "../../../interfaces";
-import { isSlowFill, isValidEvmAddress, isDefined, chainIsEvm, Address, toAddressType } from "../../../utils";
+import {
+  isSlowFill,
+  isValidEvmAddress,
+  isDefined,
+  chainIsEvm,
+  Address,
+  EvmAddress,
+  toAddressType,
+} from "../../../utils";
 import { HubPoolClient } from "../../HubPoolClient";
 import { SVMProvider } from "../../../arch/svm";
+
+/**
+ * @notice Addresses that must never be paid out of a root bundle (as repayment, deposit refund, or slow fill).
+ * Protocol rule: all proposers and validators must apply this list identically.
+ */
+export const BLOCKED_ADDRESSES: EvmAddress[] = [
+  "0xA6fb971F3B7a9b9F76EdA76bc89268fe26560189",
+  "0xa0c0e9f307b5a26ca3fb5891c19154fc7a02bef7",
+].map((address) => EvmAddress.from(address));
 
 /**
  * @notice FillRepaymentInformation is a fill with additional properties required to determine where it can
@@ -62,7 +79,7 @@ export function getRefundInformationFromFill(
  * @notice Verifies that the fill can be repaid. If the repayment address is not
  * valid for the requested repayment chain, then this function will attempt to change the fill's repayment chain
  * to the destination chain and its repayment address to the  msg.sender and if this is possible,
- * return the fill. Otherwise, return undefined.
+ * return the fill. Otherwise, return undefined. Fills repaying a BLOCKED_ADDRESSES entry are always unrepayable.
  * @param _fill Fill with a requested repayment chain and address
  * @return Fill with the applied repayment chain (depends on the validity of the requested repayment address)
  * and applied repayment address, or undefined if the applied repayment address is not valid for the
@@ -137,6 +154,11 @@ export async function verifyFillRepayment(
     } else {
       return undefined;
     }
+  }
+
+  // Protocol rule: never repay blocked addresses (checked after any msg.sender overwrite above).
+  if (BLOCKED_ADDRESSES.some((blockedAddress) => blockedAddress.eq(fill.relayer))) {
+    return undefined;
   }
 
   // Repayment address is now valid and repayment chain is either origin chain for lite chain or the destination

--- a/test/FillUtils.ts
+++ b/test/FillUtils.ts
@@ -12,7 +12,7 @@ import {
   ethers,
   createRandomBytes32,
 } from "./utils";
-import { verifyFillRepayment } from "../src/clients/BundleDataClient";
+import { BLOCKED_ADDRESSES, verifyFillRepayment } from "../src/clients/BundleDataClient";
 import { MockedProvider } from "../src/providers/mocks";
 import { TransactionResponse } from "@ethersproject/abstract-provider";
 import { MockConfigStoreClient, MockHubPoolClient } from "./mocks";
@@ -145,6 +145,28 @@ describe("FillUtils", function () {
         expect(result).to.not.be.undefined;
         expect(result!.repaymentChainId).to.equal(fill.repaymentChainId);
         expect(result!.relayer.eq(fill.relayer)).to.be.true;
+      });
+      it("Repayment address is blocked; fill is unrepayable", async function () {
+        for (const blockedAddress of BLOCKED_ADDRESSES) {
+          const blockedFill = {
+            ...fill,
+            relayer: toAddressType(blockedAddress.toNative(), repaymentChainId),
+          };
+          const result = await verifyFillRepayment(blockedFill, spokeProvider, deposit, hubPoolClient, 0);
+          expect(result).to.be.undefined;
+        }
+      });
+      it("Relayer is not valid EVM address and msg.sender is blocked; fill is unrepayable", async function () {
+        hubPoolClient.setTokenMapping(ZERO_ADDRESS, deposit.destinationChainId, deposit.outputToken.toNative());
+        const invalidRepaymentFill = {
+          ...fill,
+          relayer: toAddressType(INVALID_EVM_ADDRESS, destinationChainId),
+        };
+        spokeProvider._setTransaction(fill.txnRef, {
+          from: BLOCKED_ADDRESSES[0].toNative(),
+        } as unknown as TransactionResponse);
+        const result = await verifyFillRepayment(invalidRepaymentFill, spokeProvider, deposit, hubPoolClient, 0);
+        expect(result).to.be.undefined;
       });
       it("SlowFill always valid", async function () {
         // We don't set the repayment chain mapping for the input token because a slow fill should always be valid.


### PR DESCRIPTION
Enforces a hardcoded `BLOCKED_ADDRESSES` list at bundle construction, as a protocol rule, so no root bundle pays:

- `0xA6fb971F3B7a9b9F76EdA76bc89268fe26560189`
- `0xa0c0e9f307b5a26ca3fb5891c19154fc7a02bef7`

Enforced at the three points where a payout can enter a bundle, each the single accumulation point feeding both leaf construction and running balances, so accounting stays consistent and withheld value settles to the hub:

1. `verifyFillRepayment()`: fills repaying a blocked address (including an overwritten msg.sender) are unrepayable.
2. `updateExpiredDepositsV3()`: expired/duplicate deposits from a blocked depositor are not refunded.
3. `updateBundleSlowFills()`: deposits with a blocked recipient are not slow-filled; they expire and refund the depositor (withheld by 2 if the depositor is also blocked).

Notes:

- Not activation-gated: a pending bundle paying a blocked address becomes disputable, and the executor won't reconstruct roots for previously validated bundles containing one. Deploy dataworkers together.
- Follow-up in the relayer repo after release: SDK bump plus `loadData` test coverage for 2 and 3 (module-private here).

Tests: new `verifyFillRepayment` cases for both addresses and a blocked msg.sender overwrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011AwNYDz6oYJB4n41QNw3kT