### PR TITLE
fix(HubPoolClient): handle zero-address SVM pool rebalance routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.4.15",
+  "version": "4.4.16",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -1027,9 +1027,10 @@ export class HubPoolClient extends BaseAbstractClient {
 
         // If the destination chain is SVM, then we need to convert the destination token to the Solana address.
         // This is because the HubPool contract only holds a truncated address for the USDC token and currently
-        // only supports USDC as a destination token for Solana.
+        // only supports USDC as a destination token for Solana. The zero address is exempt from this conversion:
+        // it disables the route and is stored as-is so that route lookups correctly resolve to undefined.
         let destinationToken: Address = EvmAddress.from(args.destinationToken);
-        if (chainIsSvm(args.destinationChainId)) {
+        if (chainIsSvm(args.destinationChainId) && !destinationToken.isZeroAddress()) {
           const usdcTokenSol = TOKEN_SYMBOLS_MAP.USDC.addresses[args.destinationChainId];
           const svmUsdc = SvmAddress.from(usdcTokenSol);
           if (destinationToken.truncateToBytes20() !== svmUsdc.truncateToBytes20()) {

--- a/test/HubPoolClient.DepositToDestinationToken.ts
+++ b/test/HubPoolClient.DepositToDestinationToken.ts
@@ -354,6 +354,36 @@ describe("HubPoolClient: Deposit to Destination Token", function () {
     await assertPromiseError(hubPoolClient.update(), "SVM USDC address mismatch for chain");
   });
 
+  it("correctly disables an SVM rebalancing route", async function () {
+    const svmChain = CHAIN_IDs.SOLANA;
+    const usdcTokenSol = TOKEN_SYMBOLS_MAP.USDC.addresses[svmChain];
+    const randomL1TokenAddr = EvmAddress.from(randomL1Token);
+
+    // Set up initial route with truncated SVM address.
+    const truncatedAddress = SvmAddress.from(usdcTokenSol).truncateToBytes20();
+    const e0 = hubPoolClient.setPoolRebalanceRoute(svmChain, randomL1Token, truncatedAddress);
+    await hubPoolClient.update();
+
+    expect(
+      hubPoolClient.getL2TokenForL1TokenAtBlock(randomL1TokenAddr, svmChain, e0.blockNumber)?.toBytes32()
+    ).to.equal(SvmAddress.from(usdcTokenSol).toBytes32());
+
+    // Disabling the route (zero destination token) must not throw on update.
+    const e1 = hubPoolClient.setPoolRebalanceRoute(svmChain, randomL1Token, zeroAddress);
+    await hubPoolClient.update();
+
+    // Route still resolves at the pre-disable block.
+    expect(
+      hubPoolClient.getL2TokenForL1TokenAtBlock(randomL1TokenAddr, svmChain, e0.blockNumber)?.toBytes32()
+    ).to.equal(SvmAddress.from(usdcTokenSol).toBytes32());
+
+    // Route is removed from the disable block onwards.
+    expect(hubPoolClient.getL2TokenForL1TokenAtBlock(randomL1TokenAddr, svmChain, e1.blockNumber)).to.be.undefined;
+    expect(hubPoolClient.getL1TokenForL2TokenAtBlock(SvmAddress.from(usdcTokenSol), svmChain, e1.blockNumber)).to.be
+      .undefined;
+    expect(hubPoolClient.l2TokenEnabledForL1TokenAtBlock(randomL1TokenAddr, svmChain, e1.blockNumber)).to.be.false;
+  });
+
   it("correctly disables a rebalancing route", async function () {
     const randomL1TokenAddr = EvmAddress.from(randomL1Token);
 


### PR DESCRIPTION
## Motivation

A queued HubPool admin batch prunes pool rebalance routes by setting their destination token to the zero address, including the route for USDC on Solana (`setPoolRebalanceRoute(34268394551451, USDC, 0x0)`).

`HubPoolClient`'s `SetPoolRebalanceRoute` event processing requires any SVM-destination event to carry (truncated) SVM USDC as the destination token and **throws** otherwise. A zero-address disable event for Solana therefore makes `HubPoolClient.update()` throw — permanently, for every consumer (dataworker, relayer, finalizer), from the moment the event is mined — since `SetPoolRebalanceRoute` is searched from deep history on every update.

## Changes

- Exempt the zero address from the SVM USDC translation/validation and store it untranslated, matching EVM route-disable semantics. Downstream lookups already handle it: `getL2TokenForL1TokenAtBlock` returns `undefined`, `l2TokenEnabledForL1TokenAtBlock` returns `false`, and `getL1TokenForL2TokenAtBlock` no longer resolves the token from the disable block onwards.
- The mismatch throw is preserved for genuine non-USDC SVM routes (existing test still passes).

## Testing

New test `correctly disables an SVM rebalancing route` covers: update does not throw on the disable event, the route still resolves at pre-disable blocks, and all three lookups correctly report the route as removed at the disable block. `yarn hardhat test test/HubPoolClient.DepositToDestinationToken.ts`: 9 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)