### PR TITLE
fix(svm): preserve event log indices

### DIFF
--- a/src/arch/svm/SpokeUtils.ts
+++ b/src/arch/svm/SpokeUtils.ts
@@ -288,7 +288,7 @@ export async function findDeposit(
   }
 
   const txnIndex = 0;
-  const logIndex = 0;
+  const logIndex = depositEvent.logIndex ?? 0;
   const blockNumber = Number(depositEvent.slot);
   const txnRef = depositEvent.signature.toString();
 
@@ -483,7 +483,13 @@ export async function findFillEvent(
     return;
   }
 
-  const rawFill = unwrapEventData<SortableEvent>(rawEvent.data, ["depositId", "inputAmount"]);
+  const rawFill = {
+    ...unwrapEventData(rawEvent.data, ["depositId", "inputAmount"]),
+    blockNumber: Number(rawEvent.slot),
+    txnRef: rawEvent.signature,
+    txnIndex: 0,
+    logIndex: rawEvent.logIndex ?? 0,
+  } satisfies SortableEvent;
   const fill = unpackFillEvent(rawFill, destinationChainId);
   return fill satisfies FillWithBlock;
 }

--- a/src/arch/svm/eventsClient.ts
+++ b/src/arch/svm/eventsClient.ts
@@ -205,9 +205,11 @@ export class SvmCpiEventsClient {
    * @param txResult - The transaction result.
    * @returns A promise that resolves to an array of events with their data and name.
    */
-  private processEventFromTx(txResult?: GetTransactionReturnType): { program: Address; data: unknown; name: string }[] {
+  private processEventFromTx(
+    txResult?: GetTransactionReturnType
+  ): { program: Address; data: unknown; name: string; logIndex: number }[] {
     if (!isDefined(txResult) || isDefined(txResult.meta?.err)) return [];
-    const events: { program: Address; data: unknown; name: string }[] = [];
+    const events: { program: Address; data: unknown; name: string; logIndex: number }[] = [];
 
     const accountKeys = txResult.transaction.message.accountKeys;
     const messageAccountKeys = [...accountKeys];
@@ -216,8 +218,10 @@ export class SvmCpiEventsClient {
     messageAccountKeys.push(...(txResult?.meta?.loadedAddresses?.writable ?? []));
     messageAccountKeys.push(...(txResult?.meta?.loadedAddresses?.readonly ?? []));
 
+    let innerInstructionIndex = 0;
     for (const ixBlock of txResult.meta?.innerInstructions ?? []) {
       for (const ix of ixBlock.instructions) {
+        const logIndex = innerInstructionIndex++;
         const ixProgramId = messageAccountKeys[ix.programIdIndex];
         const singleIxAccount = ix.accounts.length === 1 ? messageAccountKeys[ix.accounts[0]] : undefined;
         if (
@@ -240,7 +244,7 @@ export class SvmCpiEventsClient {
           // Skip the 8-byte Anchor event discriminator and decode the remaining event payload.
           const eventData = Buffer.from(ixData.slice(8)).toString("base64");
           const { name, data } = decodeEvent(this.idl, eventData);
-          events.push({ program: this.programAddress, name, data });
+          events.push({ program: this.programAddress, name, data, logIndex });
         }
       }
     }
@@ -303,7 +307,7 @@ export class SvmCpiEventsClient {
         blockNumber: Number(txDetails.slot),
         txnIndex: 0,
         txnRef: txSignature,
-        logIndex: 0,
+        logIndex: event.logIndex,
       } satisfies DepositEventFromSignature;
     });
   }
@@ -362,7 +366,7 @@ export class SvmCpiEventsClient {
         blockNumber: Number(txDetails.slot),
         txnRef: txSignature,
         txnIndex: 0,
-        logIndex: 0,
+        logIndex: event.logIndex,
         destinationChainId,
       } satisfies FillEventFromSignature;
     });

--- a/src/arch/svm/types.ts
+++ b/src/arch/svm/types.ts
@@ -62,6 +62,7 @@ export type EventWithData = {
   blockTime: UnixTimestamp | null;
   signature: Signature;
   slot: bigint;
+  logIndex?: number;
   name: string;
   data: unknown;
   program: Address;

--- a/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
+++ b/src/clients/SpokePoolClient/SVMSpokePoolClient.ts
@@ -159,7 +159,7 @@ export class SVMSpokePoolClient extends SpokePoolClient {
             txnRef: event.signature,
             blockNumber: Number(event.slot),
             txnIndex: 0,
-            logIndex: 0,
+            logIndex: event.logIndex ?? 0,
           })
         );
       }),

--- a/src/clients/mocks/MockSvmCpiEventsClient.ts
+++ b/src/clients/mocks/MockSvmCpiEventsClient.ts
@@ -219,6 +219,7 @@ export class MockSvmCpiEventsClient extends SvmCpiEventsClient {
           )
         )
       ),
+      logIndex: 0,
       program: address,
       data: args,
       confirmationStatus: "finalized",

--- a/src/clients/mocks/MockSvmSpokePoolClient.ts
+++ b/src/clients/mocks/MockSvmSpokePoolClient.ts
@@ -79,7 +79,7 @@ export class MockSvmSpokePoolClient extends SVMSpokePoolClient {
           txnRef: event.signature,
           blockNumber: Number(event.slot),
           txnIndex: 0,
-          logIndex: 0,
+          logIndex: event.logIndex ?? 0,
         };
       })
     );

--- a/test/SVMSpokePoolClient.fills.ts
+++ b/test/SVMSpokePoolClient.fills.ts
@@ -111,6 +111,10 @@ describe("SVMSpokePoolClient: Fills", function () {
     fill = fill!;
 
     expect(fill.depositId).to.equal(BigNumber.from(relayData.depositId));
+    expect(fill.blockNumber).to.be.greaterThan(0);
+    expect(fill.txnRef).to.be.a("string").and.not.be.empty;
+    expect(fill.txnIndex).to.equal(0);
+    expect(fill.logIndex).to.be.at.least(0);
 
     // Looking for a fill can return undefined:
     const missingFill = await findFillEvent(

--- a/test/Solana.SvmCpiEventsClient.ForgedEvent.unit.test.ts
+++ b/test/Solana.SvmCpiEventsClient.ForgedEvent.unit.test.ts
@@ -1,4 +1,6 @@
 import { SvmSpokeIdl } from "@across-protocol/contracts";
+import { CHAIN_IDs } from "@across-protocol/constants";
+import { signature } from "@solana/kit";
 import { expect } from "chai";
 import bs58 from "bs58";
 import { SvmCpiEventsClient } from "../src/arch/svm";
@@ -43,7 +45,7 @@ describe("SvmCpiEventsClient (forged event rejection)", () => {
   // Access the private members exercised by this test without widening to `any`.
   let internal: {
     programEventAuthority: string;
-    processEventFromTx(txResult: unknown): { name: string }[];
+    processEventFromTx(txResult: unknown): { name: string; logIndex: number }[];
   };
 
   before(async () => {
@@ -78,6 +80,48 @@ describe("SvmCpiEventsClient (forged event rejection)", () => {
   it("decodes a genuine emitted event (Anchor event discriminator prefix)", () => {
     const events = internal.processEventFromTx(makeTx(ANCHOR_EVENT_DISCRIMINATOR));
     expect(events.map((e) => e.name)).to.deep.equal(["FundsDeposited"]);
+  });
+
+  it("assigns distinct stable indices to multiple events in one transaction", () => {
+    const tx = makeTx(ANCHOR_EVENT_DISCRIMINATOR);
+    const eventInstruction = tx.meta.innerInstructions[0].instructions[0];
+    tx.meta.innerInstructions[0].instructions.push(
+      {
+        ...eventInstruction,
+        data: bs58.encode(Buffer.concat([GET_UNSAFE_DEPOSIT_ID_DISCRIMINATOR, eventDiscriminatorAndBody])),
+      },
+      { ...eventInstruction }
+    );
+
+    const events = internal.processEventFromTx(tx);
+
+    expect(events.map(({ name, logIndex }) => ({ name, logIndex }))).to.deep.equal([
+      { name: "FundsDeposited", logIndex: 0 },
+      { name: "FundsDeposited", logIndex: 2 },
+    ]);
+  });
+
+  it("preserves event indices in the deposit helper for a transaction signature", async () => {
+    const tx = {
+      ...makeTx(ANCHOR_EVENT_DISCRIMINATOR),
+      blockTime: 1n,
+      slot: 1n,
+    };
+    tx.meta.innerInstructions[0].instructions.push({ ...tx.meta.innerInstructions[0].instructions[0] });
+    const rpc = {
+      getTransaction: () => ({ send: () => Promise.resolve(tx) }),
+    } as unknown as Parameters<typeof SvmCpiEventsClient.createFor>[0];
+    const helperClient = await SvmCpiEventsClient.createFor(rpc, PROGRAM, SvmSpokeIdl);
+    const txSignature = signature(
+      "3rLkGVvyYL2LTuDzbo8MBYNwjhYaKo1pEoqd24HCPQJEhNgyVnKZeNFsFrStKYY6cVizBfLpa2RMiB8dxHPzGHMV"
+    );
+
+    const events = await helperClient.getDepositEventsFromSignature(CHAIN_IDs.SOLANA, txSignature);
+
+    expect(events?.map(({ txnIndex, logIndex }) => ({ txnIndex, logIndex }))).to.deep.equal([
+      { txnIndex: 0, logIndex: 0 },
+      { txnIndex: 0, logIndex: 1 },
+    ]);
   });
 
   it("ignores a forged event emitted via an arbitrary CPI into the program", () => {

--- a/test/SvmSpokePoolClient.ts
+++ b/test/SvmSpokePoolClient.ts
@@ -65,4 +65,20 @@ describe("SvmSpokePoolClient: Event fetching", function () {
       expect(fillEvent.recipient.eq(toAddressType(expectedFill.data.recipient, CHAIN_IDs.SOLANA))).to.be.true;
     });
   });
+
+  it("preserves distinct log indices for multiple events in one transaction", async function () {
+    const spokePoolClient = new MockSvmSpokePoolClient(logger, CHAIN_IDs.SOLANA_DEVNET);
+    const fillOverrides = { originChainId: BigInt(CHAIN_IDs.MAINNET) } as SvmSpokeClient.FilledRelay;
+    const firstFill = spokePoolClient.fillRelay(fillOverrides);
+    const secondFill = spokePoolClient.fillRelay(fillOverrides);
+
+    secondFill.signature = firstFill.signature;
+    secondFill.slot = firstFill.slot;
+    firstFill.logIndex = 0;
+    secondFill.logIndex = 1;
+
+    await spokePoolClient.update([SVMEventNames.FilledRelay]);
+
+    expect(spokePoolClient.getFills().map(({ logIndex }) => logIndex)).to.deep.equal([0, 1]);
+  });
 });


### PR DESCRIPTION
## Summary

Assign each decoded SVM event its deterministic inner-instruction ordinal and propagate it as `logIndex` through event clients and helpers. This prevents multiple same-type events in one transaction from colliding during downstream deduplication while retaining compatibility with custom clients that omit the new metadata.

## Test plan

- `yarn hardhat test test/Solana.SvmCpiEventsClient.ForgedEvent.unit.test.ts test/SvmSpokePoolClient.ts`
- `yarn build:types`
- Targeted ESLint and Prettier checks