### PR TITLE
chore: bump contracts to 5.0.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@across-protocol/sdk",
   "author": "UMA Team",
-  "version": "4.4.16",
+  "version": "4.4.17",
   "license": "AGPL-3.0",
   "homepage": "https://docs.across.to/reference/sdk",
   "repository": {
@@ -81,7 +81,7 @@
   },
   "dependencies": {
     "@across-protocol/constants": "^3.1.123",
-    "@across-protocol/contracts": "5.0.24",
+    "@across-protocol/contracts": "5.0.26",
     "@coral-xyz/anchor": "^0.30.1",
     "@eth-optimism/sdk": "^3.3.1",
     "@ethersproject/bignumber": "^5.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,10 +17,10 @@
   resolved "https://registry.yarnpkg.com/@across-protocol/constants/-/constants-3.1.123.tgz#72c9f8aecdbced2a21d7d2313398db87f5193af8"
   integrity sha512-68SA6sNd/DsVJU/RbhmyC+u40iScoX+QDQNdPBAUJjG1khHc3+ltFz4oy3ahnxCOA+nHNwXJ6on8piI31m4/rA==
 
-"@across-protocol/contracts@5.0.24":
-  version "5.0.24"
-  resolved "https://registry.yarnpkg.com/@across-protocol/contracts/-/contracts-5.0.24.tgz#3d15aa4ff779303d48f7345afd97e3913de4ecee"
-  integrity sha512-qx8dZ/XpwLsNjzVIIwd/E33ZIX1KgmhpX2G/rD16qb6sLprpJyyDjI/LXKrhRbihvbeASiog8HGE9f3ymSrZKw==
+"@across-protocol/contracts@5.0.26":
+  version "5.0.26"
+  resolved "https://registry.yarnpkg.com/@across-protocol/contracts/-/contracts-5.0.26.tgz#8d1811fc5799945f2ca898f4aec5e4d227c978ee"
+  integrity sha512-YVdEtv4esbAjlqlsd1CP11h7qon1Xlv6B8BQ4aqPOjPXBQqJfZxpUPuVKC2D8emWlDi19hFFfnlbekIZjerRrA==
   dependencies:
     "@across-protocol/constants" "^3.1.118"
     "@coral-xyz/anchor" "^0.31.1"


### PR DESCRIPTION
Bumps `@across-protocol/contracts` 5.0.24 → 5.0.26 and the SDK patch version 4.4.16 → 4.4.17 (matching the convention in #1482 / #1469 / #1456).

5.0.26 is the version pinned by across-protocol/relayer#3646, which needs the new `SpokePoolPeriphery` `depositWithAuthorizationBytes` / `swapAndBridgeWithAuthorizationBytes` methods (across-protocol/contracts#1504) plus the new periphery deployments.

That relayer PR currently *also* pins 5.0.26 via `resolutions`, specifically because this package still pinned 5.0.24 and a split dependency tree makes the contracts types mutually incompatible under `tsc`. Once this lands and is released, that override can be dropped.

## Verification

- `yarn build` clean — `typechain` restaged (315 contracts, 627 typings) and all three `tsc` targets (cjs/esm/types) exit 0 against 5.0.26. This was the main risk, since typechain artifacts are generated from the contracts package.
- `yarn lint-check` clean.
- `yarn install --frozen-lockfile` succeeds, so CI's install step is satisfied.
- `yarn test` **not run locally** — it aborts in a root `before all` hook with `spawn solana-test-validator ENOENT`; this runner has no Solana toolchain. It fails before any SDK code executes and is unrelated to this change. Leaving the suite to CI, which installs the toolchain and supplies `NODE_URL_1`.

Diff is package.json (2 lines) + yarn.lock (4 lines); no source changes.

Requested by Aleksa in Slack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)