### PR TITLE
fix(BundleDataClient): gate blocked-recipient slow fills in _canCreateSlowFillLeaf

### DIFF
--- a/src/clients/BundleDataClient/BundleDataClient.ts
+++ b/src/clients/BundleDataClient/BundleDataClient.ts
@@ -155,12 +155,6 @@ function updateBundleSlowFills(dict: BundleSlowFills, deposit: V3DepositWithBloc
     return;
   }
 
-  // Protocol rule: never slow fill deposits with blocked recipients; the deposit instead expires and is
-  // refunded to the depositor.
-  if (BLOCKED_ADDRESSES.some((blockedAddress) => blockedAddress.eq(deposit.recipient))) {
-    return;
-  }
-
   const { destinationChainId, outputToken } = deposit;
   dict[destinationChainId] ??= {};
   dict[destinationChainId][outputToken.toBytes32()] ??= [];
@@ -539,7 +533,10 @@ export class BundleDataClient {
         ) &&
         // Cannot slow fill from or to a lite chain.
         !deposit.fromLiteChain &&
-        !deposit.toLiteChain
+        !deposit.toLiteChain &&
+        // Protocol rule: never slow fill deposits with blocked recipients. Checked here so that slow fill
+        // leaf creation and unexecutable-slow-fill excess accounting stay consistent.
+        !BLOCKED_ADDRESSES.some((blockedAddress) => blockedAddress.eq(deposit.recipient))
       );
     };
 


### PR DESCRIPTION
Fixes a real P1 from Codex review on #1487: the blocked-recipient check sat in `updateBundleSlowFills`, suppressing leaf creation (no destination-chain credit) but not the unexecutable-slow-fill excess accounting, which infers prior leaf creation via `_canCreateSlowFillLeaf`. A blocked-recipient deposit with a prior-bundle slow fill request that later expired or was fast-filled would be marked as an excess, debiting the destination spoke funds that were never sent.

Moving the check into `_canCreateSlowFillLeaf` — the shared predicate gating every `validatedBundleSlowFills` push and both excess sites — keeps leaf creation and excess accounting consistent. The `updateBundleSlowFills` guard is removed (redundant).

The second Codex P1 (Arweave bypass) is not a real concern: dispute validation never loads Arweave data (`Dataworker#validate` leaves `loadDataFromArweave` false), only the executor's post-liveness re-validation does, and validated bundles are permissionlessly executable regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011AwNYDz6oYJB4n41QNw3kT