### PR TITLE
fix(coingecko): route symbol price lookups to the Pro host

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.4.14",
+  "version": "4.4.15",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/src/coingecko/Coingecko.ts
+++ b/src/coingecko/Coingecko.ts
@@ -303,7 +303,8 @@ export class Coingecko {
       const result = await this.call<Record<string, CGTokenPrice>>(
         `simple/price?symbols=${encodeURIComponent(symbol)}&vs_currencies=${encodeURIComponent(
           currency
-        )}&include_last_updated_at=true`
+        )}&include_last_updated_at=true`,
+        { proOnly: true }
       );
       const cgPrice = result?.[symbol.toLowerCase()] || result?.[symbol.toUpperCase()];
       if (cgPrice === undefined || !cgPrice?.[currency]) {
@@ -391,13 +392,20 @@ export class Coingecko {
     return this.call("asset_platforms");
   }
 
-  call<T>(path: string): Promise<T> {
+  call<T>(path: string, opts: { proOnly?: boolean } = {}): Promise<T> {
     const sendRequest = async () => {
       const { proHost } = this;
 
       // If no pro api key, only send basic request:
       if (this.apiKey === undefined) {
         return await this._callBasic<T>(path);
+      }
+
+      // The basic host answers symbol lookups with an empty 200 (only the Pro
+      // host resolves them), so the catch-based fallback never fires. When a
+      // key is set, go to Pro directly for these paths.
+      if (opts.proOnly) {
+        return await this._callPro<T>(path);
       }
 
       // If pro api key, try basic and use pro as fallback.

--- a/test/Coingecko.test.ts
+++ b/test/Coingecko.test.ts
@@ -6,8 +6,8 @@ import { expect, sinon } from "./utils";
 
 // Bypass the singleton + protected constructor so each test gets isolated state.
 class TestGecko extends Coingecko {
-  public constructor(host: string, logger: winston.Logger) {
-    super(host, host, logger);
+  public constructor(host: string, logger: winston.Logger, proHost = host, apiKey?: string) {
+    super(host, proHost, logger, apiKey);
   }
 }
 
@@ -112,6 +112,36 @@ describe("Coingecko", () => {
       fetchStub.resolves(jsonResponse({}));
       await cg.getCurrentPriceBySymbol("BTC/USD", "usd").catch(() => undefined);
       expect(fetchStub.firstCall.args[0] as string).to.include("symbols=BTC%2FUSD");
+    });
+  });
+
+  describe("Pro host routing (getCurrentPriceBySymbol)", () => {
+    // Regression: the basic host answers symbol lookups with an empty 200, so
+    // the catch-based fallback never fired and symbol prices always 404'd even
+    // with a Pro key configured. Symbol lookups must go straight to Pro.
+    const BASIC_HOST = "https://basic.example";
+    const PRO_HOST = "https://pro.example";
+
+    it("routes to the Pro host when an API key is set", async () => {
+      const gecko = new TestGecko(BASIC_HOST, silentLogger, PRO_HOST, "test-pro-key");
+      fetchStub.resolves(jsonResponse({ usdc: { usd: 0.9999, last_updated_at: msToS(Date.now()) } }));
+
+      const [, price] = await gecko.getCurrentPriceBySymbol("USDC", "usd");
+
+      expect(price).to.equal(0.9999);
+      expect(fetchStub.calledOnce).to.equal(true);
+      const calledUrl = fetchStub.firstCall.args[0] as string;
+      expect(calledUrl.startsWith(PRO_HOST)).to.equal(true);
+    });
+
+    it("uses the basic host when no API key is set", async () => {
+      const gecko = new TestGecko(BASIC_HOST, silentLogger, PRO_HOST);
+      fetchStub.resolves(jsonResponse({ usdc: { usd: 0.9999, last_updated_at: msToS(Date.now()) } }));
+
+      await gecko.getCurrentPriceBySymbol("USDC", "usd");
+
+      const calledUrl = fetchStub.firstCall.args[0] as string;
+      expect(calledUrl.startsWith(BASIC_HOST)).to.equal(true);
     });
   });
 


### PR DESCRIPTION
## Problem

Price lookups by **symbol** (e.g. `GET /api/coingecko?symbol=USDC`) started failing with `400 "No price found for symbol 'USDC'."`, while lookups by `l1Token` / `tokenAddress` kept working. Reproduced live in production, and it's what's currently reddening the `e2e-api-tests` (`e2e-api/coingecko.test.ts`) in [quote-api#2749](https://github.com/across-protocol/quote-api/pull/2749) and on `quote-api` `master`.

## Root cause

`Coingecko.getCurrentPriceBySymbol()` calls `simple/price?symbols=<sym>&vs_currencies=<cur>`.

- The **basic host** (`api.coingecko.com`) answers that request with `HTTP 200` and an **empty body** `{}` — it does not resolve symbol lookups. Only the **Pro host** (`pro-api.coingecko.com`) returns a price. (CoinGecko's own docs list the Pro host as the base URL for this endpoint.)
- `call()` only falls back to the Pro host when the basic request **throws**. A `200`-with-empty-body isn't an error, so the fallback never fired — symbol lookups never reached Pro even with `REACT_APP_COINGECKO_PRO_API_KEY` configured.
- Empty result → `CoingeckoPriceNotFoundError` → quote-api surfaces it as `400`.

Address-based lookups use `simple/token_price/...` / `simple/price?ids=...`, which the basic host *does* serve — which is exactly why only the symbol path broke.

Verified directly against CoinGecko:

| Request | Result |
|---|---|
| basic host + `symbols=USDC` | `{}` (empty 200) |
| Pro host + key + `symbols=USDC` | `{"usdc":{"usd":0.99…}}` ✅ |
| basic host + `ids=usd-coin` | `{"usd-coin":{"usd":0.99…}}` ✅ |

## Fix

Add an opt-in `proOnly` flag to `call()` and set it on the symbol lookup, so symbol requests go straight to the Pro host when an API key is configured. Keyless behavior is unchanged (still basic host), and all other endpoints are untouched.

## Tests

- `routes to the Pro host when an API key is set`
- `uses the basic host when no API key is set`

Full `Coingecko` suite (36 tests) + lint pass locally.

## Release

Version bumped to **4.4.15** in this PR, ready to tag/release on merge.

## Follow-up

After release, bump `@across-protocol/sdk` in `quote-api` (currently `4.4.9`) to `4.4.15` to pick this up and unblock the coingecko e2e tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

