### PR TITLE
fix(quicknode): Append Avalanche C-Chain path by default

### DIFF
--- a/src/providers/quicknode.ts
+++ b/src/providers/quicknode.ts
@@ -1,4 +1,5 @@
 import { CHAIN_IDs, MAINNET_CHAIN_IDs as _MAINNET_CHAIN_IDs, PUBLIC_NETWORKS } from "../constants";
+import { isDefined } from "../utils/TypeGuards";
 import { RPCTransport } from "./types";
 
 const SNOWFLAKES = {
@@ -14,7 +15,7 @@ const MAINNET_CHAIN_IDs = Object.values(_MAINNET_CHAIN_IDs).map(Number);
 
 /* Some chains nest their EVM RPC beneath a chain-specific path (i.e. the avalanchego API structure). */
 const PATHS: { [chainId: number]: { [transport in RPCTransport]: string } } = {
-  [CHAIN_IDs.AVALANCHE]: { https: "/ext/bc/C/rpc", wss: "/ext/bc/C/ws" },
+  [CHAIN_IDs.AVALANCHE]: { https: "ext/bc/C/rpc", wss: "ext/bc/C/ws" },
 };
 
 export function getURL(chainId: number, apiKey: string, transport: RPCTransport): string {
@@ -41,7 +42,9 @@ export function getURL(chainId: number, apiKey: string, transport: RPCTransport)
   }
   chain = chain.toLowerCase().replace(" ", "-");
 
-  const path = PATHS[chainId]?.[transport] ?? "";
+  const path = PATHS[chainId]?.[transport];
 
-  return `${transport}://${prefix}.${chain}.${domain}/${apiKey}${path}`;
+  return isDefined(path)
+    ? `${transport}://${prefix}.${chain}.${domain}/${apiKey}/${path}`
+    : `${transport}://${prefix}.${chain}.${domain}/${apiKey}`;
 }

--- a/src/providers/quicknode.ts
+++ b/src/providers/quicknode.ts
@@ -12,6 +12,11 @@ const SNOWFLAKES = {
 const SNOWFLAKE_CHAIN_IDs = Object.keys(SNOWFLAKES).map(Number);
 const MAINNET_CHAIN_IDs = Object.values(_MAINNET_CHAIN_IDs).map(Number);
 
+/* Some chains nest their EVM RPC beneath a chain-specific path (i.e. the avalanchego API structure). */
+const PATHS: { [chainId: number]: { [transport in RPCTransport]: string } } = {
+  [CHAIN_IDs.AVALANCHE]: { https: "/ext/bc/C/rpc", wss: "/ext/bc/C/ws" },
+};
+
 export function getURL(chainId: number, apiKey: string, transport: RPCTransport): string {
   const envVar = "RPC_PROVIDER_KEY_QUICKNODE_PREFIX";
   const prefix = process.env[`${envVar}_${chainId}`] ?? process.env[envVar];
@@ -36,5 +41,7 @@ export function getURL(chainId: number, apiKey: string, transport: RPCTransport)
   }
   chain = chain.toLowerCase().replace(" ", "-");
 
-  return `${transport}://${prefix}.${chain}.${domain}/${apiKey}`;
+  const path = PATHS[chainId]?.[transport] ?? "";
+
+  return `${transport}://${prefix}.${chain}.${domain}/${apiKey}${path}`;
 }

--- a/test/ProviderUrls.test.ts
+++ b/test/ProviderUrls.test.ts
@@ -1,0 +1,39 @@
+import { CHAIN_IDs } from "../src/constants";
+import { getURL } from "../src/providers/quicknode";
+import { expect } from "./utils";
+
+describe("Provider URL generation", () => {
+  describe("quicknode.getURL", () => {
+    const envVar = "RPC_PROVIDER_KEY_QUICKNODE_PREFIX";
+    const prefix = "test-prefix";
+    const apiKey = "test-key";
+    let previous: string | undefined;
+
+    before(() => {
+      previous = process.env[envVar];
+      process.env[envVar] = prefix;
+    });
+
+    after(() => {
+      if (previous === undefined) {
+        delete process.env[envVar];
+      } else {
+        process.env[envVar] = previous;
+      }
+    });
+
+    it("appends the Avalanche C-Chain path", () => {
+      expect(getURL(CHAIN_IDs.AVALANCHE, apiKey, "https")).to.equal(
+        `https://${prefix}.avalanche-mainnet.quiknode.pro/${apiKey}/ext/bc/C/rpc`
+      );
+      expect(getURL(CHAIN_IDs.AVALANCHE, apiKey, "wss")).to.equal(
+        `wss://${prefix}.avalanche-mainnet.quiknode.pro/${apiKey}/ext/bc/C/ws`
+      );
+    });
+
+    it("does not append a path for chains without one", () => {
+      expect(getURL(CHAIN_IDs.MAINNET, apiKey, "https")).to.equal(`https://${prefix}.quiknode.pro/${apiKey}`);
+      expect(getURL(CHAIN_IDs.OPTIMISM, apiKey, "https")).to.equal(`https://${prefix}.optimism.quiknode.pro/${apiKey}`);
+    });
+  });
+});


### PR DESCRIPTION
## Motivation

QuickNode serves the Avalanche C-Chain EVM RPC beneath the avalanchego API path: `/ext/bc/C/rpc` (HTTPS) and `/ext/bc/C/ws` (WSS). `quicknode.getURL()` currently emits the bare endpoint root (`https://<prefix>.avalanche-mainnet.quiknode.pro/<key>`), which QuickNode answers with **HTTP 404** for every request.

Any deployment relying on SDK URL generation for chain 43114 (i.e. without an explicit `RPC_PROVIDER_QUICKNODE_43114` override) therefore has a permanently dead QuickNode provider on Avalanche. This silently reduced quorum headroom for the Across dataworker (`across-config-15m.json` was missing the override) and was the root cause of the `zion-across-arweave` `Not enough providers agreed to meet quorum` crashes on 2026-07-27, once a Chainstack response-shape change removed the remaining 2-provider agreement. Companion config fix: UMAprotocol/bot-configs#4229.

## Change

- Add a `PATHS` map to `src/providers/quicknode.ts` appending the chain-specific API path per transport; populated for Avalanche (`https` → `/ext/bc/C/rpc`, `wss` → `/ext/bc/C/ws`). All other chains are unchanged.
- Unit tests covering the Avalanche path suffix (both transports) and the no-suffix behavior for mainnet/OP.

Explicit env URL overrides are unaffected — they bypass `getURL()` entirely, so configs that already carry the full URL keep working as before.

## Verification

- `POST eth_blockNumber` against the generated URL **without** the path → HTTP 404 "404 page not found"; **with** `/ext/bc/C/rpc` → valid result.
- WSS handshake against `/ext/bc/C/ws` → `HTTP/1.1 101 Switching Protocols`.
- `hardhat test test/ProviderUrls.test.ts` → 2 passing; eslint + prettier clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)