### PR TITLE
fix(svm): validate fill-status event ownership

### DIFF
--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -43,6 +43,7 @@ import winston from "winston";
 import { arrayify } from "ethers/lib/utils";
 import { CHAIN_IDs, TOKEN_SYMBOLS_MAP } from "../../constants";
 import {
+  ConvertedRelayData,
   DepositWithBlock,
   FillStatus,
   FillWithBlock,
@@ -64,6 +65,7 @@ import {
   isUnsafeDepositId,
   keccak256,
   mapAsync,
+  toAddressType,
   unpackDepositEvent,
   unpackFillEvent,
 } from "../../utils";
@@ -87,7 +89,14 @@ import {
 } from "./";
 import { SvmCpiEventsClient } from "./eventsClient";
 import { SVM_LONG_TERM_STORAGE_SLOT_SKIPPED, SVM_SLOT_SKIPPED, isSolanaError } from "./provider";
-import { AttestedCCTPMessage, SVMEventNames, SVMProvider, LatestBlockhash, SolanaTransaction } from "./types";
+import {
+  AttestedCCTPMessage,
+  EventWithData,
+  SVMEventNames,
+  SVMProvider,
+  LatestBlockhash,
+  SolanaTransaction,
+} from "./types";
 import {
   getEmergencyDeleteRootBundleRootBundleId,
   getNearestSlotTime,
@@ -352,7 +361,7 @@ export async function relayFillStatus(
   }
 
   // If status couldn't be determined from the PDA, or if a specific slot was requested, reconstruct from events.
-  return resolveFillStatusFromPdaEvents(fillStatusPda, toSlot, svmEventsClient);
+  return resolveFillStatusFromPdaEvents(fillStatusPda, destinationChainId, toSlot, svmEventsClient);
 }
 
 /**
@@ -427,7 +436,12 @@ export async function fillStatusArray(
       chunk.map(async (missingIndex) => {
         return {
           index: missingIndex,
-          fillStatus: await resolveFillStatusFromPdaEvents(fillStatusPdas[missingIndex], toSlot, svmEventsClient),
+          fillStatus: await resolveFillStatusFromPdaEvents(
+            fillStatusPdas[missingIndex],
+            destinationChainId,
+            toSlot,
+            svmEventsClient
+          ),
         };
       })
     );
@@ -469,12 +483,13 @@ export async function findFillEvent(
   const fillStatusPda = await getFillStatusPda(programId, relayData, destinationChainId);
 
   // Get fill events from fillStatus PDA
-  const fillEvents = await svmEventsClient.queryDerivedAddressEvents(
+  const fillEvents = await queryFillStatusEvents(
     SVMEventNames.FilledRelay,
     fillStatusPda,
+    destinationChainId,
+    svmEventsClient,
     BigInt(fromSlot),
-    BigInt(toSlot),
-    { limit: 10 }
+    BigInt(toSlot)
   );
   assert(fillEvents.length <= 1, `Expected at most one fill event for ${fillStatusPda}, got ${fillEvents.length}`);
 
@@ -1002,16 +1017,17 @@ export function getRelayDataHash(relayData: RelayData & { messageHash: string },
 
 async function resolveFillStatusFromPdaEvents(
   fillStatusPda: Address,
+  destinationChainId: number,
   toSlot: bigint,
   svmEventsClient: SvmCpiEventsClient
 ): Promise<FillStatus> {
   // Get fill and requested slow fill events from fillStatus PDA
-  const eventsToQuery = [SVMEventNames.FilledRelay, SVMEventNames.RequestedSlowFill];
+  const eventsToQuery = [SVMEventNames.FilledRelay, SVMEventNames.RequestedSlowFill] as const;
   const relevantEvents = (
     await Promise.all(
       eventsToQuery.map((eventName) =>
         // PDAs should have only a few events, requesting up to 10 should be enough.
-        svmEventsClient.queryDerivedAddressEvents(eventName, fillStatusPda, undefined, toSlot, { limit: 10 })
+        queryFillStatusEvents(eventName, fillStatusPda, destinationChainId, svmEventsClient, undefined, toSlot)
       )
     )
   ).flat();
@@ -1036,6 +1052,43 @@ async function resolveFillStatusFromPdaEvents(
     default:
       throw new Error(`Unexpected event name: ${fillStatusEvent!.name}`);
   }
+}
+
+type FillStatusEventRelayData = Omit<ConvertedRelayData, "message"> & { messageHash: string };
+
+/**
+ * A signature lookup only proves that a transaction mentioned the fill-status PDA. Recompute the
+ * PDA from each decoded event so an unrelated fill event in that transaction cannot be attributed
+ * to the queried relay.
+ */
+async function queryFillStatusEvents(
+  eventName: SVMEventNames.FilledRelay | SVMEventNames.RequestedSlowFill,
+  fillStatusPda: Address,
+  destinationChainId: number,
+  svmEventsClient: SvmCpiEventsClient,
+  fromSlot?: bigint,
+  toSlot?: bigint
+): Promise<EventWithData[]> {
+  const events = await svmEventsClient.queryDerivedAddressEvents(eventName, fillStatusPda, fromSlot, toSlot, {
+    limit: 10,
+  });
+  const programId = svmEventsClient.getProgramAddress();
+  const matches = await Promise.all(
+    events.map(async (event) => {
+      const rawRelayData = unwrapEventData<FillStatusEventRelayData>(event.data, ["depositId", "inputAmount"]);
+      const relayData = {
+        ...rawRelayData,
+        depositor: toAddressType(rawRelayData.depositor, rawRelayData.originChainId),
+        recipient: toAddressType(rawRelayData.recipient, destinationChainId),
+        inputToken: toAddressType(rawRelayData.inputToken, rawRelayData.originChainId),
+        outputToken: toAddressType(rawRelayData.outputToken, destinationChainId),
+        exclusiveRelayer: toAddressType(rawRelayData.exclusiveRelayer, destinationChainId),
+        message: "0x",
+      } satisfies RelayDataWithMessageHash;
+      return (await getFillStatusPda(programId, relayData, destinationChainId)) === fillStatusPda;
+    })
+  );
+  return events.filter((_, index) => matches[index]);
 }
 
 /**

--- a/test/Solana.SvmFillStatusEvents.unit.test.ts
+++ b/test/Solana.SvmFillStatusEvents.unit.test.ts
@@ -1,0 +1,102 @@
+import { CHAIN_IDs } from "@across-protocol/constants";
+import { SvmSpokeClient } from "@across-protocol/contracts";
+import { address } from "@solana/kit";
+import { expect } from "chai";
+import { SVM_DEFAULT_ADDRESS, SVMEventNames, findFillEvent, numberToU8a32, relayFillStatus } from "../src/arch/svm";
+import { MockSvmCpiEventsClient } from "../src/clients/mocks";
+import { FillStatus } from "../src/interfaces";
+import { EvmAddress } from "../src/utils";
+import { createSpyLogger } from "./utils";
+import { formatRelayData } from "./utils/svm/utils";
+
+describe("SVM fill-status event lookup", () => {
+  it("ignores fill events for another relay in a transaction that mentions the queried PDA", async () => {
+    const programId = address(SvmSpokeClient.SVM_SPOKE_PROGRAM_ADDRESS);
+    const eventsClient = new MockSvmCpiEventsClient(programId, CHAIN_IDs.SOLANA);
+    const targetRelayData: SvmSpokeClient.RelayDataArgs = {
+      depositor: address(EvmAddress.from("0x1111111111111111111111111111111111111111").toBase58()),
+      recipient: address("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"),
+      exclusiveRelayer: SVM_DEFAULT_ADDRESS,
+      inputToken: address(EvmAddress.from("0x2222222222222222222222222222222222222222").toBase58()),
+      outputToken: address("So11111111111111111111111111111111111111112"),
+      inputAmount: numberToU8a32(100),
+      outputAmount: 90,
+      originChainId: CHAIN_IDs.MAINNET,
+      depositId: numberToU8a32(1),
+      fillDeadline: 2_000_000_000,
+      exclusivityDeadline: 0,
+      message: new Uint8Array(),
+    };
+    const unrelatedRelayData = { ...targetRelayData, depositId: numberToU8a32(2) };
+    const messageHash = new Uint8Array(32);
+
+    const unrelatedFillEvent = eventsClient.fillRelay({
+      ...unrelatedRelayData,
+      outputAmount: BigInt(unrelatedRelayData.outputAmount),
+      messageHash,
+      slot: 1n,
+    } as unknown as SvmSpokeClient.FilledRelay & { slot: bigint });
+    const unrelatedSlowFillEvent = eventsClient.requestSlowFill({
+      ...unrelatedRelayData,
+      outputAmount: BigInt(unrelatedRelayData.outputAmount),
+      messageHash,
+      slot: 2n,
+    } as unknown as SvmSpokeClient.RequestedSlowFill & { slot: bigint });
+    const targetSlowFillEvent = eventsClient.requestSlowFill({
+      ...targetRelayData,
+      outputAmount: BigInt(targetRelayData.outputAmount),
+      messageHash,
+      slot: 3n,
+    } as unknown as SvmSpokeClient.RequestedSlowFill & { slot: bigint });
+    const targetFillEvent = eventsClient.fillRelay({
+      ...targetRelayData,
+      outputAmount: BigInt(targetRelayData.outputAmount),
+      messageHash,
+      slot: 4n,
+    } as unknown as SvmSpokeClient.FilledRelay & { slot: bigint });
+
+    eventsClient.queryDerivedAddressEvents = (eventName, _derivedAddress, fromSlot, toSlot) => {
+      const events =
+        eventName === SVMEventNames.FilledRelay
+          ? [unrelatedFillEvent, targetFillEvent]
+          : [unrelatedSlowFillEvent, targetSlowFillEvent];
+      return Promise.resolve(
+        events.filter((event) => (!fromSlot || event.slot >= fromSlot) && (!toSlot || event.slot <= toSlot))
+      );
+    };
+
+    const relayData = formatRelayData(targetRelayData);
+    const fill = await findFillEvent(relayData, CHAIN_IDs.SOLANA, eventsClient, 0, 10);
+    expect(fill?.depositId.eq(relayData.depositId)).to.be.true;
+
+    const statusBeforeTargetEvents = await relayFillStatus(
+      programId,
+      relayData,
+      CHAIN_IDs.SOLANA,
+      eventsClient,
+      createSpyLogger().spyLogger,
+      2
+    );
+    expect(statusBeforeTargetEvents).to.equal(FillStatus.Unfilled);
+
+    const requestedSlowFillStatus = await relayFillStatus(
+      programId,
+      relayData,
+      CHAIN_IDs.SOLANA,
+      eventsClient,
+      createSpyLogger().spyLogger,
+      3
+    );
+    expect(requestedSlowFillStatus).to.equal(FillStatus.RequestedSlowFill);
+
+    const filledStatus = await relayFillStatus(
+      programId,
+      relayData,
+      CHAIN_IDs.SOLANA,
+      eventsClient,
+      createSpyLogger().spyLogger,
+      4
+    );
+    expect(filledStatus).to.equal(FillStatus.Filled);
+  });
+});


### PR DESCRIPTION
## Summary

Recompute the fill-status PDA from each candidate `FilledRelay` and `RequestedSlowFill` event before using it for fill lookup or status reconstruction. This prevents an unrelated event from a transaction that merely mentions the queried PDA from being attributed to that relay.

## Test plan

- `yarn hardhat test test/Solana.SvmFillStatusEvents.unit.test.ts test/Solana.SvmCpiEventsClient.ForgedEvent.unit.test.ts`
- `yarn build:types`
- Targeted ESLint and Prettier checks