### PR TITLE
feat(HubPoolClient): expose proposed poolRebalanceLeafCount on PendingRootBundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.4.13",
+  "version": "4.4.14",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -1153,6 +1153,7 @@ export class HubPoolClient extends BaseAbstractClient {
           relayerRefundRoot: pendingRootBundleProposal.relayerRefundRoot,
           slowRelayRoot: pendingRootBundleProposal.slowRelayRoot,
           proposer: pendingRootBundleProposal.proposer,
+          poolRebalanceLeafCount: mostRecentProposedRootBundle.poolRebalanceLeafCount,
           unclaimedPoolRebalanceLeafCount: pendingRootBundleProposal.unclaimedPoolRebalanceLeafCount,
           challengePeriodEndTimestamp: pendingRootBundleProposal.challengePeriodEndTimestamp,
           bundleEvaluationBlockNumbers: mostRecentProposedRootBundle.bundleEvaluationBlockNumbers.map(

--- a/src/clients/mocks/MockHubPoolClient.ts
+++ b/src/clients/mocks/MockHubPoolClient.ts
@@ -12,6 +12,7 @@ const emptyRootBundle: PendingRootBundle = {
   relayerRefundRoot: "",
   slowRelayRoot: "",
   proposer: EvmAddress.from(ZERO_ADDRESS),
+  poolRebalanceLeafCount: 0,
   unclaimedPoolRebalanceLeafCount: 0,
   challengePeriodEndTimestamp: 0,
   bundleEvaluationBlockNumbers: [],

--- a/src/interfaces/HubPool.ts
+++ b/src/interfaces/HubPool.ts
@@ -114,6 +114,8 @@ export interface PendingRootBundle {
   relayerRefundRoot: string;
   slowRelayRoot: string;
   proposer: EvmAddress;
+  // Leaf count committed at proposal time. Unlike unclaimedPoolRebalanceLeafCount, this does not decrement as leaves execute.
+  poolRebalanceLeafCount: number;
   unclaimedPoolRebalanceLeafCount: number;
   challengePeriodEndTimestamp: number;
   bundleEvaluationBlockNumbers: number[];

--- a/test/HubPoolClient.RootBundleEvents.ts
+++ b/test/HubPoolClient.RootBundleEvents.ts
@@ -92,6 +92,7 @@ describe("HubPoolClient: RootBundle Events", function () {
         poolRebalanceRoot: tree.getHexRoot(),
         relayerRefundRoot: constants.mockTreeRoot,
         slowRelayRoot: constants.mockTreeRoot,
+        poolRebalanceLeafCount: 2,
         unclaimedPoolRebalanceLeafCount: 2,
         challengePeriodEndTimestamp: proposeTime + liveness,
         bundleEvaluationBlockNumbers: [11, 22],


### PR DESCRIPTION
`PendingRootBundle` only carried `unclaimedPoolRebalanceLeafCount`, the live on-chain counter that decrements as leaves execute. Consumers that need the leaf count the proposer originally committed had to re-resolve it from the `ProposeRootBundle` events.

Surface it directly: add `poolRebalanceLeafCount` to the interface and populate it in `HubPoolClient` from the same `ProposeRootBundle` event the pending bundle is already built from (`mostRecentProposedRootBundle`) — no extra lookup, and it maps to the latest proposal by event log order, so propose→dispute→propose resolves to the live proposal.

Enables `across-protocol/relayer#3610` to read `pendingRootBundle.poolRebalanceLeafCount` and drop the explicit `ProposedRootBundle` parameter threaded through `validateRootBundle`.

Verified: full `build:{cjs,esm,types}` clean, `HubPoolClient.*` suites green (18 passing), lint/prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)