### PR TITLE
fix(quicknode): Append TRON and HyperEVM path suffixes by default

### DIFF
--- a/src/providers/quicknode.ts
+++ b/src/providers/quicknode.ts
@@ -13,9 +13,11 @@ const SNOWFLAKES = {
 const SNOWFLAKE_CHAIN_IDs = Object.keys(SNOWFLAKES).map(Number);
 const MAINNET_CHAIN_IDs = Object.values(_MAINNET_CHAIN_IDs).map(Number);
 
-/* Some chains nest their EVM RPC beneath a chain-specific path (i.e. the avalanchego API structure). */
-const PATHS: { [chainId: number]: { [transport in RPCTransport]: string } } = {
+/* Some chains nest their EVM RPC beneath a chain-specific path (avalanchego API structure, node flavors, ...). */
+const PATHS: { [chainId: number]: { [transport in RPCTransport]?: string } } = {
   [CHAIN_IDs.AVALANCHE]: { https: "ext/bc/C/rpc", wss: "ext/bc/C/ws" },
+  [CHAIN_IDs.HYPEREVM]: { https: "nanoreth", wss: "nanoreth" }, // Archive (nanoreth) flavor.
+  [CHAIN_IDs.TRON]: { https: "jsonrpc" }, // QuickNode TRON has no WebSocket support.
 };
 
 export function getURL(chainId: number, apiKey: string, transport: RPCTransport): string {

--- a/test/ProviderUrls.test.ts
+++ b/test/ProviderUrls.test.ts
@@ -31,6 +31,23 @@ describe("Provider URL generation", () => {
       );
     });
 
+    it("appends the HyperEVM nanoreth (archive) path", () => {
+      expect(getURL(CHAIN_IDs.HYPEREVM, apiKey, "https")).to.equal(
+        `https://${prefix}.hype-mainnet.quiknode.pro/${apiKey}/nanoreth`
+      );
+      expect(getURL(CHAIN_IDs.HYPEREVM, apiKey, "wss")).to.equal(
+        `wss://${prefix}.hype-mainnet.quiknode.pro/${apiKey}/nanoreth`
+      );
+    });
+
+    it("appends the TRON jsonrpc path (https only)", () => {
+      expect(getURL(CHAIN_IDs.TRON, apiKey, "https")).to.equal(
+        `https://${prefix}.tron-mainnet.quiknode.pro/${apiKey}/jsonrpc`
+      );
+      // QuickNode TRON has no WebSocket support; no path is defined for wss.
+      expect(getURL(CHAIN_IDs.TRON, apiKey, "wss")).to.equal(`wss://${prefix}.tron-mainnet.quiknode.pro/${apiKey}`);
+    });
+
     it("does not append a path for chains without one", () => {
       expect(getURL(CHAIN_IDs.MAINNET, apiKey, "https")).to.equal(`https://${prefix}.quiknode.pro/${apiKey}`);
       expect(getURL(CHAIN_IDs.OPTIMISM, apiKey, "https")).to.equal(`https://${prefix}.optimism.quiknode.pro/${apiKey}`);


### PR DESCRIPTION
**Stacked on #1496** (Avalanche C-Chain path) — extends the same `PATHS` approach to the other two chains where bot-configs carries QuickNode URL overrides. Will retarget to `master` once #1496 merges.

## Motivation

Same failure class as #1496: QuickNode nests some chains' RPC beneath a path suffix that `quicknode.getURL()` omits, so any deployment relying on SDK URL generation gets a degraded or dead provider. Audited every `RPC_PROVIDER_QUICKNODE_*` / `RPC_WS_PROVIDER_QUICKNODE_*` override in bot-configs and verified each candidate URL live against production endpoints:

| Chain | SDK default (bare root) | With suffix |
|---|---|---|
| TRON (728126428), https | **HTTP 404** on every request | `/jsonrpc` → serves chainId `0x2b6653dc` ✓ |
| TRON, wss | — | no WebSocket support (no upgrade; no WS override/provider-list exists in configs) |
| HyperEVM (999), https | answers `eth_chainId` but **404s all historical blocks** (non-archive) | `/nanoreth` → full archive (block `0x1` ✓) |
| HyperEVM, wss | **does not upgrade** (HTTP 200) | `/nanoreth` → `101 Switching Protocols` ✓ |

**Alchemy checked too, no changes needed:** `tron-mainnet.g.alchemy.com/v2/<key>` and `hyperliquid-mainnet.g.alchemy.com/v2/<key>` both serve the correct chain at the root over https, and the HyperEVM wss root upgrades correctly — consistent with bot-configs carrying no Alchemy overrides for these chains.

## Change

- `PATHS` gains `HYPEREVM: { https: "/nanoreth", wss: "/nanoreth" }` and `TRON: { https: "/jsonrpc" }`.
- Map type is now `Partial` per transport so TRON's missing WebSocket endpoint is expressible (wss falls back to no suffix, unchanged behavior).
- Unit tests for both chains and both transports, including the TRON-wss no-suffix case.

Explicit env URL overrides bypass `getURL()`, so existing configs keep working unchanged.

## Verification

- `hardhat test test/ProviderUrls.test.ts` → 4 passing; eslint + prettier clean.
- All URL claims in the table verified live 2026-07-27 ~13:5x UTC against the production QuickNode/Alchemy endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)